### PR TITLE
fix(CD): Add `GenesisConfig.toml` to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ out/
 ethereum/broadcast
 
 .env
-
-GenesisConfig.toml

--- a/GenesisConfig.toml
+++ b/GenesisConfig.toml
@@ -1,0 +1,2 @@
+authority_set_id = 750
+authority_set_hash = "3535453e3b04a139e765128d161b7eb4423d263e8c88f69ef1207a13a1db9666"


### PR DESCRIPTION
CD Requires that `GenesisConfig.toml` is present in repo, but it was in `.gitignore` previously
