### PR TITLE
refactor(relayer): use proper async in relayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,17 +1536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom 0.2.15",
- "instant",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10224,7 +10213,6 @@ dependencies = [
  "anyhow",
  "ark-serialize 0.4.2",
  "axum",
- "backoff",
  "bridging-payment-client",
  "cgo_oligami",
  "checkpoint_light_client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,6 +1536,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.15",
+ "instant",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10213,6 +10224,7 @@ dependencies = [
  "anyhow",
  "ark-serialize 0.4.2",
  "axum",
+ "backoff",
  "bridging-payment-client",
  "cgo_oligami",
  "checkpoint_light_client",
@@ -10249,6 +10261,7 @@ dependencies = [
  "serde_json",
  "sled",
  "sp-core 21.0.0",
+ "subxt",
  "thiserror 2.0.11",
  "tokio",
  "utils-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ static_assertions = "1.1.0"
 thiserror = { version = "2.0.11", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tokio = { version = "1.23.0", features = ["full"] }
+backoff = { version = "0.4.0" }
 tree_hash = { git = "https://github.com/gear-tech/tree_hash.git", branch = "gear-v0.6.0", default-features = false }
 tree_hash_derive = { git = "https://github.com/gear-tech/tree_hash.git", branch = "gear-v0.6.0" }
 unroll = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ static_assertions = "1.1.0"
 thiserror = { version = "2.0.11", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tokio = { version = "1.23.0", features = ["full"] }
-backoff = { version = "0.4.0" }
 tree_hash = { git = "https://github.com/gear-tech/tree_hash.git", branch = "gear-v0.6.0", default-features = false }
 tree_hash_derive = { git = "https://github.com/gear-tech/tree_hash.git", branch = "gear-v0.6.0" }
 unroll = "0.1.5"

--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -9,7 +9,7 @@ use alloy::{
             BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
             WalletFiller,
         },
-        Identity, Provider, ProviderBuilder, RootProvider, WalletProvider,
+        Identity, Provider, ProviderBuilder, RootProvider
     },
     rpc::types::{BlockId, BlockNumberOrTag, Filter},
     signers::local::PrivateKeySigner,

--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -9,7 +9,7 @@ use alloy::{
             BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
             WalletFiller,
         },
-        Identity, Provider, ProviderBuilder, RootProvider
+        Identity, Provider, ProviderBuilder, RootProvider,
     },
     rpc::types::{BlockId, BlockNumberOrTag, Filter},
     signers::local::PrivateKeySigner,
@@ -87,6 +87,8 @@ pub enum TxStatus {
 pub struct EthApi {
     contracts: Contracts<ProviderType, Http<Client>, Ethereum>,
     public_key: Address,
+    wallet: EthereumWallet,
+    url: Url,
 }
 
 impl EthApi {
@@ -118,8 +120,8 @@ impl EthApi {
 
         let provider: ProviderType = ProviderBuilder::new()
             .with_recommended_fillers()
-            .wallet(wallet)
-            .on_http(url);
+            .wallet(wallet.clone())
+            .on_http(url.clone());
 
         let contracts = Contracts::new(
             provider,
@@ -130,6 +132,28 @@ impl EthApi {
         Ok(EthApi {
             contracts,
             public_key,
+            url,
+            wallet,
+        })
+    }
+
+    pub fn reconnect(&self) -> Result<EthApi, Error> {
+        let provider: ProviderType = ProviderBuilder::new()
+            .with_recommended_fillers()
+            .wallet(self.wallet.clone())
+            .on_http(self.url.clone());
+
+        let contracts = Contracts::new(
+            provider,
+            self.contracts.message_queue_instance.address().0 .0,
+            self.contracts.relayer_instance.address().0 .0,
+        )?;
+
+        Ok(EthApi {
+            contracts,
+            public_key: self.public_key,
+            url: self.url.clone(),
+            wallet: self.wallet.clone(),
         })
     }
 

--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -9,7 +9,7 @@ use alloy::{
             BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
             WalletFiller,
         },
-        Identity, Provider, ProviderBuilder, RootProvider,
+        Identity, Provider, ProviderBuilder, RootProvider, WalletProvider,
     },
     rpc::types::{BlockId, BlockNumberOrTag, Filter},
     signers::local::PrivateKeySigner,

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -51,7 +51,6 @@ thiserror = { workspace = true, features = ["std"] }
 tokio.workspace = true
 utils-prometheus.workspace = true
 subxt.workspace = true
-backoff.workspace = true
 
 [build-dependencies]
 cgo_oligami.workspace = true

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -50,6 +50,8 @@ sled.workspace = true
 thiserror = { workspace = true, features = ["std"] }
 tokio.workspace = true
 utils-prometheus.workspace = true
+subxt.workspace = true
+backoff.workspace = true
 
 [build-dependencies]
 cgo_oligami.workspace = true

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -126,7 +126,7 @@ async fn main() {
 
                     metrics_builder = metrics_builder.register_service(&relayer);
 
-                    relayer.run();
+                    relayer.run().await;
                 }
                 GearEthTokensCommands::PaidTokenTransfers {
                     bridging_payment_address,
@@ -147,7 +147,7 @@ async fn main() {
 
                     metrics_builder = metrics_builder.register_service(&relayer);
 
-                    relayer.run();
+                    relayer.run().await;
                 }
             }
 
@@ -241,7 +241,7 @@ async fn main() {
                         .run(prometheus_args.endpoint)
                         .await;
 
-                    relayer.run();
+                    relayer.run().await;
                 }
                 EthGearTokensCommands::PaidTokenTransfers {
                     bridging_payment_address,
@@ -269,13 +269,14 @@ async fn main() {
                         .run(prometheus_args.endpoint)
                         .await;
 
-                    relayer.run();
+                    relayer.run().await;
                 }
             }
 
             loop {
                 // relayer.run() spawns thread and exits, so we need to add this loop after calling run.
-                std::thread::sleep(Duration::from_millis(100));
+                // TODO(playx): is this necessary now? We switched to full async
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
         }
         CliCommands::GearEthManual(args) => {

--- a/relayer/src/message_relayer/common/ethereum/block_listener.rs
+++ b/relayer/src/message_relayer/common/ethereum/block_listener.rs
@@ -1,7 +1,5 @@
-use std::{
-    sync::mpsc::{channel, Receiver, Sender},
-    time::Duration,
-};
+use std::time::Duration;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use ethereum_client::EthApi;
 use prometheus::IntGauge;
@@ -43,8 +41,8 @@ impl BlockListener {
         }
     }
 
-    pub fn run(self) -> Receiver<EthereumBlockNumber> {
-        let (sender, receiver) = channel();
+    pub async fn run(self) -> UnboundedReceiver<EthereumBlockNumber> {
+        let (sender, receiver) = unbounded_channel();
 
         tokio::spawn(async move {
             loop {
@@ -58,7 +56,7 @@ impl BlockListener {
         receiver
     }
 
-    async fn run_inner(&self, sender: &Sender<EthereumBlockNumber>) -> anyhow::Result<()> {
+    async fn run_inner(&self, sender: &UnboundedSender<EthereumBlockNumber>) -> anyhow::Result<()> {
         let mut current_block = self.from_block;
 
         self.metrics.latest_block.set(current_block as i64);

--- a/relayer/src/message_relayer/common/ethereum/deposit_event_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/deposit_event_extractor.rs
@@ -70,7 +70,7 @@ impl DepositEventExtractor {
         blocks: &mut UnboundedReceiver<EthereumBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            while let Some(block) = blocks.try_recv().ok() {
+            while let Ok(block) = blocks.try_recv() {
                 self.process_block_events(block, sender).await?;
             }
         }

--- a/relayer/src/message_relayer/common/ethereum/deposit_event_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/deposit_event_extractor.rs
@@ -1,8 +1,6 @@
-use std::sync::mpsc::{channel, Receiver, Sender};
-
-use futures::executor::block_on;
 use prometheus::IntCounter;
 use sails_rs::H160;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use ethereum_beacon_client::BeaconClient;
 use ethereum_client::{DepositEventEntry, EthApi};
@@ -48,13 +46,18 @@ impl DepositEventExtractor {
         }
     }
 
-    pub fn run(self, blocks: Receiver<EthereumBlockNumber>) -> Receiver<TxHashWithSlot> {
-        let (sender, receiver) = channel();
+    pub async fn run(
+        self,
+        mut blocks: UnboundedReceiver<EthereumBlockNumber>,
+    ) -> UnboundedReceiver<TxHashWithSlot> {
+        let (sender, receiver) = unbounded_channel();
 
-        tokio::task::spawn_blocking(move || loop {
-            let res = block_on(self.run_inner(&sender, &blocks));
-            if let Err(err) = res {
-                log::error!("Deposit event extractor failed: {}", err);
+        tokio::task::spawn(async move {
+            loop {
+                let res = self.run_inner(&sender, &mut blocks).await;
+                if let Err(err) = res {
+                    log::error!("Deposit event extractor failed: {}", err);
+                }
             }
         });
 
@@ -63,11 +66,11 @@ impl DepositEventExtractor {
 
     async fn run_inner(
         &self,
-        sender: &Sender<TxHashWithSlot>,
-        blocks: &Receiver<EthereumBlockNumber>,
+        sender: &UnboundedSender<TxHashWithSlot>,
+        blocks: &mut UnboundedReceiver<EthereumBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            for block in blocks.try_iter() {
+            while let Some(block) = blocks.try_recv().ok() {
                 self.process_block_events(block, sender).await?;
             }
         }
@@ -76,7 +79,7 @@ impl DepositEventExtractor {
     async fn process_block_events(
         &self,
         block: EthereumBlockNumber,
-        sender: &Sender<TxHashWithSlot>,
+        sender: &UnboundedSender<TxHashWithSlot>,
     ) -> anyhow::Result<()> {
         let events = self
             .eth_api

--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -65,7 +65,7 @@ impl MerkleRootExtractor {
         sender: &UnboundedSender<RelayedMerkleRoot>,
     ) -> anyhow::Result<()> {
         loop {
-            while let Some(block) = blocks.try_recv().ok() {
+            while let Ok(block) = blocks.try_recv() {
                 let merkle_roots = self
                     .eth_api
                     .fetch_merkle_roots_in_range(block.0, block.0)

--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -1,7 +1,6 @@
-use std::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use ethereum_client::EthApi;
-use futures::executor::block_on;
 use gear_rpc_client::GearApi;
 use prometheus::IntGauge;
 use utils_prometheus::{impl_metered_service, MeteredService};
@@ -42,13 +41,18 @@ impl MerkleRootExtractor {
         }
     }
 
-    pub fn run(self, blocks: Receiver<EthereumBlockNumber>) -> Receiver<RelayedMerkleRoot> {
-        let (sender, receiver) = channel();
+    pub async fn run(
+        self,
+        mut blocks: UnboundedReceiver<EthereumBlockNumber>,
+    ) -> UnboundedReceiver<RelayedMerkleRoot> {
+        let (sender, receiver) = unbounded_channel();
 
-        tokio::task::spawn_blocking(move || loop {
-            let res = block_on(self.run_inner(&blocks, &sender));
-            if let Err(err) = res {
-                log::error!("Merkle root extractor failed: {}", err);
+        tokio::task::spawn(async move {
+            loop {
+                let res = self.run_inner(&mut blocks, &sender).await;
+                if let Err(err) = res {
+                    log::error!("Merkle root extractor failed: {}", err);
+                }
             }
         });
 
@@ -57,11 +61,11 @@ impl MerkleRootExtractor {
 
     async fn run_inner(
         &self,
-        blocks: &Receiver<EthereumBlockNumber>,
-        sender: &Sender<RelayedMerkleRoot>,
+        blocks: &mut UnboundedReceiver<EthereumBlockNumber>,
+        sender: &UnboundedSender<RelayedMerkleRoot>,
     ) -> anyhow::Result<()> {
         loop {
-            for block in blocks.try_iter() {
+            while let Some(block) = blocks.try_recv().ok() {
                 let merkle_roots = self
                     .eth_api
                     .fetch_merkle_roots_in_range(block.0, block.0)

--- a/relayer/src/message_relayer/common/ethereum/message_paid_event_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_paid_event_extractor.rs
@@ -74,7 +74,7 @@ impl MessagePaidEventExtractor {
         blocks: &mut UnboundedReceiver<EthereumBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            while let Some(block) = blocks.try_recv().ok() {
+            while let Ok(block) = blocks.try_recv() {
                 self.process_block_events(block, sender).await?;
             }
         }

--- a/relayer/src/message_relayer/common/ethereum/message_paid_event_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_paid_event_extractor.rs
@@ -1,8 +1,6 @@
-use std::sync::mpsc::{channel, Receiver, Sender};
-
-use futures::executor::block_on;
 use prometheus::IntCounter;
 use sails_rs::H160;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use ethereum_beacon_client::BeaconClient;
 use ethereum_client::{EthApi, FeePaidEntry};
@@ -52,13 +50,18 @@ impl MessagePaidEventExtractor {
         }
     }
 
-    pub fn run(self, blocks: Receiver<EthereumBlockNumber>) -> Receiver<TxHashWithSlot> {
-        let (sender, receiver) = channel();
+    pub async fn run(
+        self,
+        mut blocks: UnboundedReceiver<EthereumBlockNumber>,
+    ) -> UnboundedReceiver<TxHashWithSlot> {
+        let (sender, receiver) = unbounded_channel();
 
-        tokio::task::spawn_blocking(move || loop {
-            let res = block_on(self.run_inner(&sender, &blocks));
-            if let Err(err) = res {
-                log::error!("Deposit event extractor failed: {}", err);
+        tokio::task::spawn(async move {
+            loop {
+                let res = self.run_inner(&sender, &mut blocks).await;
+                if let Err(err) = res {
+                    log::error!("Deposit event extractor failed: {}", err);
+                }
             }
         });
 
@@ -67,11 +70,11 @@ impl MessagePaidEventExtractor {
 
     async fn run_inner(
         &self,
-        sender: &Sender<TxHashWithSlot>,
-        blocks: &Receiver<EthereumBlockNumber>,
+        sender: &UnboundedSender<TxHashWithSlot>,
+        blocks: &mut UnboundedReceiver<EthereumBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            for block in blocks.try_iter() {
+            while let Some(block) = blocks.try_recv().ok() {
                 self.process_block_events(block, sender).await?;
             }
         }
@@ -80,7 +83,7 @@ impl MessagePaidEventExtractor {
     async fn process_block_events(
         &self,
         block: EthereumBlockNumber,
-        sender: &Sender<TxHashWithSlot>,
+        sender: &UnboundedSender<TxHashWithSlot>,
     ) -> anyhow::Result<()> {
         let events = self
             .eth_api

--- a/relayer/src/message_relayer/common/ethereum/message_sender/mod.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_sender/mod.rs
@@ -100,7 +100,7 @@ impl MessageSender {
                 }
             }
 
-            while let Some(merkle_root) = merkle_roots.try_recv().ok() {
+            while let Ok(merkle_root) = merkle_roots.try_recv() {
                 match eras.entry(merkle_root.authority_set_id) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().push_merkle_root(merkle_root);

--- a/relayer/src/message_relayer/common/ethereum/message_sender/mod.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_sender/mod.rs
@@ -1,10 +1,7 @@
-use std::{
-    collections::{btree_map::Entry, BTreeMap},
-    sync::mpsc::Receiver,
-};
+use std::collections::{btree_map::Entry, BTreeMap};
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use ethereum_client::EthApi;
-use futures::executor::block_on;
 use gear_rpc_client::GearApi;
 use prometheus::{Gauge, IntGauge};
 use utils_prometheus::{impl_metered_service, MeteredService};
@@ -57,23 +54,25 @@ impl MessageSender {
         }
     }
 
-    pub fn run(
+    pub async fn run(
         self,
-        messages: Receiver<MessageInBlock>,
-        merkle_roots: Receiver<RelayedMerkleRoot>,
+        mut messages: UnboundedReceiver<MessageInBlock>,
+        mut merkle_roots: UnboundedReceiver<RelayedMerkleRoot>,
     ) {
-        tokio::task::spawn_blocking(move || loop {
-            let res = block_on(self.run_inner(&messages, &merkle_roots));
-            if let Err(err) = res {
-                log::error!("Ethereum message sender failed: {}", err);
+        tokio::task::spawn(async move {
+            loop {
+                let res = self.run_inner(&mut messages, &mut merkle_roots).await;
+                if let Err(err) = res {
+                    log::error!("Ethereum message sender failed: {}", err);
+                }
             }
         });
     }
 
     async fn run_inner(
         &self,
-        messages: &Receiver<MessageInBlock>,
-        merkle_roots: &Receiver<RelayedMerkleRoot>,
+        messages: &mut UnboundedReceiver<MessageInBlock>,
+        merkle_roots: &mut UnboundedReceiver<RelayedMerkleRoot>,
     ) -> anyhow::Result<()> {
         let mut eras: BTreeMap<AuthoritySetId, Era> = BTreeMap::new();
 
@@ -81,7 +80,7 @@ impl MessageSender {
             let fee_payer_balance = self.eth_api.get_approx_balance().await?;
             self.metrics.fee_payer_balance.set(fee_payer_balance);
 
-            for message in messages.try_iter() {
+            while let Some(message) = messages.recv().await {
                 let authority_set_id = AuthoritySetId(
                     self.gear_api
                         .signed_by_authority_set_id(message.block_hash)
@@ -101,7 +100,7 @@ impl MessageSender {
                 }
             }
 
-            for merkle_root in merkle_roots.try_iter() {
+            while let Some(merkle_root) = merkle_roots.try_recv().ok() {
                 match eras.entry(merkle_root.authority_set_id) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().push_merkle_root(merkle_root);

--- a/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
@@ -1,4 +1,3 @@
-use futures::executor::block_on;
 use gear_rpc_client::GearApi;
 use parity_scale_codec::{Decode, Encode};
 use primitive_types::H256;
@@ -53,7 +52,7 @@ impl CheckpointsExtractor {
 
         tokio::task::spawn(async move {
             loop {
-                let res = block_on(self.run_inner(&sender, &mut blocks));
+                let res = self.run_inner(&sender, &mut blocks).await;
                 if let Err(err) = res {
                     log::error!("Checkpoints extractor failed: {}", err);
                 }

--- a/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
@@ -76,7 +76,7 @@ impl CheckpointsExtractor {
         .await?;
 
         loop {
-            while let Some(block) = blocks.try_recv().ok() {
+            while let Ok(block) = blocks.try_recv() {
                 self.process_block_events(&gear_api, block.0, sender)
                     .await?;
             }

--- a/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
@@ -1,10 +1,9 @@
-use std::sync::mpsc::{channel, Receiver, Sender};
-
 use futures::executor::block_on;
 use gear_rpc_client::GearApi;
 use parity_scale_codec::{Decode, Encode};
 use primitive_types::H256;
 use prometheus::IntGauge;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 use checkpoint_light_client_io::meta::{Order, State, StateRequest};
@@ -46,13 +45,18 @@ impl CheckpointsExtractor {
         }
     }
 
-    pub fn run(mut self, blocks: Receiver<GearBlockNumber>) -> Receiver<EthereumSlotNumber> {
-        let (sender, receiver) = channel();
+    pub async fn run(
+        mut self,
+        mut blocks: UnboundedReceiver<GearBlockNumber>,
+    ) -> UnboundedReceiver<EthereumSlotNumber> {
+        let (sender, receiver) = unbounded_channel();
 
-        tokio::task::spawn_blocking(move || loop {
-            let res = block_on(self.run_inner(&sender, &blocks));
-            if let Err(err) = res {
-                log::error!("Checkpoints extractor failed: {}", err);
+        tokio::task::spawn(async move {
+            loop {
+                let res = block_on(self.run_inner(&sender, &mut blocks));
+                if let Err(err) = res {
+                    log::error!("Checkpoints extractor failed: {}", err);
+                }
             }
         });
 
@@ -61,8 +65,8 @@ impl CheckpointsExtractor {
 
     async fn run_inner(
         &mut self,
-        sender: &Sender<EthereumSlotNumber>,
-        blocks: &Receiver<GearBlockNumber>,
+        sender: &UnboundedSender<EthereumSlotNumber>,
+        blocks: &mut UnboundedReceiver<GearBlockNumber>,
     ) -> anyhow::Result<()> {
         let gear_api = GearApi::new(
             &self.args.vara_domain,
@@ -72,7 +76,7 @@ impl CheckpointsExtractor {
         .await?;
 
         loop {
-            for block in blocks.try_iter() {
+            while let Some(block) = blocks.try_recv().ok() {
                 self.process_block_events(&gear_api, block.0, sender)
                     .await?;
             }
@@ -83,7 +87,7 @@ impl CheckpointsExtractor {
         &mut self,
         gear_api: &GearApi,
         block: u32,
-        sender: &Sender<EthereumSlotNumber>,
+        sender: &UnboundedSender<EthereumSlotNumber>,
     ) -> anyhow::Result<()> {
         let block_hash = gear_api.block_number_to_hash(block).await?;
 

--- a/relayer/src/message_relayer/common/gear/message_paid_event_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_paid_event_extractor.rs
@@ -65,7 +65,7 @@ impl MessagePaidEventExtractor {
         blocks: &mut UnboundedReceiver<GearBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            while let Some(block) = blocks.try_recv().ok() {
+            while let Ok(block) = blocks.try_recv() {
                 self.process_block_events(block.0, sender).await?;
             }
         }

--- a/relayer/src/message_relayer/common/gear/message_paid_event_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_paid_event_extractor.rs
@@ -1,10 +1,8 @@
-use std::sync::mpsc::{channel, Receiver, Sender};
-
-use futures::executor::block_on;
 use gear_rpc_client::GearApi;
 use primitive_types::H256;
 use prometheus::IntCounter;
 use sails_rs::events::EventIo;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 use bridging_payment_client::bridging_payment::events::BridgingPaymentEvents;
@@ -43,13 +41,18 @@ impl MessagePaidEventExtractor {
         }
     }
 
-    pub fn run(self, blocks: Receiver<GearBlockNumber>) -> Receiver<PaidMessage> {
-        let (sender, receiver) = channel();
+    pub async fn run(
+        self,
+        mut blocks: UnboundedReceiver<GearBlockNumber>,
+    ) -> UnboundedReceiver<PaidMessage> {
+        let (sender, receiver) = unbounded_channel();
 
-        tokio::task::spawn_blocking(move || loop {
-            let res = block_on(self.run_inner(&sender, &blocks));
-            if let Err(err) = res {
-                log::error!("Message paid event extractor failed: {}", err);
+        tokio::task::spawn(async move {
+            loop {
+                let res = self.run_inner(&sender, &mut blocks).await;
+                if let Err(err) = res {
+                    log::error!("Message paid event extractor failed: {}", err);
+                }
             }
         });
 
@@ -58,11 +61,11 @@ impl MessagePaidEventExtractor {
 
     async fn run_inner(
         &self,
-        sender: &Sender<PaidMessage>,
-        blocks: &Receiver<GearBlockNumber>,
+        sender: &UnboundedSender<PaidMessage>,
+        blocks: &mut UnboundedReceiver<GearBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            for block in blocks.try_iter() {
+            while let Some(block) = blocks.try_recv().ok() {
                 self.process_block_events(block.0, sender).await?;
             }
         }
@@ -71,7 +74,7 @@ impl MessagePaidEventExtractor {
     async fn process_block_events(
         &self,
         block: u32,
-        sender: &Sender<PaidMessage>,
+        sender: &UnboundedSender<PaidMessage>,
     ) -> anyhow::Result<()> {
         let block_hash = self.gear_api.block_number_to_hash(block).await?;
 

--- a/relayer/src/message_relayer/common/gear/message_queued_event_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_queued_event_extractor.rs
@@ -58,7 +58,7 @@ impl MessageQueuedEventExtractor {
         blocks: &mut UnboundedReceiver<GearBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            while let Some(block) = blocks.try_recv().ok() {
+            while let Ok(block) = blocks.try_recv() {
                 self.process_block_events(block, sender).await?;
             }
         }

--- a/relayer/src/message_relayer/common/gear/message_queued_event_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_queued_event_extractor.rs
@@ -1,8 +1,6 @@
-use std::sync::mpsc::{channel, Receiver, Sender};
-
-use futures::executor::block_on;
 use gear_rpc_client::GearApi;
 use prometheus::IntCounter;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 use crate::message_relayer::common::{GearBlockNumber, MessageInBlock};
@@ -36,13 +34,18 @@ impl MessageQueuedEventExtractor {
         }
     }
 
-    pub fn run(self, blocks: Receiver<GearBlockNumber>) -> Receiver<MessageInBlock> {
-        let (sender, receiver) = channel();
+    pub async fn run(
+        self,
+        mut blocks: UnboundedReceiver<GearBlockNumber>,
+    ) -> UnboundedReceiver<MessageInBlock> {
+        let (sender, receiver) = unbounded_channel();
 
-        tokio::task::spawn_blocking(move || loop {
-            let res = block_on(self.run_inner(&sender, &blocks));
-            if let Err(err) = res {
-                log::error!("Message queued extractor failed: {}", err);
+        tokio::task::spawn(async move {
+            loop {
+                let res = self.run_inner(&sender, &mut blocks).await;
+                if let Err(err) = res {
+                    log::error!("Message queued extractor failed: {}", err);
+                }
             }
         });
 
@@ -51,11 +54,11 @@ impl MessageQueuedEventExtractor {
 
     async fn run_inner(
         &self,
-        sender: &Sender<MessageInBlock>,
-        blocks: &Receiver<GearBlockNumber>,
+        sender: &UnboundedSender<MessageInBlock>,
+        blocks: &mut UnboundedReceiver<GearBlockNumber>,
     ) -> anyhow::Result<()> {
         loop {
-            for block in blocks.try_iter() {
+            while let Some(block) = blocks.try_recv().ok() {
                 self.process_block_events(block, sender).await?;
             }
         }
@@ -64,7 +67,7 @@ impl MessageQueuedEventExtractor {
     async fn process_block_events(
         &self,
         block: GearBlockNumber,
-        sender: &Sender<MessageInBlock>,
+        sender: &UnboundedSender<MessageInBlock>,
     ) -> anyhow::Result<()> {
         let block_hash = self.gear_api.block_number_to_hash(block.0).await?;
 

--- a/relayer/src/message_relayer/common/gear/message_sender/mod.rs
+++ b/relayer/src/message_relayer/common/gear/message_sender/mod.rs
@@ -1,7 +1,6 @@
-use std::future::Future;
-
 use crate::message_relayer::common::{EthereumSlotNumber, GSdkArgs, TxHashWithSlot};
 use anyhow::anyhow;
+use backoff::backoff::Backoff;
 use ethereum_beacon_client::BeaconClient;
 use ethereum_client::EthApi;
 use futures::executor::block_on;
@@ -14,6 +13,7 @@ use sails_rs::{
     gclient::calls::GClientRemoting,
     Encode,
 };
+
 use tokio::sync::mpsc::UnboundedReceiver;
 use utils_prometheus::{impl_metered_service, MeteredService};
 use vft_manager_client::vft_manager::io::SubmitReceipt;
@@ -100,43 +100,124 @@ impl MessageSender {
         mut messages: UnboundedReceiver<TxHashWithSlot>,
         mut checkpoints: UnboundedReceiver<EthereumSlotNumber>,
     ) {
-        struct AssertSendSafe<F>(F);
+        let _ = tokio::task::spawn_blocking(move || {
+            block_on(async move {
+                let mut retries = 0;
+                let mut eth_api = self.eth_api.clone();
+                let mut beacon_client = self.beacon_client.clone();
+                let mut backoff = backoff::ExponentialBackoff::default();
+                loop {
+                    match self.run_inner(&mut messages, &mut checkpoints, &eth_api, &beacon_client).await {
+                        Ok(()) => continue,
+                        Err(err) => {
+                            match self.handle_error(&mut eth_api, &mut beacon_client, err)
+                                .await {
+                                    Ok(()) => continue,
+                                    Err(err) => match err {
+                                        backoff::Error::Permanent(permanent) => {
+                                            log::error!("Gear message sender failed with permanent error: {}", permanent);
+                                        }
 
-        unsafe impl<F> Send for AssertSendSafe<F> {}
-        unsafe impl<F> Sync for AssertSendSafe<F> {}
+                                        backoff::Error::Transient { err, retry_after } => {
+                                            log::error!("Gear message sender failed with transiet error: {}", err);
 
-        impl<F: Future> Future for AssertSendSafe<F> {
-            type Output = F::Output;
-
-            fn poll(
-                self: std::pin::Pin<&mut Self>,
-                cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<Self::Output> {
-                unsafe {
-                    let inner = self.map_unchecked_mut(|s| &mut s.0);
-                    Future::poll(inner, cx)
+                                            if let Some(duration) = retry_after {
+                                                log::error!("Retrying after {:?}", duration);
+                                                tokio::time::sleep(duration).await;
+                                                retries += 1;
+                                            } else {
+                                                match backoff.next_backoff() {
+                                                    Some(duration) => {
+                                                        log::error!("Retrying after {:?}", duration);
+                                                        tokio::time::sleep(duration).await;
+                                                        retries += 1;
+                                                    }
+                                                    None => {
+                                                        log::error!("Gear message sender failed (timed out after {retries} retries): {err}");
+                                                        return;
+                                                    }
+                                                }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
+            });
+        })
+        .await;
+    }
+
+    /// Handle an error. If error is recoverable, return Ok(()), otherwise return Err which
+    /// would terminate the `run` loop.
+    ///
+    /// # Recoverable errors
+    ///
+    /// At the moment only transport errors are considered recoverable. When they happen
+    /// we reconstruct EthApi and GearApi clients which should force a new connection to the
+    /// server.
+    async fn handle_error(
+        &self,
+        eth_api: &mut EthApi,
+        beacon_client: &mut BeaconClient,
+        error: anyhow::Error,
+    ) -> Result<(), backoff::Error<anyhow::Error>> {
+        use gclient::Error as GClientError;
+        use sails_rs::errors::Error as SailsError;
+        use subxt::error::RpcError;
+        use subxt::Error as SubxtError;
+
+        if let Some(err) = error.downcast_ref::<SailsError>() {
+            match err {
+                SailsError::GClient(err) => {
+                    match err {
+                        GClientError::Subxt(err) => {
+                            // while connection failed, it will reconnect automatically
+                            // just return Ok(())
+                            if err.is_disconnected_will_reconnect() {
+                                return Ok(());
+                            }
+                            match err {
+                                SubxtError::Rpc(RpcError::SubscriptionDropped)
+                                | SubxtError::Rpc(RpcError::RequestRejected(_)) => {
+                                    *beacon_client = beacon_client.reconnect().await?;
+                                    *eth_api =
+                                        eth_api.reconnect().map_err(|e| anyhow::Error::new(e))?;
+                                    return Err(backoff::Error::Transient {
+                                        err: error,
+                                        retry_after: None,
+                                    });
+                                }
+
+                                _ => {
+                                    log::error!("Gear message sender failed: {}", err);
+                                    return Err(backoff::Error::Permanent(error));
+                                }
+                            }
+                        }
+
+                        _ => return Ok(()),
+                    }
+                }
+
+                _ => return Ok(()),
             }
         }
-        tokio::spawn(AssertSendSafe(async move {
-            loop {
-                let res = self.run_inner(&mut messages, &mut checkpoints).await;
-                if let Err(err) = res {
-                    log::error!("Gear message sender failed: {}", err);
-                }
-            }
-        }));
+        Ok(())
     }
 
     async fn run_inner(
         &mut self,
         messages: &mut UnboundedReceiver<TxHashWithSlot>,
         checkpoints: &mut UnboundedReceiver<EthereumSlotNumber>,
+        eth_api: &EthApi,
+        beacon_client: &BeaconClient,
     ) -> anyhow::Result<()> {
         let mut latest_checkpoint_slot = None;
 
         loop {
-            while let Some(checkpoint) = checkpoints.try_recv().ok() {
+            while let Ok(checkpoint) = checkpoints.try_recv() {
                 if latest_checkpoint_slot.unwrap_or_default() < checkpoint {
                     latest_checkpoint_slot = Some(checkpoint);
                 } else {
@@ -149,7 +230,7 @@ impl MessageSender {
                 }
             }
 
-            while let Some(message) = messages.try_recv().ok() {
+            while let Ok(message) = messages.try_recv() {
                 self.waiting_checkpoint.push(message);
             }
 
@@ -162,7 +243,7 @@ impl MessageSender {
                 if self.waiting_checkpoint[i].slot_number
                     <= latest_checkpoint_slot.unwrap_or_default()
                 {
-                    self.submit_message(&self.waiting_checkpoint[i], &gear_api)
+                    self.submit_message(&self.waiting_checkpoint[i], &gear_api, &eth_api, &beacon_client)
                         .await?;
                     let _ = self.waiting_checkpoint.remove(i);
                 }
@@ -180,9 +261,11 @@ impl MessageSender {
         &self,
         message: &TxHashWithSlot,
         gear_api: &GearApi,
+        eth_api: &EthApi,
+        beacon_client: &BeaconClient
     ) -> anyhow::Result<()> {
         let payload =
-            compose_payload::compose(&self.beacon_client, &self.eth_api, message.tx_hash).await?;
+            compose_payload::compose(&beacon_client, eth_api, message.tx_hash).await?;
 
         log::info!(
             "Sending message in gear_message_sender: tx_index={}, slot={}",

--- a/relayer/src/message_relayer/common/gear/message_sender/mod.rs
+++ b/relayer/src/message_relayer/common/gear/message_sender/mod.rs
@@ -116,6 +116,7 @@ impl MessageSender {
                                     Err(err) => match err {
                                         backoff::Error::Permanent(permanent) => {
                                             log::error!("Gear message sender failed with permanent error: {}", permanent);
+                                            return;
                                         }
 
                                         backoff::Error::Transient { err, retry_after } => {

--- a/relayer/src/message_relayer/common/gear/message_sender/mod.rs
+++ b/relayer/src/message_relayer/common/gear/message_sender/mod.rs
@@ -105,7 +105,7 @@ impl MessageSender {
                     match self.run_inner(&mut messages, &mut checkpoints).await {
                         Ok(_) => continue,
                         Err(err) => {
-                            log::error!("Gear messenger failed with: {err}");
+                            log::error!("Gear message sender failed with: {err}");
                         }
                     }
                 }

--- a/relayer/src/message_relayer/common/paid_messages_filter.rs
+++ b/relayer/src/message_relayer/common/paid_messages_filter.rs
@@ -66,7 +66,7 @@ impl PaidMessagesFilter {
         paid_messages: &mut UnboundedReceiver<PaidMessage>,
     ) -> anyhow::Result<()> {
         loop {
-            while let Some(message) = messages.try_recv().ok() {
+            while let Ok(message) = messages.try_recv() {
                 if let Some(msg) = self
                     .pending_messages
                     .insert(message.message.nonce_le, message)
@@ -78,7 +78,7 @@ impl PaidMessagesFilter {
                 }
             }
 
-            while let Some(PaidMessage { nonce }) = paid_messages.try_recv().ok() {
+            while let Ok(PaidMessage { nonce }) = paid_messages.try_recv() {
                 self.pending_nonces.push(nonce);
             }
 

--- a/relayer/src/message_relayer/common/paid_messages_filter.rs
+++ b/relayer/src/message_relayer/common/paid_messages_filter.rs
@@ -1,7 +1,5 @@
-use std::{
-    collections::HashMap,
-    sync::mpsc::{channel, Receiver, Sender},
-};
+use std::collections::HashMap;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use prometheus::IntGauge;
 use utils_prometheus::{impl_metered_service, MeteredService};
@@ -40,16 +38,18 @@ impl PaidMessagesFilter {
         }
     }
 
-    pub fn run(
+    pub async fn run(
         mut self,
-        messages: Receiver<MessageInBlock>,
-        paid_messages: Receiver<PaidMessage>,
-    ) -> Receiver<MessageInBlock> {
-        let (sender, receiver) = channel();
+        mut messages: UnboundedReceiver<MessageInBlock>,
+        mut paid_messages: UnboundedReceiver<PaidMessage>,
+    ) -> UnboundedReceiver<MessageInBlock> {
+        let (sender, receiver) = unbounded_channel();
 
         tokio::spawn(async move {
             loop {
-                let res = self.run_inner(&sender, &messages, &paid_messages);
+                let res = self
+                    .run_inner(&sender, &mut messages, &mut paid_messages)
+                    .await;
                 if let Err(err) = res {
                     log::error!("Paid messages filter failed: {}", err);
                 }
@@ -59,14 +59,14 @@ impl PaidMessagesFilter {
         receiver
     }
 
-    fn run_inner(
+    async fn run_inner(
         &mut self,
-        sender: &Sender<MessageInBlock>,
-        messages: &Receiver<MessageInBlock>,
-        paid_messages: &Receiver<PaidMessage>,
+        sender: &UnboundedSender<MessageInBlock>,
+        messages: &mut UnboundedReceiver<MessageInBlock>,
+        paid_messages: &mut UnboundedReceiver<PaidMessage>,
     ) -> anyhow::Result<()> {
         loop {
-            for message in messages.try_iter() {
+            while let Some(message) = messages.try_recv().ok() {
                 if let Some(msg) = self
                     .pending_messages
                     .insert(message.message.nonce_le, message)
@@ -78,7 +78,7 @@ impl PaidMessagesFilter {
                 }
             }
 
-            for PaidMessage { nonce } in paid_messages.try_iter() {
+            while let Some(PaidMessage { nonce }) = paid_messages.try_recv().ok() {
                 self.pending_nonces.push(nonce);
             }
 

--- a/relayer/src/message_relayer/eth_to_gear/all_token_transfers.rs
+++ b/relayer/src/message_relayer/eth_to_gear/all_token_transfers.rs
@@ -99,13 +99,15 @@ impl Relayer {
         })
     }
 
-    pub fn run(self) {
-        let [gear_blocks] = self.gear_block_listener.run();
-        let ethereum_blocks = self.ethereum_block_listener.run();
+    pub async fn run(self) {
+        let [gear_blocks] = self.gear_block_listener.run().await;
+        let ethereum_blocks = self.ethereum_block_listener.run().await;
 
-        let deposit_events = self.deposit_event_extractor.run(ethereum_blocks);
-        let checkpoints = self.checkpoints_extractor.run(gear_blocks);
+        let deposit_events = self.deposit_event_extractor.run(ethereum_blocks).await;
+        let checkpoints = self.checkpoints_extractor.run(gear_blocks).await;
 
-        self.gear_message_sender.run(deposit_events, checkpoints);
+        self.gear_message_sender
+            .run(deposit_events, checkpoints)
+            .await;
     }
 }

--- a/relayer/src/message_relayer/eth_to_gear/paid_token_transfers.rs
+++ b/relayer/src/message_relayer/eth_to_gear/paid_token_transfers.rs
@@ -99,14 +99,15 @@ impl Relayer {
         })
     }
 
-    pub fn run(self) {
-        let [gear_blocks] = self.gear_block_listener.run();
-        let ethereum_blocks = self.ethereum_block_listener.run();
+    pub async fn run(self) {
+        let [gear_blocks] = self.gear_block_listener.run().await;
+        let ethereum_blocks = self.ethereum_block_listener.run().await;
 
-        let message_paid_events = self.message_paid_event_extractor.run(ethereum_blocks);
-        let checkpoints = self.checkpoints_extractor.run(gear_blocks);
+        let message_paid_events = self.message_paid_event_extractor.run(ethereum_blocks).await;
+        let checkpoints = self.checkpoints_extractor.run(gear_blocks).await;
 
         self.gear_message_sender
-            .run(message_paid_events, checkpoints);
+            .run(message_paid_events, checkpoints)
+            .await;
     }
 }

--- a/relayer/src/message_relayer/gear_to_eth/all_token_transfers.rs
+++ b/relayer/src/message_relayer/gear_to_eth/all_token_transfers.rs
@@ -74,14 +74,14 @@ impl Relayer {
         })
     }
 
-    pub fn run(self) {
-        let [gear_blocks] = self.gear_block_listener.run();
-        let ethereum_blocks = self.ethereum_block_listener.run();
+    pub async fn run(self) {
+        let [gear_blocks] = self.gear_block_listener.run().await;
+        let ethereum_blocks = self.ethereum_block_listener.run().await;
 
-        let messages = self.message_sent_listener.run(gear_blocks);
+        let messages = self.message_sent_listener.run(gear_blocks).await;
 
-        let merkle_roots = self.merkle_root_extractor.run(ethereum_blocks);
+        let merkle_roots = self.merkle_root_extractor.run(ethereum_blocks).await;
 
-        self.message_sender.run(messages, merkle_roots);
+        self.message_sender.run(messages, merkle_roots).await;
     }
 }

--- a/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
+++ b/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
@@ -97,17 +97,19 @@ impl Relayer {
         })
     }
 
-    pub fn run(self) {
-        let [gear_blocks_0, gear_blocks_1] = self.gear_block_listener.run();
-        let ethereum_blocks = self.ethereum_block_listener.run();
+    pub async fn run(self) {
+        let [gear_blocks_0, gear_blocks_1] = self.gear_block_listener.run().await;
+        let ethereum_blocks = self.ethereum_block_listener.run().await;
 
-        let messages = self.message_sent_listener.run(gear_blocks_0);
-        let paid_messages = self.message_paid_listener.run(gear_blocks_1);
+        let messages = self.message_sent_listener.run(gear_blocks_0).await;
+        let paid_messages = self.message_paid_listener.run(gear_blocks_1).await;
 
-        let filtered_messages = self.paid_messages_filter.run(messages, paid_messages);
+        let filtered_messages = self.paid_messages_filter.run(messages, paid_messages).await;
 
-        let merkle_roots = self.merkle_root_extractor.run(ethereum_blocks);
+        let merkle_roots = self.merkle_root_extractor.run(ethereum_blocks).await;
 
-        self.message_sender.run(filtered_messages, merkle_roots);
+        self.message_sender
+            .run(filtered_messages, merkle_roots)
+            .await;
     }
 }


### PR DESCRIPTION
- Changed code from using std channels to tokio channels
- No `block_on` and `spawn_blocking` used anymore (1), tokio tasks are used instead

(1) MessageSender cannot yet just use `tokio::task::spawn` because `send_recv` from Sails is not Send-able future. Investigate how to make it work

# TODO
1) Make recovery in case of error graceful, do not simply restart the `run_inner()` in most cases
2) Add ability to resubscribe to GearApi and EthApi, necessary for 1)

@gshep 
