### PR TITLE
refactor(relayers): Make `EthereumMessageSender` work on the chainhead

### DIFF
--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -164,9 +164,21 @@ impl EthApi {
         self.contracts.get_tx_status(tx_hash).await
     }
 
-    pub async fn read_finalized_merkle_root(&self, block: u32) -> Result<Option<[u8; 32]>, Error> {
+    pub async fn read_finalized_merkle_root(
+        &self,
+        gear_block: u32,
+    ) -> Result<Option<[u8; 32]>, Error> {
         self.contracts
-            .read_finalized_merkle_root(U256::from(block))
+            .read_merkle_root(U256::from(gear_block), BlockNumberOrTag::Finalized)
+            .await
+    }
+
+    pub async fn read_chainhead_merkle_root(
+        &self,
+        gear_block: u32,
+    ) -> Result<Option<[u8; 32]>, Error> {
+        self.contracts
+            .read_merkle_root(U256::from(gear_block), BlockNumberOrTag::Latest)
             .await
     }
 
@@ -456,11 +468,15 @@ where
         }
     }
 
-    pub async fn read_finalized_merkle_root(&self, block: U256) -> Result<Option<[u8; 32]>, Error> {
+    pub async fn read_merkle_root(
+        &self,
+        block: U256,
+        block_tag: BlockNumberOrTag,
+    ) -> Result<Option<[u8; 32]>, Error> {
         let root = self
             .relayer_instance
             .getMerkleRoot(block)
-            .block(BlockId::Number(BlockNumberOrTag::Finalized))
+            .block(BlockId::Number(block_tag))
             .call()
             .await
             .map_err(Error::ErrorDuringContractExecution)?

--- a/relayer/src/message_relayer/common/ethereum/message_sender/mod.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_sender/mod.rs
@@ -93,7 +93,7 @@ impl MessageSender {
                         entry.get_mut().push_message(message);
                     }
                     Entry::Vacant(entry) => {
-                        let mut era = Era::new(self.era_metrics.clone());
+                        let mut era = Era::new(authority_set_id, self.era_metrics.clone());
                         era.push_message(message);
 
                         entry.insert(era);
@@ -107,7 +107,8 @@ impl MessageSender {
                         entry.get_mut().push_merkle_root(merkle_root);
                     }
                     Entry::Vacant(entry) => {
-                        let mut era = Era::new(self.era_metrics.clone());
+                        let mut era =
+                            Era::new(merkle_root.authority_set_id, self.era_metrics.clone());
                         era.push_merkle_root(merkle_root);
 
                         entry.insert(era);


### PR DESCRIPTION
Resolves #110 
