### PR TITLE
refactor(relayer): remember transactions to be processed

### DIFF
--- a/relayer/src/message_relayer/eth_to_gear/proof_composer.rs
+++ b/relayer/src/message_relayer/eth_to_gear/proof_composer.rs
@@ -87,6 +87,7 @@ pub struct ProofComposer {
     pub last_checkpoint: Option<EthereumSlotNumber>,
     pub historical_proxy_address: H256,
     pub suri: String,
+    pub to_process: Vec<(Uuid, TxHashWithSlot)>,
 }
 
 impl ProofComposer {
@@ -105,6 +106,7 @@ impl ProofComposer {
             last_checkpoint: None,
             historical_proxy_address,
             suri,
+            to_process: Vec::with_capacity(100),
         }
     }
 
@@ -193,33 +195,36 @@ async fn handle_requests(
     responses: &UnboundedSender<Response>,
 ) -> anyhow::Result<()> {
     loop {
+        while !this.to_process.is_empty() {
+            let (tx_uuid, tx) = this.to_process.last().unwrap();
+            log::debug!("Processing transaction #{tx_uuid} (hash: {:?})", tx.tx_hash);
+            this.process(responses, tx.clone(), *tx_uuid).await?;
+            this.to_process.pop().unwrap();
+        }
+
         tokio::select! {
+
             Some(checkpoint) = checkpoints.recv() => {
                 log::info!("Received checkpoint: {checkpoint}");
                 this.last_checkpoint = Some(checkpoint);
 
-                let mut to_process = Vec::new();
-
                 this.waiting_for_checkpoints.retain(|(tx_uuid, tx)| {
                     if tx.slot_number <= checkpoint {
-                        to_process.push((*tx_uuid, tx.clone()));
+                        this.to_process.push((*tx_uuid, tx.clone()));
                         false
                     } else {
                         true
                     }
                 });
 
-                for (tx_uuid, tx) in to_process {
-                    log::debug!("Processing waiting transaction {tx_uuid}: {tx:?}");
-                    this.process(responses, tx, tx_uuid).await?;
-                }
+                continue;
             }
 
             Some(Request { tx_uuid, tx }) = requests.recv() => {
                 if this.last_checkpoint.filter(|&last_checkpoint| tx.slot_number <= last_checkpoint)
                     .is_some()
                 {
-                    this.process(responses, tx, tx_uuid).await?;
+                    this.to_process.push((tx_uuid, tx.clone()));
                 } else {
                     log::debug!("Transaction {tx_uuid} is waiting for checkpoint, adding to queue");
                     this.waiting_for_checkpoints.push((tx_uuid, tx));


### PR DESCRIPTION
At the moment, eth_to_gear relayer has a chance to loose transactions. For example in ProofComposer task: 
- transaction is received and passed to `compose()`
- `compose()` function fails
- task reconnects to Gear/Eth API and continues execution without restarting transaction
At the time being, it requires restart of relayer to restart the transaction.

This PR fixes that by adding a list of to processed transactions. If transaction completes it is removed from a list, otherwise it is kept there. 