### PR TITLE
fix(cd): Explicitly install rust toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH="/root/.foundry/bin:${PATH}"
 COPY . .
 
 # Build relayer
-RUN rustup toolchain install nightly-2025-01-09-x86_64-unknown-linux-gnu
+RUN rustup toolchain install
 RUN cargo build -p relayer --release
 
 # Compose final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ ENV PATH="/root/.foundry/bin:${PATH}"
 COPY . .
 
 # Build relayer
+RUN rustup toolchain install nightly-2025-01-09-x86_64-unknown-linux-gnu
 RUN cargo build -p relayer --release
 
 # Compose final image


### PR DESCRIPTION
From rustup 1.28.0 it now [requires](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html) "override" toolchain to be explicitly installed via `rustup toolchain install` before running `cargo build`