### PR TITLE
refactor(vft-manager): Add new getters

### DIFF
--- a/api/gear/vft_manager.idl
+++ b/api/gear/vft_manager.idl
@@ -98,14 +98,6 @@ type Error = enum {
   Paused,
 };
 
-/// Entry for a single message in [MessageTracker].
-type MessageInfo = struct {
-  /// State of the message.
-  status: MessageStatus,
-  /// Request details.
-  details: TxDetails,
-};
-
 /// State in which message processing can be.
 type MessageStatus = enum {
   /// Message to deposit tokens is sent.
@@ -136,21 +128,34 @@ type TxDetails = struct {
   token_supply: TokenSupply,
 };
 
+/// Entry for a single message in [MessageTracker].
+type MessageInfo = struct {
+  /// State of the message.
+  status: MessageStatus,
+  /// Request details.
+  details: TxDetails,
+};
+
+type Order = enum {
+  Direct,
+  Reverse,
+};
+
 constructor {
   /// The constructor is intended for test purposes and is available only when the feature
-  /// `gas_calculation` is enabled.
-  GasCalculation : (_init_config: InitConfig, _slot_first: u64);
+  /// `mocks` is enabled.
+  GasCalculation : (_init_config: InitConfig, _slot_first: u64, _count: opt u32);
   New : (init_config: InitConfig);
 };
 
 service VftManager {
-  /// The method is intended for tests and is available only when the feature `gas_calculation`
+  /// The method is intended for tests and is available only when the feature `mocks`
   /// is enabled. Sends a VFT-message to the sender to mint/unlock tokens depending
   /// on the `_supply_type`.
   /// 
   /// Designed for benchmarking gas consumption by the VFT-response processing function.
   CalculateGasForReply : (_slot: u64, _transaction_index: u64, _supply_type: TokenSupply) -> result (null, Error);
-  /// The method is intended for tests and is available only when the feature `gas_calculation`
+  /// The method is intended for tests and is available only when the feature `mocks`
   /// is enabled. Populates the collection with processed transactions.
   /// 
   /// Returns false when the collection is populated.
@@ -164,6 +169,9 @@ service VftManager {
   /// - Gas attached to a message wasn't enough to execute entire logic in `request_bridging`.
   /// - Network was heavily loaded and some message was stuck so `request_bridging` failed.
   HandleRequestBridgingInterruptedTransfer : (msg_id: message_id) -> result (null, Error);
+  /// The method is intended for tests and is available only when the feature `mocks`
+  /// is enabled. Inserts the message info into the corresponding collection.
+  InsertMessageInfo : (_msg_id: message_id, _status: MessageStatus, _details: TxDetails) -> null;
   /// Add a new token pair to a [State::token_map]. Can be called only by a [State::admin].
   MapVaraToEthAddress : (vara_token_id: actor_id, eth_token_id: h160, supply_type: TokenSupply) -> null;
   /// Pause the `vft-manager`.
@@ -229,7 +237,8 @@ service VftManager {
   /// Get current [State::pause_admin] address.
   query PauseAdmin : () -> actor_id;
   /// Get state of a `request_bridging` message tracker.
-  query RequestBridingMsgTrackerState : () -> vec struct { message_id, MessageInfo };
+  query RequestBridingMsgTrackerState : (start: u32, count: u32) -> vec struct { message_id, MessageInfo };
+  query Transactions : (order: Order, start: u32, count: u32) -> vec struct { u64, u64 };
   /// Get current [token mapping](State::token_map).
   query VaraToEthAddresses : () -> vec struct { actor_id, h160, TokenSupply };
 

--- a/gear-programs/vft-manager/Cargo.toml
+++ b/gear-programs/vft-manager/Cargo.toml
@@ -31,4 +31,4 @@ gclient.workspace = true
 
 [features]
 wasm-binary = []
-gas_calculation = ["vft-manager-app/gas_calculation"]
+mocks = ["vft-manager-app/mocks"]

--- a/gear-programs/vft-manager/app/Cargo.toml
+++ b/gear-programs/vft-manager/app/Cargo.toml
@@ -34,8 +34,8 @@ sails-rs = { workspace = true, features = ["gclient"] }
 sp-core = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
-vft-manager = { workspace = true, features = ["wasm-binary", "gas_calculation"] }
+vft-manager = { workspace = true, features = ["wasm-binary", "mocks"] }
 vft-manager-client.workspace = true
 
 [features]
-gas_calculation = []
+mocks = []

--- a/gear-programs/vft-manager/app/src/lib.rs
+++ b/gear-programs/vft-manager/app/src/lib.rs
@@ -15,22 +15,23 @@ impl Program {
     }
 
     /// The constructor is intended for test purposes and is available only when the feature
-    /// `gas_calculation` is enabled.
-    pub fn gas_calculation(_init_config: InitConfig, _slot_first: u64) -> Self {
-        #[cfg(feature = "gas_calculation")]
+    /// `mocks` is enabled.
+    pub fn gas_calculation(_init_config: InitConfig, _slot_first: u64, _count: Option<u32>) -> Self {
+        #[cfg(feature = "mocks")]
         {
             let self_ = Self::new(_init_config);
 
             let transactions = services::submit_receipt::transactions_mut();
-            for i in 0..services::SIZE_FILL_TRANSACTIONS_STEP {
+            let count = _count.map(|c| c as usize).unwrap_or(services::SIZE_FILL_TRANSACTIONS_STEP);
+            for i in 0..count {
                 transactions.insert((_slot_first, i as u64));
             }
 
             self_
         }
 
-        #[cfg(not(feature = "gas_calculation"))]
-        panic!("Please rebuild with enabled `gas_calculation` feature")
+        #[cfg(not(feature = "mocks"))]
+        panic!("Please rebuild with enabled `mocks` feature")
     }
 
     pub fn vft_manager(&self) -> VftManager<GStdExecContext> {

--- a/gear-programs/vft-manager/app/src/lib.rs
+++ b/gear-programs/vft-manager/app/src/lib.rs
@@ -16,13 +16,19 @@ impl Program {
 
     /// The constructor is intended for test purposes and is available only when the feature
     /// `mocks` is enabled.
-    pub fn gas_calculation(_init_config: InitConfig, _slot_first: u64, _count: Option<u32>) -> Self {
+    pub fn gas_calculation(
+        _init_config: InitConfig,
+        _slot_first: u64,
+        _count: Option<u32>,
+    ) -> Self {
         #[cfg(feature = "mocks")]
         {
             let self_ = Self::new(_init_config);
 
             let transactions = services::submit_receipt::transactions_mut();
-            let count = _count.map(|c| c as usize).unwrap_or(services::SIZE_FILL_TRANSACTIONS_STEP);
+            let count = _count
+                .map(|c| c as usize)
+                .unwrap_or(services::SIZE_FILL_TRANSACTIONS_STEP);
             for i in 0..count {
                 transactions.insert((_slot_first, i as u64));
             }

--- a/gear-programs/vft-manager/app/src/services/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/mod.rs
@@ -414,7 +414,7 @@ where
         start: u32,
         count: u32,
     ) -> Vec<(MessageId, request_bridging::MsgTrackerMessageInfo)> {
-        request_bridging::msg_tracker_mut()
+        request_bridging::msg_tracker_ref()
             .message_info
             .iter()
             .skip(start as usize)

--- a/gear-programs/vft-manager/app/src/services/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/mod.rs
@@ -472,21 +472,21 @@ where
         }
     }
 
-    /// The method is intended for tests and is available only when the feature `gas_calculation`
+    /// The method is intended for tests and is available only when the feature `mocks`
     /// is enabled. Populates the collection with processed transactions.
     ///
     /// Returns false when the collection is populated.
     pub fn fill_transactions(&mut self) -> bool {
-        #[cfg(feature = "gas_calculation")]
+        #[cfg(feature = "mocks")]
         {
             submit_receipt::fill_transactions()
         }
 
-        #[cfg(not(feature = "gas_calculation"))]
-        panic!("Please rebuild with enabled `gas_calculation` feature")
+        #[cfg(not(feature = "mocks"))]
+        panic!("Please rebuild with enabled `mocks` feature")
     }
 
-    /// The method is intended for tests and is available only when the feature `gas_calculation`
+    /// The method is intended for tests and is available only when the feature `mocks`
     /// is enabled. Sends a VFT-message to the sender to mint/unlock tokens depending
     /// on the `_supply_type`.
     ///
@@ -497,7 +497,7 @@ where
         _transaction_index: u64,
         _supply_type: TokenSupply,
     ) -> Result<(), Error> {
-        #[cfg(feature = "gas_calculation")]
+        #[cfg(feature = "mocks")]
         {
             use submit_receipt::token_operations;
 
@@ -529,8 +529,8 @@ where
             }
         }
 
-        #[cfg(not(feature = "gas_calculation"))]
-        panic!("Please rebuild with enabled `gas_calculation` feature")
+        #[cfg(not(feature = "mocks"))]
+        panic!("Please rebuild with enabled `mocks` feature")
     }
 }
 

--- a/gear-programs/vft-manager/app/src/services/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/mod.rs
@@ -5,6 +5,7 @@ mod token_mapping;
 
 use error::Error;
 use token_mapping::TokenMap;
+use request_bridging::{MessageStatus, TxDetails};
 
 mod request_bridging;
 pub mod submit_receipt;
@@ -485,6 +486,23 @@ where
         #[cfg(feature = "mocks")]
         {
             submit_receipt::fill_transactions()
+        }
+
+        #[cfg(not(feature = "mocks"))]
+        panic!("Please rebuild with enabled `mocks` feature")
+    }
+
+    /// The method is intended for tests and is available only when the feature `mocks`
+    /// is enabled. Inserts the message info into the corresponding collection.
+    pub fn insert_message_info(
+        &mut self,
+        _msg_id: MessageId,
+        _status: MessageStatus,
+        _details: TxDetails,
+    ) {
+        #[cfg(feature = "mocks")]
+        {
+            request_bridging::msg_tracker_mut().insert_message_info(_msg_id, _status, _details);
         }
 
         #[cfg(not(feature = "mocks"))]

--- a/gear-programs/vft-manager/app/src/services/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/mod.rs
@@ -410,8 +410,13 @@ where
     /// Get state of a `request_bridging` message tracker.
     pub fn request_briding_msg_tracker_state(
         &self,
+        start: u32, count: u32,
     ) -> Vec<(MessageId, request_bridging::MsgTrackerMessageInfo)> {
-        request_bridging::msg_tracker_state()
+        request_bridging::msg_tracker_mut().message_info.iter()
+            .skip(start as usize)
+            .take(count as usize)
+            .map(|(k, v)| (*k, v.clone()))
+            .collect()
     }
 
     /// Get current [token mapping](State::token_map).

--- a/gear-programs/vft-manager/app/src/services/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/mod.rs
@@ -4,8 +4,8 @@ mod error;
 mod token_mapping;
 
 use error::Error;
-use token_mapping::TokenMap;
 use request_bridging::{MessageStatus, TxDetails};
+use token_mapping::TokenMap;
 
 mod request_bridging;
 pub mod submit_receipt;
@@ -411,9 +411,12 @@ where
     /// Get state of a `request_bridging` message tracker.
     pub fn request_briding_msg_tracker_state(
         &self,
-        start: u32, count: u32,
+        start: u32,
+        count: u32,
     ) -> Vec<(MessageId, request_bridging::MsgTrackerMessageInfo)> {
-        request_bridging::msg_tracker_mut().message_info.iter()
+        request_bridging::msg_tracker_mut()
+            .message_info
+            .iter()
             .skip(start as usize)
             .take(count as usize)
             .map(|(k, v)| (*k, v.clone()))
@@ -471,7 +474,7 @@ where
                 .copied()
                 .collect()
         }
-    
+
         match order {
             Order::Direct => collect(start, count, submit_receipt::transactions().iter()),
             Order::Reverse => collect(start, count, submit_receipt::transactions().iter().rev()),

--- a/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
@@ -9,9 +9,8 @@ mod msg_tracker;
 mod token_operations;
 
 use bridge_builtin_operations::Payload;
-use msg_tracker::{MessageStatus, TxDetails};
 
-pub use msg_tracker::{msg_tracker_mut, MessageInfo as MsgTrackerMessageInfo};
+pub use msg_tracker::{msg_tracker_mut, MessageInfo as MsgTrackerMessageInfo, MessageStatus, TxDetails};
 
 /// Initialize state that's used by this VFT Manager method.
 pub fn seed() {

--- a/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
@@ -9,9 +9,9 @@ mod msg_tracker;
 mod token_operations;
 
 use bridge_builtin_operations::Payload;
-use msg_tracker::{msg_tracker_mut, MessageStatus, TxDetails};
+use msg_tracker::{MessageStatus, TxDetails};
 
-pub use msg_tracker::{msg_tracker_state, MessageInfo as MsgTrackerMessageInfo};
+pub use msg_tracker::{msg_tracker_mut, MessageInfo as MsgTrackerMessageInfo};
 
 /// Initialize state that's used by this VFT Manager method.
 pub fn seed() {

--- a/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
@@ -10,7 +10,9 @@ mod token_operations;
 
 use bridge_builtin_operations::Payload;
 
-pub use msg_tracker::{msg_tracker_mut, MessageInfo as MsgTrackerMessageInfo, MessageStatus, TxDetails};
+pub use msg_tracker::{
+    msg_tracker_mut, MessageInfo as MsgTrackerMessageInfo, MessageStatus, TxDetails,
+};
 
 /// Initialize state that's used by this VFT Manager method.
 pub fn seed() {

--- a/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/request_bridging/mod.rs
@@ -11,7 +11,8 @@ mod token_operations;
 use bridge_builtin_operations::Payload;
 
 pub use msg_tracker::{
-    msg_tracker_mut, MessageInfo as MsgTrackerMessageInfo, MessageStatus, TxDetails,
+    msg_tracker_mut, msg_tracker_ref, MessageInfo as MsgTrackerMessageInfo, MessageStatus,
+    TxDetails,
 };
 
 /// Initialize state that's used by this VFT Manager method.

--- a/gear-programs/vft-manager/app/src/services/request_bridging/msg_tracker.rs
+++ b/gear-programs/vft-manager/app/src/services/request_bridging/msg_tracker.rs
@@ -61,11 +61,6 @@ pub fn init() {
     unsafe { MSG_TRACKER = Some(MessageTracker::default()) }
 }
 
-/// Fetch state of this message tracker.
-pub fn msg_tracker_state() -> Vec<(MessageId, MessageInfo)> {
-    msg_tracker_mut().message_info.clone().into_iter().collect()
-}
-
 /// Get mutable reference to a global message tracker.
 pub fn msg_tracker_mut() -> &'static mut MessageTracker {
     #[allow(clippy::deref_addrof)]

--- a/gear-programs/vft-manager/app/src/services/request_bridging/msg_tracker.rs
+++ b/gear-programs/vft-manager/app/src/services/request_bridging/msg_tracker.rs
@@ -61,6 +61,12 @@ pub fn init() {
     unsafe { MSG_TRACKER = Some(MessageTracker::default()) }
 }
 
+/// Get reference to a global message tracker.
+pub fn msg_tracker_ref() -> &'static MessageTracker {
+    #[allow(clippy::deref_addrof)]
+    unsafe { (*&raw const MSG_TRACKER).as_ref() }.expect("VftManager::seed() should be called")
+}
+
 /// Get mutable reference to a global message tracker.
 pub fn msg_tracker_mut() -> &'static mut MessageTracker {
     #[allow(clippy::deref_addrof)]

--- a/gear-programs/vft-manager/app/src/services/submit_receipt/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/submit_receipt/mod.rs
@@ -14,6 +14,12 @@ static mut TRANSACTIONS: Option<BTreeSet<(u64, u64)>> = None;
 /// program can store.
 const TX_HISTORY_DEPTH: usize = 50_000_000;
 
+/// Get reference to a transactions storage.
+pub fn transactions() -> &'static BTreeSet<(u64, u64)> {
+    #[allow(clippy::deref_addrof)]
+    unsafe { (*&raw const TRANSACTIONS).as_ref() }.expect("Program should be constructed")
+}
+
 /// Get mutable reference to a transactions storage.
 pub fn transactions_mut() -> &'static mut BTreeSet<(u64, u64)> {
     #[allow(clippy::deref_addrof)]

--- a/gear-programs/vft-manager/app/tests/gclient.rs
+++ b/gear-programs/vft-manager/app/tests/gclient.rs
@@ -391,7 +391,8 @@ async fn bench_gas_for_reply() -> Result<()> {
 async fn getter_transactions() -> Result<()> {
     const CAPACITY: usize = 10;
 
-    let (api, _suri, _suri2, code_id, _code_id_vft, gas_limit, salt) = connect_to_node().await?;
+    let (api, suri, _suri2, code_id, _code_id_vft, gas_limit, salt) = connect_to_node().await?;
+    let api = api.with(suri).unwrap();
 
     // deploy VFT-manager
     let factory = vft_manager_client::VftManagerFactory::new(GClientRemoting::new(api.clone()));
@@ -469,7 +470,8 @@ async fn getter_transactions() -> Result<()> {
 
 #[tokio::test]
 async fn msg_tracker_state() -> Result<()> {
-    let (api, _suri, _suri2, code_id, _code_id_vft, gas_limit, salt) = connect_to_node().await?;
+    let (api, suri, _suri2, code_id, _code_id_vft, gas_limit, salt) = connect_to_node().await?;
+    let api = api.with(suri).unwrap();
 
     // deploy VFT-manager
     let factory = vft_manager_client::VftManagerFactory::new(GClientRemoting::new(api.clone()));

--- a/gear-programs/vft-manager/app/tests/gclient.rs
+++ b/gear-programs/vft-manager/app/tests/gclient.rs
@@ -298,6 +298,7 @@ async fn bench_gas_for_reply() -> Result<()> {
                 },
             },
             slot_start,
+            None,
         )
         .with_gas_limit(gas_limit)
         .send_recv(code_id, salt)


### PR DESCRIPTION
The first part of the upgrade-able feature. Adds new getter for the processed Ethereum-transactions and refactors the msg_tracker state getter.

@gear-tech/dev 
