### PR TITLE
refactor: Change replay back mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,26 +1971,17 @@ dependencies = [
 name = "checkpoint_light_client"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "ark-bls12-381",
  "ark-serialize 0.4.2",
  "checkpoint_light_client-io",
  "circular-buffer",
- "futures",
  "gbuiltin-bls381",
- "gclient",
  "gear-wasm-builder",
  "getrandom 0.2.15",
  "gstd",
- "hex",
  "hex-literal",
  "lazy_static",
  "parity-scale-codec",
  "primitive-types 0.12.2",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "tokio",
  "tree_hash_derive",
 ]
 

--- a/gear-programs/checkpoint-light-client/Cargo.toml
+++ b/gear-programs/checkpoint-light-client/Cargo.toml
@@ -18,19 +18,8 @@ tree_hash_derive.workspace = true
 gear-wasm-builder.workspace = true
 checkpoint_light_client-io.workspace = true
 
-[dev-dependencies]
-gclient.workspace = true
-ark-bls12-381 = { workspace = true, features = ["std"] }
-serde = { workspace = true, features = ["std"] }
-futures.workspace = true
-tokio.workspace = true
-hex = { workspace = true, features = ["std"] }
-reqwest.workspace = true
-serde_json.workspace = true
-anyhow.workspace = true
-
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
+getrandom = { version = "0.2", default-features = false, features = ["custom"] }
 lazy_static = { version = "1.1", features = ["spin_no_std"] }
 
 [features]

--- a/relayer/src/ethereum_checkpoints/mod.rs
+++ b/relayer/src/ethereum_checkpoints/mod.rs
@@ -172,7 +172,7 @@ pub async fn relay(args: RelayCheckpointsArgs) {
                 return;
             }
             Ok(Err(e)) => {
-                log::info!("The program failed with: {e:?}. Skipping");
+                log::error!("The program failed with: {e:?}. Skipping");
                 if let sync_update::Error::NotActual = e {
                     slot_last = slot;
                 }

--- a/relayer/src/ethereum_checkpoints/mod.rs
+++ b/relayer/src/ethereum_checkpoints/mod.rs
@@ -2,6 +2,7 @@ use super::*;
 use anyhow::{anyhow, Result as AnyResult};
 use checkpoint_light_client_io::{
     ethereum_common::{utils as eth_utils, SLOTS_PER_EPOCH},
+    meta::ReplayBack,
     tree_hash::Hash256,
     Handle, HandleResult, Slot, SyncCommitteeUpdate, G2,
 };
@@ -97,18 +98,15 @@ pub async fn relay(args: RelayCheckpointsArgs) {
                 &client,
                 program_id,
                 gas_limit,
-                replay_back.map(|r| r.last_header),
+                replay_back,
                 checkpoint,
                 sync_update,
             )
             .await
             {
-                log::error!("{e:?}");
+                log::error!("{e:?}. Exiting");
+                return;
             }
-
-            log::info!("Exiting");
-
-            return;
         }
         Ok(Ok(_) | Err(sync_update::Error::NotActual)) => (),
         _ => {

--- a/relayer/src/ethereum_checkpoints/mod.rs
+++ b/relayer/src/ethereum_checkpoints/mod.rs
@@ -168,10 +168,15 @@ pub async fn relay(args: RelayCheckpointsArgs) {
                 }
             }
             Ok(Err(sync_update::Error::ReplayBackRequired { .. })) => {
-                log::info!("Replay back within the main loop. Exiting");
+                log::error!("Replay back within the main loop. Exiting");
                 return;
             }
