### PR TITLE
refactor: Move some entities to ethereum-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,6 +3697,7 @@ dependencies = [
 name = "ethereum-common"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",

--- a/ethereum-common/Cargo.toml
+++ b/ethereum-common/Cargo.toml
@@ -21,6 +21,7 @@ hash256-std-hasher.workspace = true
 memory-db.workspace = true
 rlp.workspace = true
 tiny-keccak.workspace = true
+alloy = { workspace = true, optional = true }
 alloy-consensus.workspace = true
 alloy-eips.workspace = true
 alloy-rlp.workspace = true
@@ -48,6 +49,7 @@ std = [
     "hash256-std-hasher/std",
     "memory-db/std",
     "rlp/std",
+    "alloy",
     "alloy-consensus/std",
     "alloy-eips/std",
     "alloy-rlp/std",

--- a/ethereum-common/src/lib.rs
+++ b/ethereum-common/src/lib.rs
@@ -36,3 +36,5 @@ pub use trie_db;
 pub const SLOTS_PER_EPOCH: u64 = 32;
 pub const EPOCHS_PER_SYNC_COMMITTEE: u64 = 256;
 pub const SYNC_COMMITTEE_SIZE: usize = 512;
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#configuration
+pub const MAX_REQUEST_LIGHT_CLIENT_UPDATES: u8 = 128;

--- a/ethereum-common/src/utils.rs
+++ b/ethereum-common/src/utils.rs
@@ -1,13 +1,17 @@
 use super::{
-    beacon::{Block, BlockHeader, SignedBeaconBlockHeader},
+    beacon::{Block, BlockHeader, Bytes32, SignedBeaconBlockHeader, SyncAggregate, SyncCommittee},
+    memory_db,
     patricia_trie::{TrieDB, TrieDBMut},
     trie_db::{Recorder, Trie, TrieMut},
-    *,
+    Debug, Hash256, TreeHash, TreeHashType, EPOCHS_PER_SYNC_COMMITTEE, H256, SLOTS_PER_EPOCH, U256,
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_primitives::Log;
 use alloy_rlp::Encodable;
-use core::str::FromStr;
+use core::{fmt, str::FromStr};
+use serde::{de, Deserialize};
 
 const CAPACITY_RLP_RECEIPT: usize = 10_000;
 
@@ -16,21 +20,21 @@ pub type ReceiptEnvelope = alloy_consensus::ReceiptEnvelope<Log>;
 pub type Receipt = (u64, ReceiptEnvelope);
 
 #[derive(Clone, Debug)]
-pub enum ProofError {
+pub enum MerkleProofError {
     ReceiptNotFound,
     InsertionFailed,
     RootIsNotValid,
 }
 
-impl fmt::Display for ProofError {
+impl fmt::Display for MerkleProofError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(self, f)
     }
 }
 
-impl core::error::Error for ProofError {}
+impl core::error::Error for MerkleProofError {}
 
-pub struct Proof {
+pub struct MerkleProof {
     pub proof: Vec<Vec<u8>>,
     pub receipt: ReceiptEnvelope,
 }
@@ -66,6 +70,59 @@ pub struct BeaconBlockResponse {
 pub struct BeaconBlockData {
     pub message: Block,
 }
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+pub struct Bootstrap {
+    #[serde(deserialize_with = "deserialize_block_header")]
+    pub header: BlockHeader,
+    pub current_sync_committee: SyncCommittee,
+    pub current_sync_committee_branch: Vec<Bytes32>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+pub struct BootstrapResponse {
+    pub data: Bootstrap,
+}
+
+#[derive(Deserialize)]
+pub struct FinalityUpdateResponse {
+    pub data: FinalityUpdate,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct FinalityUpdate {
+    #[serde(deserialize_with = "deserialize_block_header")]
+    pub attested_header: BlockHeader,
+    #[serde(deserialize_with = "deserialize_block_header")]
+    pub finalized_header: BlockHeader,
+    pub finality_branch: Vec<Bytes32>,
+    pub sync_aggregate: SyncAggregate,
+    #[serde(deserialize_with = "deserialize_u64")]
+    pub signature_slot: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Update {
+    #[serde(deserialize_with = "deserialize_block_header")]
+    pub attested_header: BlockHeader,
+    pub next_sync_committee: SyncCommittee,
+    pub next_sync_committee_branch: Vec<Bytes32>,
+    #[serde(deserialize_with = "deserialize_block_header")]
+    pub finalized_header: BlockHeader,
+    pub finality_branch: Vec<Bytes32>,
+    pub sync_aggregate: SyncAggregate,
+    #[serde(deserialize_with = "deserialize_u64")]
+    pub signature_slot: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpdateData {
+    pub data: Update,
+}
+
+pub type UpdateResponse = Vec<UpdateData>;
 
 pub fn calculate_epoch(slot: u64) -> u64 {
     slot / SLOTS_PER_EPOCH
@@ -218,7 +275,10 @@ pub fn map_receipt_envelope(
     }
 }
 
-pub fn generate_proof(tx_index: u64, receipts: &[Receipt]) -> Result<Proof, ProofError> {
+pub fn generate_merkle_proof(
+    tx_index: u64,
+    receipts: &[Receipt],
+) -> Result<MerkleProof, MerkleProofError> {
     let mut memory_db = memory_db::new();
     let key_value_tuples = rlp_encode_receipts_and_nibble_tuples(receipts);
     let root = {
@@ -227,7 +287,7 @@ pub fn generate_proof(tx_index: u64, receipts: &[Receipt]) -> Result<Proof, Proo
         for (key, value) in &key_value_tuples {
             triedbmut
                 .insert(key, value)
-                .map_err(|_| ProofError::InsertionFailed)?;
+                .map_err(|_| MerkleProofError::InsertionFailed)?;
         }
 
         *triedbmut.root()
@@ -236,21 +296,21 @@ pub fn generate_proof(tx_index: u64, receipts: &[Receipt]) -> Result<Proof, Proo
     let (tx_index, receipt) = receipts
         .iter()
         .find(|(index, _)| index == &tx_index)
-        .ok_or(ProofError::ReceiptNotFound)?;
+        .ok_or(MerkleProofError::ReceiptNotFound)?;
 
-    let trie = TrieDB::new(&memory_db, &root).map_err(|_| ProofError::RootIsNotValid)?;
+    let trie = TrieDB::new(&memory_db, &root).map_err(|_| MerkleProofError::RootIsNotValid)?;
     let (key, _expected_value) = rlp_encode_index_and_receipt(tx_index, receipt);
 
     let mut recorder = Recorder::new();
     let _value = trie.get_with(&key, &mut recorder);
 
-    Ok(Proof {
+    Ok(MerkleProof {
         proof: recorder.drain().into_iter().map(|r| r.data).collect(),
         receipt: receipt.clone(),
     })
 }
 
-pub fn deserialize_header<'de, D>(deserializer: D) -> Result<BlockHeader, D::Error>
+pub fn deserialize_block_header<'de, D>(deserializer: D) -> Result<BlockHeader, D::Error>
 where
     D: serde::Deserializer<'de>,
 {

--- a/relayer/src/erc20/mod.rs
+++ b/relayer/src/erc20/mod.rs
@@ -8,7 +8,7 @@ use alloy_rlp::Encodable;
 use anyhow::{anyhow, Result as AnyResult};
 use checkpoint_light_client_io::ethereum_common::{
     beacon::{light::Block as LightBeaconBlock, Block as BeaconBlock},
-    utils::{self as eth_utils, Proof},
+    utils::{self as eth_utils, MerkleProof},
     SLOTS_PER_EPOCH,
 };
 use erc20_relay_client::{
@@ -102,7 +102,7 @@ async fn relay_inner(args: RelayErc20Args) -> AnyResult<()> {
         .collect::<Option<Vec<_>>>()
         .unwrap_or_default();
 
-    let Proof { proof, receipt } = eth_utils::generate_proof(tx_index, &receipts[..])?;
+    let MerkleProof { proof, receipt } = eth_utils::generate_merkle_proof(tx_index, &receipts[..])?;
 
     let mut receipt_rlp = Vec::with_capacity(Encodable::length(&receipt));
     Encodable::encode(&receipt, &mut receipt_rlp);

--- a/relayer/src/ethereum_checkpoints/mod.rs
+++ b/relayer/src/ethereum_checkpoints/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use anyhow::{anyhow, Result as AnyResult};
 use checkpoint_light_client_io::{
-    ethereum_common::{utils as eth_utils, SLOTS_PER_EPOCH},
+    ethereum_common::{utils as eth_utils, MAX_REQUEST_LIGHT_CLIENT_UPDATES, SLOTS_PER_EPOCH},
     meta::ReplayBack,
     tree_hash::Hash256,
     Handle, HandleResult, Slot, SyncCommitteeUpdate, G2,
@@ -18,7 +18,7 @@ use tokio::{
     sync::mpsc::{self, Sender},
     time::{self, Duration},
 };
-use utils::{slots_batch::Iter as SlotsBatchIter, MAX_REQUEST_LIGHT_CLIENT_UPDATES};
+use utils::slots_batch::Iter as SlotsBatchIter;
 
 #[cfg(test)]
 mod tests;

--- a/relayer/src/ethereum_checkpoints/tests/mod.rs
+++ b/relayer/src/ethereum_checkpoints/tests/mod.rs
@@ -1,8 +1,11 @@
-use super::utils::{self, slots_batch, BootstrapResponse, FinalityUpdateResponse, UpdateData};
+use super::utils::{self, slots_batch};
 use checkpoint_light_client::WASM_BINARY;
 use checkpoint_light_client_io::{
     ethereum_common::{
-        base_types::BytesFixed, network::Network, utils as eth_utils, SLOTS_PER_EPOCH,
+        base_types::BytesFixed,
+        network::Network,
+        utils::{self as eth_utils, BootstrapResponse, FinalityUpdateResponse, UpdateData},
+        SLOTS_PER_EPOCH,
     },
     replay_back, sync_update,
     tree_hash::TreeHash,

--- a/relayer/src/ethereum_checkpoints/utils/mod.rs
+++ b/relayer/src/ethereum_checkpoints/utils/mod.rs
@@ -3,8 +3,11 @@ use ark_serialize::CanonicalDeserialize;
 use checkpoint_light_client_io::{
     ethereum_common::{
         base_types::{BytesFixed, FixedArray},
-        beacon::{BLSPubKey, Block as BeaconBlock, Bytes32, SyncAggregate, SyncCommittee},
-        utils::{self as eth_utils, BeaconBlockHeaderResponse, BeaconBlockResponse},
+        beacon::{BLSPubKey, Block as BeaconBlock},
+        utils::{
+            BeaconBlockHeaderResponse, BeaconBlockResponse, Bootstrap, BootstrapResponse,
+            FinalityUpdate, FinalityUpdateResponse, Update, UpdateResponse,
+        },
         MAX_REQUEST_LIGHT_CLIENT_UPDATES,
     },
     ArkScale, BeaconBlockHeader, G1TypeInfo, G2TypeInfo, Slot, SyncCommitteeKeys,
@@ -15,59 +18,6 @@ use serde::{de::DeserializeOwned, Deserialize};
 use std::{cmp, error::Error, fmt};
 
 pub mod slots_batch;
-
-#[allow(dead_code)]
-#[derive(Deserialize, Debug)]
-pub struct Bootstrap {
-    #[serde(deserialize_with = "eth_utils::deserialize_header")]
-    pub header: BeaconBlockHeader,
-    pub current_sync_committee: SyncCommittee,
-    pub current_sync_committee_branch: Vec<Bytes32>,
-}
-
-#[allow(dead_code)]
-#[derive(Deserialize, Debug)]
-pub struct BootstrapResponse {
-    pub data: Bootstrap,
-}
-
-#[derive(Deserialize)]
-pub struct FinalityUpdateResponse {
-    pub data: FinalityUpdate,
-}
-
-#[derive(Clone, Deserialize)]
-pub struct FinalityUpdate {
-    #[serde(deserialize_with = "eth_utils::deserialize_header")]
-    pub attested_header: BeaconBlockHeader,
-    #[serde(deserialize_with = "eth_utils::deserialize_header")]
-    pub finalized_header: BeaconBlockHeader,
-    pub finality_branch: Vec<Bytes32>,
-    pub sync_aggregate: SyncAggregate,
-    #[serde(deserialize_with = "eth_utils::deserialize_u64")]
-    pub signature_slot: u64,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct Update {
-    #[serde(deserialize_with = "eth_utils::deserialize_header")]
-    pub attested_header: BeaconBlockHeader,
-    pub next_sync_committee: SyncCommittee,
-    pub next_sync_committee_branch: Vec<Bytes32>,
-    #[serde(deserialize_with = "eth_utils::deserialize_header")]
-    pub finalized_header: BeaconBlockHeader,
-    pub finality_branch: Vec<Bytes32>,
-    pub sync_aggregate: SyncAggregate,
-    #[serde(deserialize_with = "eth_utils::deserialize_u64")]
-    pub signature_slot: u64,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct UpdateData {
-    pub data: Update,
-}
-
-pub type UpdateResponse = Vec<UpdateData>;
 
 #[derive(Clone, Debug)]
 pub struct ErrorNotFound;

--- a/relayer/src/ethereum_checkpoints/utils/mod.rs
+++ b/relayer/src/ethereum_checkpoints/utils/mod.rs
@@ -4,11 +4,7 @@ use checkpoint_light_client_io::{
     ethereum_common::{
         base_types::{BytesFixed, FixedArray},
         beacon::{BLSPubKey, Block as BeaconBlock},
-        utils::{
-            BeaconBlockHeaderResponse, BeaconBlockResponse, Bootstrap, BootstrapResponse,
-            FinalityUpdate, FinalityUpdateResponse, Update, UpdateResponse,
-        },
-        MAX_REQUEST_LIGHT_CLIENT_UPDATES,
+        utils, MAX_REQUEST_LIGHT_CLIENT_UPDATES,
     },
     ArkScale, BeaconBlockHeader, G1TypeInfo, G2TypeInfo, Slot, SyncCommitteeKeys,
     SyncCommitteeUpdate, G1, G2, SYNC_COMMITTEE_SIZE,
@@ -16,6 +12,10 @@ use checkpoint_light_client_io::{
 use reqwest::{Client, RequestBuilder};
 use serde::{de::DeserializeOwned, Deserialize};
 use std::{cmp, error::Error, fmt};
+use utils::{
+    BeaconBlockHeaderResponse, BeaconBlockResponse, FinalityUpdate, FinalityUpdateResponse, Update,
+    UpdateResponse,
+};
 
 pub mod slots_batch;
 
@@ -57,7 +57,7 @@ pub async fn get_bootstrap(
     client: &Client,
     rpc_url: &str,
     checkpoint: &str,
-) -> AnyResult<Bootstrap> {
+) -> AnyResult<utils::Bootstrap> {
     let checkpoint_no_prefix = match checkpoint.starts_with("0x") {
         true => &checkpoint[2..],
         false => checkpoint,
@@ -65,7 +65,7 @@ pub async fn get_bootstrap(
 
     let url = format!("{rpc_url}/eth/v1/beacon/light_client/bootstrap/0x{checkpoint_no_prefix}",);
 
-    get::<BootstrapResponse>(client.get(&url))
+    get::<utils::BootstrapResponse>(client.get(&url))
         .await
         .map(|response| response.data)
 }


### PR DESCRIPTION
Resolves #159 

- `map_receipt_envelope` func
- introduce `generate_proof` func
- move `Beacon*` structs

@gear-tech/dev 
