### PR TITLE
refactor(relayer): Send latest checkpoint from light-client program on startup

### DIFF
--- a/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
@@ -1,12 +1,13 @@
 use crate::message_relayer::common::{gear::block_listener::GearBlock, EthereumSlotNumber};
 use checkpoint_light_client_client::{
     service_replay_back::events::ServiceReplayBackEvents,
-    service_sync_update::events::ServiceSyncUpdateEvents,
+    service_sync_update::events::ServiceSyncUpdateEvents, traits::ServiceState, Order,
 };
+use gclient::GearApi;
 use primitive_types::H256;
 use prometheus::IntGauge;
 
-use sails_rs::events::EventIo;
+use sails_rs::{calls::Query, events::EventIo, gclient::calls::GClientRemoting};
 use tokio::sync::{
     broadcast::{error::RecvError, Receiver},
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
@@ -67,6 +68,22 @@ impl CheckpointsExtractor {
 
             metrics: Metrics::new(),
         }
+    }
+
+    pub async fn get_latest_checkpoint(&self, gear_api: GearApi) -> Option<EthereumSlotNumber> {
+        let remoting = GClientRemoting::new(gear_api);
+        checkpoint_light_client_client::ServiceState::new(remoting)
+            .get(Order::Reverse, 0, 1)
+            .recv(self.checkpoint_light_client_address.into())
+            .await
+            .ok()
+            .map(|state| {
+                state
+                    .checkpoints
+                    .last()
+                    .map(|(checkpoint, _)| EthereumSlotNumber(*checkpoint))
+            })
+            .unwrap_or(None)
     }
 
     pub async fn run(

--- a/relayer/src/message_relayer/eth_to_gear/mod.rs
+++ b/relayer/src/message_relayer/eth_to_gear/mod.rs
@@ -1,3 +1,10 @@
+use checkpoint_light_client_client::{traits::ServiceState, Order};
+use gclient::GearApi;
+use primitive_types::H256;
+use sails_rs::{calls::Query, gclient::calls::GClientRemoting};
+
+use super::common::EthereumSlotNumber;
+
 pub mod all_token_transfers;
 pub mod api_provider;
 pub mod manual;
@@ -7,3 +14,22 @@ pub mod message_sender;
 pub mod proof_composer;
 pub mod storage;
 pub mod tx_manager;
+
+pub async fn get_latest_checkpoint(
+    checkpoint_light_client_address: H256,
+    gear_api: GearApi,
+) -> Option<EthereumSlotNumber> {
+    let remoting = GClientRemoting::new(gear_api);
+    checkpoint_light_client_client::ServiceState::new(remoting)
+        .get(Order::Reverse, 0, 1)
+        .recv(checkpoint_light_client_address.into())
+        .await
+        .ok()
+        .map(|state| {
+            state
+                .checkpoints
+                .last()
+                .map(|(checkpoint, _)| EthereumSlotNumber(*checkpoint))
+        })
+        .unwrap_or(None)
+}

--- a/relayer/src/message_relayer/eth_to_gear/paid_token_transfers.rs
+++ b/relayer/src/message_relayer/eth_to_gear/paid_token_transfers.rs
@@ -3,14 +3,10 @@ use super::{
     storage::{JSONStorage, Storage},
     tx_manager,
 };
-use checkpoint_light_client_client::{traits::ServiceState, Order};
 use ethereum_beacon_client::BeaconClient;
 use ethereum_client::EthApi;
 use primitive_types::{H160, H256};
-use sails_rs::{
-    calls::{ActionIo, Query},
-    gclient::calls::GClientRemoting,
-};
+use sails_rs::calls::ActionIo;
 use std::{iter, sync::Arc};
 use tx_manager::TransactionManager;
 use utils_prometheus::MeteredService;
@@ -87,23 +83,14 @@ impl Relayer {
             genesis_time,
         );
 
+        let checkpoints_extractor = CheckpointsExtractor::new(checkpoint_light_client_address);
+
         let client = api_provider
             .gclient_client(&suri)
             .expect("failed to create gclient");
-        let remoting = GClientRemoting::new(client);
-        let latest_checkpoint = checkpoint_light_client_client::ServiceState::new(remoting)
-            .get(Order::Reverse, 0, 1)
-            .recv(checkpoint_light_client_address.into())
-            .await
-            .ok()
-            .map(|state| {
-                state
-                    .checkpoints
-                    .last()
-                    .map(|(checkpoint, _)| EthereumSlotNumber(*checkpoint))
-            })
-            .unwrap_or(None);
-        let checkpoints_extractor = CheckpointsExtractor::new(checkpoint_light_client_address);
+
+        let latest_checkpoint =
+            super::get_latest_checkpoint(checkpoint_light_client_address, client).await;
 
         let route =
             <vft_manager_client::vft_manager::io::SubmitReceipt as ActionIo>::ROUTE.to_vec();

--- a/tests/src/relayer/eth_to_gear.rs
+++ b/tests/src/relayer/eth_to_gear.rs
@@ -331,7 +331,7 @@ async fn test_api_provider() {
 
 #[tokio::test]
 async fn test_tx_manager() {
-    pretty_env_logger::formatted_timed_builder()
+    let _ = pretty_env_logger::formatted_timed_builder()
         .filter_level(log::LevelFilter::Off)
         .format_target(false)
         .filter(Some("prover"), log::LevelFilter::Info)
@@ -340,7 +340,7 @@ async fn test_tx_manager() {
         .filter(Some("metrics"), log::LevelFilter::Info)
         .format_timestamp_secs()
         .parse_default_env()
-        .init();
+        .try_init();
     let contracts = super::upload::EthContracts::new().await;
 
     let api_provider = ApiProvider::new("ws://127.0.0.1".to_owned(), 9944, 2)


### PR DESCRIPTION
This removes requirement on waiting for checkpoint if you're trying to manually relay transaction. If tx checkpoint is already stored in light-client program we can just use it. 

@gshep 