-            Ok(Err(e)) => log::info!("The program failed with: {e:?}. Skipping"),
+            Ok(Err(e)) => {
+                log::info!("The program failed with: {e:?}. Skipping");
+                if let sync_update::Error::NotActual = e {
+                    slot_last = slot;
+                }
+            }
             Err(e) => {
                 log::error!("{e:?}");
                 return;

--- a/relayer/src/ethereum_checkpoints/replay_back.rs
+++ b/relayer/src/ethereum_checkpoints/replay_back.rs
@@ -7,7 +7,6 @@ pub async fn execute(
     client_http: &Client,
     beacon_endpoint: &str,
     client: &GearApi,
-    listener: &mut EventListener,
     program_id: [u8; 32],
     gas_limit: u64,
     replayed_slot: Option<Slot>,
@@ -25,7 +24,6 @@ pub async fn execute(
             client_http,
             beacon_endpoint,
             client,
-            listener,
             program_id,
             gas_limit,
             slots_batch_iter,
@@ -65,7 +63,6 @@ pub async fn execute(
             client_http,
             beacon_endpoint,
             client,
-            listener,
             program_id,
             gas_limit,
             slots_batch_iter.next(),
@@ -77,7 +74,6 @@ pub async fn execute(
             client_http,
             beacon_endpoint,
             client,
-            listener,
             program_id,
             gas_limit,
             slots_batch_iter,
@@ -97,7 +93,6 @@ pub async fn execute(
         client_http,
         beacon_endpoint,
         client,
-        listener,
         program_id,
         gas_limit,
         slots_batch_iter.next(),
@@ -109,7 +104,6 @@ pub async fn execute(
         client_http,
         beacon_endpoint,
         client,
-        listener,
         program_id,
         gas_limit,
         slots_batch_iter,
@@ -125,7 +119,6 @@ async fn replay_back_slots(
     client_http: &Client,
     beacon_endpoint: &str,
     client: &GearApi,
-    listener: &mut EventListener,
     program_id: [u8; 32],
     gas_limit: u64,
     slots_batch_iter: SlotsBatchIter,
@@ -135,7 +128,6 @@ async fn replay_back_slots(
             client_http,
             beacon_endpoint,
             client,
-            listener,
             program_id,
             slot_start,
             slot_end,
@@ -152,7 +144,6 @@ async fn replay_back_slots_inner(
     client_http: &Client,
     beacon_endpoint: &str,
     client: &GearApi,
-    listener: &mut EventListener,
     program_id: [u8; 32],
     slot_start: Slot,
     slot_end: Slot,
@@ -161,6 +152,8 @@ async fn replay_back_slots_inner(
     let payload = Handle::ReplayBack(
         request_headers(client_http, beacon_endpoint, slot_start, slot_end).await?,
     );
+
+    let mut listener = client.subscribe().await?;
 
     let (message_id, _) = client
         .send_message(program_id.into(), payload, gas_limit, 0)
@@ -190,7 +183,6 @@ async fn replay_back_slots_start(
     client_http: &Client,
     beacon_endpoint: &str,
     client: &GearApi,
-    listener: &mut EventListener,
     program_id: [u8; 32],
     gas_limit: u64,
     slots: Option<(Slot, Slot)>,
@@ -204,6 +196,8 @@ async fn replay_back_slots_start(
         sync_update,
         headers: request_headers(client_http, beacon_endpoint, slot_start, slot_end).await?,
     };
+
+    let mut listener = client.subscribe().await?;
 
     let (message_id, _) = client
         .send_message(program_id.into(), payload, gas_limit, 0)

--- a/relayer/src/ethereum_checkpoints/sync_update.rs
+++ b/relayer/src/ethereum_checkpoints/sync_update.rs
@@ -75,11 +75,12 @@ async fn receive(
 
 pub async fn try_to_apply(
     client: &GearApi,
-    listener: &mut EventListener,
     program_id: [u8; 32],
     sync_update: SyncCommitteeUpdate,
     gas_limit: u64,
 ) -> AnyResult<Result<(), Error>> {
+    let mut listener = client.subscribe().await?;
+
     let payload = Handle::SyncUpdate(sync_update);
     let (message_id, _) = client
         .send_message(program_id.into(), payload, gas_limit, 0)


### PR DESCRIPTION
Resolves #97 

- continue execution after blocks have been replayed back
- create gear events listener on demand to avoid errors spam on pruning nodes
- 

@gear-tech/dev 
