### PR TITLE
fix(relayer): prevent PaidMessageFilter from looping infinitely

### DIFF
--- a/relayer/src/message_relayer/common/paid_messages_filter.rs
+++ b/relayer/src/message_relayer/common/paid_messages_filter.rs
@@ -53,11 +53,9 @@ impl PaidMessagesFilter {
         let (sender, receiver) = unbounded_channel();
 
         tokio::spawn(async move {
-            loop {
-                match run_inner(&mut self, &sender, &mut messages, &mut paid_messages).await {
-                    Ok(_) => break,
-                    Err(e) => log::error!("Paid messages filter failed: {e}"),
-                }
+            match run_inner(&mut self, &sender, &mut messages, &mut paid_messages).await {
+                Ok(_) => {}
+                Err(e) => log::error!("Paid messages filter failed: {e}"),
             }
         });
 


### PR DESCRIPTION
@gshep 

This prevents infinite looping in case one of channels closes unexpectedly: 
![image](https://github.com/user-attachments/assets/3e90d99c-3999-4a2d-97d0-7bc6c505b3bc)
