### PR TITLE
feat(relayer): Add POST-handler of a list to gear-eth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,189 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-codec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dfe5c9e0004c623edc65391dfd51daa201e7e30ebd9c9bedf873048ec32bc2"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "base64 0.22.1",
+ "bitflags 2.9.1",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more 2.0.1",
+ "encoding_rs",
+ "flate2",
+ "foldhash",
+ "futures-core",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.9.1",
+ "sha1",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
+dependencies = [
+ "bytestring",
+ "cfg-if",
+ "http 0.2.12",
+ "regex",
+ "regex-lite",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie",
+ "derive_more 2.0.1",
+ "encoding_rs",
+ "foldhash",
+ "futures-core",
+ "futures-util",
+ "impl-more",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2 0.5.10",
+ "time",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
+dependencies = [
+ "actix-router",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "actor-system-error"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +314,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -2080,6 +2278,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2366,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -2561,6 +2789,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -4111,6 +4350,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -6546,6 +6795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-more"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
+
+[[package]]
 name = "impl-rlp"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7210,6 +7465,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7847,6 +8108,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "local-channel"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8173,6 +8451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -10571,6 +10850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10604,6 +10889,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 name = "relayer"
 version = "0.3.0"
 dependencies = [
+ "actix-web",
  "alloy",
  "alloy-consensus",
  "alloy-eips",
@@ -16859,6 +17145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
+]
+
+[[package]]
 name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16875,6 +17170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ version = "0.3.0"
 edition = "2021"
 
 [workspace.dependencies]
+actix-web = "4.11.0"
 mock-contract = { path = "./mock-contract" }
 relayer = { path = "./relayer" }
 gear-rpc-client = { path = "./gear-rpc-client" }
@@ -147,7 +148,7 @@ prometheus = { version = "0.13.0", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
 rand_chacha = "0.3.1"
 rayon = "1.5.3"
-reqwest = "0.11.24"
+reqwest = { version = "0.11.24", features = ["json"] }
 ring = { git = "https://github.com/gear-tech/ring.git", branch = "gear-v0.17.8", default-features = false, features = [
     "alloc",
 ] }

--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -24,13 +24,13 @@ use sp_consensus_grandpa::GrandpaJustification;
 use sp_core::{crypto::Wraps, Blake2Hasher, Hasher};
 use sp_runtime::{traits::AppVerify, AccountId32};
 use subxt::{
+    backend::BlockRef,
     blocks::Block as BlockImpl,
     dynamic::DecodedValueThunk,
     rpc_params,
     storage::Address,
     utils::{Yes, H256},
     OnlineClient,
-    backend::BlockRef,
 };
 use trie_db::{node::NodeHandle, ChildReference};
 
@@ -78,7 +78,8 @@ impl GearApi {
 
     /// Get block with the specified hash.
     pub async fn get_block_at(&self, block_hash: H256) -> AnyResult<GearBlock> {
-        Ok(self.api
+        Ok(self
+            .api
             .blocks()
             .at(BlockRef::from_hash(block_hash))
             .await?)
@@ -114,10 +115,7 @@ impl GearApi {
 
     /// Get authority set state for specified block. If block is not specified
     /// the latest finalized block is taken.
-    pub async fn authority_set_state(
-        &self,
-        block: Option<H256>,
-    ) -> AnyResult<AuthoritySetState> {
+    pub async fn authority_set_state(&self, block: Option<H256>) -> AnyResult<AuthoritySetState> {
         let block = match block {
             Some(block) => block,
             None => self.latest_finalized_block().await?,
@@ -328,10 +326,7 @@ impl GearApi {
         self.fetch_authority_set_in_block(block).await
     }
 
-    pub async fn search_for_authority_set_block(
-        &self,
-        authority_set_id: u64,
-    ) -> AnyResult<H256> {
+    pub async fn search_for_authority_set_block(&self, authority_set_id: u64) -> AnyResult<H256> {
         let latest_block = self.latest_finalized_block().await?;
         let latest_vs_id = self.authority_set_id(latest_block).await?;
 

--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, Context, Result as AnyResult};
 use blake2::{
     digest::{Update, VariableOutput},
     Blake2bVar,
@@ -30,12 +30,15 @@ use subxt::{
     storage::Address,
     utils::{Yes, H256},
     OnlineClient,
+    backend::BlockRef,
 };
 use trie_db::{node::NodeHandle, ChildReference};
 
 use crate::dto::StorageInclusionProof;
 
 pub mod dto;
+
+pub type GearBlock = BlockImpl<GearConfig, OnlineClient<GearConfig>>;
 
 struct StorageTrieInclusionProof {
     branch_nodes_data: Vec<BranchNodeData>,
@@ -66,14 +69,22 @@ impl From<gsdk::Api> for GearApi {
 }
 
 impl GearApi {
-    pub async fn new(domain: &str, port: u16, retries: u8) -> anyhow::Result<GearApi> {
+    pub async fn new(domain: &str, port: u16, retries: u8) -> AnyResult<GearApi> {
         let uri: &str = &format!("{domain}:{port}");
         Ok(GearApi {
             api: gsdk::Api::builder().retries(retries).build(uri).await?,
         })
     }
 
-    pub async fn block_hash_to_number(&self, block: H256) -> anyhow::Result<u32> {
+    /// Get block with the specified hash.
+    pub async fn get_block_at(&self, block_hash: H256) -> AnyResult<GearBlock> {
+        Ok(self.api
+            .blocks()
+            .at(BlockRef::from_hash(block_hash))
+            .await?)
+    }
+
+    pub async fn block_hash_to_number(&self, block: H256) -> AnyResult<u32> {
         self.api
             .rpc()
             .chain_get_block(Some(block))
@@ -82,7 +93,7 @@ impl GearApi {
             .ok_or_else(|| anyhow!("Block {} not present on RPC node", block))
     }
 
-    pub async fn block_number_to_hash(&self, block: u32) -> anyhow::Result<H256> {
+    pub async fn block_number_to_hash(&self, block: u32) -> AnyResult<H256> {
         self.api
             .rpc()
             .chain_get_block_hash(Some(block.into()))
@@ -90,12 +101,12 @@ impl GearApi {
             .ok_or_else(|| anyhow!("Block #{} not present on RPC node", block))
     }
 
-    pub async fn latest_finalized_block(&self) -> anyhow::Result<H256> {
+    pub async fn latest_finalized_block(&self) -> AnyResult<H256> {
         Ok(self.api.rpc().chain_get_finalized_head().await?)
     }
 
     /// Fetch authority set id for the given block.
-    pub async fn authority_set_id(&self, block: H256) -> anyhow::Result<u64> {
+    pub async fn authority_set_id(&self, block: H256) -> AnyResult<u64> {
         let block = (*self.api).blocks().at(block).await?;
         let set_id_address = gsdk::Api::storage_root(GrandpaStorage::CurrentSetId);
         Self::fetch_from_storage(&block, &set_id_address).await
@@ -106,7 +117,7 @@ impl GearApi {
     pub async fn authority_set_state(
         &self,
         block: Option<H256>,
-    ) -> anyhow::Result<AuthoritySetState> {
+    ) -> AnyResult<AuthoritySetState> {
         let block = match block {
             Some(block) => block,
             None => self.latest_finalized_block().await?,
@@ -133,7 +144,7 @@ impl GearApi {
     }
 
     /// Find authority set id that have signed given `block`.
-    pub async fn signed_by_authority_set_id(&self, block: H256) -> anyhow::Result<u64> {
+    pub async fn signed_by_authority_set_id(&self, block: H256) -> AnyResult<u64> {
         let stored_set_id = self.authority_set_id(block).await?;
         let previous_block = self.previous_block(block).await?;
         let previous_block_stored_set_id = self.authority_set_id(previous_block).await?;
@@ -145,7 +156,7 @@ impl GearApi {
         })
     }
 
-    pub async fn find_era_first_block(&self, authority_set_id: u64) -> anyhow::Result<H256> {
+    pub async fn find_era_first_block(&self, authority_set_id: u64) -> AnyResult<H256> {
         let current_set_block = self
             .search_for_authority_set_block(authority_set_id)
             .await?;
@@ -185,7 +196,7 @@ impl GearApi {
         }
     }
 
-    async fn previous_block(&self, block: H256) -> anyhow::Result<H256> {
+    async fn previous_block(&self, block: H256) -> AnyResult<H256> {
         let block = self.api.blocks().at(block).await?;
         Ok(block.header().parent_hash)
     }
@@ -193,7 +204,7 @@ impl GearApi {
     pub async fn fetch_finality_proof_for_session(
         &self,
         authority_set_id: u64,
-    ) -> anyhow::Result<(H256, dto::BlockFinalityProof)> {
+    ) -> AnyResult<(H256, dto::BlockFinalityProof)> {
         let block = self
             .search_for_authority_set_block(authority_set_id)
             .await?;
@@ -204,7 +215,7 @@ impl GearApi {
     /// Subscribes to GRANDPA justifications stream and returns it.
     pub async fn subscribe_grandpa_justifications(
         &self,
-    ) -> anyhow::Result<impl Stream<Item = anyhow::Result<GrandpaJustification<GearHeader>>>> {
+    ) -> AnyResult<impl Stream<Item = AnyResult<GrandpaJustification<GearHeader>>>> {
         let stream = self
             .api
             .rpc()
@@ -216,7 +227,7 @@ impl GearApi {
             )
             .await?;
 
-        let stream = stream.map(|res: Result<String, _>| -> anyhow::Result<_, _> {
+        let stream = stream.map(|res: Result<String, _>| -> AnyResult<_, _> {
             let hex_string = res?;
             let bytes = hex::decode(&hex_string[2..]).context("failed to decoded hex")?;
             let justification = GrandpaJustification::<GearHeader>::decode(&mut &bytes[..])?;
@@ -240,7 +251,7 @@ impl GearApi {
     pub async fn fetch_finality_proof(
         &self,
         after_block: H256,
-    ) -> anyhow::Result<(H256, dto::BlockFinalityProof)> {
+    ) -> AnyResult<(H256, dto::BlockFinalityProof)> {
         let after_block_number = self.block_hash_to_number(after_block).await?;
         let finality: Option<String> = self
             .api
@@ -268,7 +279,7 @@ impl GearApi {
     pub async fn produce_finality_proof(
         &self,
         justification: GrandpaJustification<GearHeader>,
-    ) -> anyhow::Result<(H256, dto::BlockFinalityProof)> {
+    ) -> AnyResult<(H256, dto::BlockFinalityProof)> {
         let block_number = justification.commit.target_number;
         let block_hash = justification.commit.target_hash;
 
@@ -310,7 +321,7 @@ impl GearApi {
         ))
     }
 
-    async fn fetch_authority_set(&self, authority_set_id: u64) -> anyhow::Result<Vec<[u8; 32]>> {
+    async fn fetch_authority_set(&self, authority_set_id: u64) -> AnyResult<Vec<[u8; 32]>> {
         let block = self
             .search_for_authority_set_block(authority_set_id)
             .await?;
@@ -320,7 +331,7 @@ impl GearApi {
     pub async fn search_for_authority_set_block(
         &self,
         authority_set_id: u64,
-    ) -> anyhow::Result<H256> {
+    ) -> AnyResult<H256> {
         let latest_block = self.latest_finalized_block().await?;
         let latest_vs_id = self.authority_set_id(latest_block).await?;
 
@@ -390,7 +401,7 @@ impl GearApi {
         }
     }
 
-    async fn fetch_authority_set_in_block(&self, block: H256) -> anyhow::Result<Vec<[u8; 32]>> {
+    async fn fetch_authority_set_in_block(&self, block: H256) -> AnyResult<Vec<[u8; 32]>> {
         let block = (*self.api).blocks().at(block).await?;
 
         let session_keys_address = gsdk::Api::storage_root(SessionStorage::QueuedKeys);
@@ -406,7 +417,7 @@ impl GearApi {
     pub async fn fetch_sent_message_inclusion_proof(
         &self,
         block: H256,
-    ) -> anyhow::Result<dto::StorageInclusionProof> {
+    ) -> AnyResult<dto::StorageInclusionProof> {
         let address = hex::decode(MERKLE_ROOT_STORAGE_ADDRESS).unwrap();
         self.fetch_block_inclusion_proof(block, &address).await
     }
@@ -414,7 +425,7 @@ impl GearApi {
     pub async fn fetch_next_session_keys_inclusion_proof(
         &self,
         block: H256,
-    ) -> anyhow::Result<dto::StorageInclusionProof> {
+    ) -> AnyResult<dto::StorageInclusionProof> {
         let address = hex::decode(NEXT_VALIDATOR_SET_ADDRESS).unwrap();
         self.fetch_block_inclusion_proof(block, &address).await
     }
@@ -423,7 +434,7 @@ impl GearApi {
         &self,
         block: H256,
         address: &[u8],
-    ) -> anyhow::Result<dto::StorageInclusionProof> {
+    ) -> AnyResult<dto::StorageInclusionProof> {
         let storage_inclusion_proof = self.fetch_storage_inclusion_proof(block, address).await?;
 
         let block = (*self.api).blocks().at(block).await?;
@@ -459,7 +470,7 @@ impl GearApi {
         &self,
         block: H256,
         address: &[u8],
-    ) -> anyhow::Result<StorageTrieInclusionProof> {
+    ) -> AnyResult<StorageTrieInclusionProof> {
         use trie_db::{
             node::{Node, Value},
             NodeCodec, TrieLayout,
@@ -574,7 +585,7 @@ impl GearApi {
     async fn fetch_from_storage<T, A>(
         block: &BlockImpl<GearConfig, OnlineClient<GearConfig>>,
         address: &A,
-    ) -> anyhow::Result<T>
+    ) -> AnyResult<T>
     where
         A: Address<IsFetchable = Yes, Target = DecodedValueThunk>,
         T: Decode,
@@ -593,7 +604,7 @@ impl GearApi {
         &self,
         block: H256,
         message_hash: H256,
-    ) -> anyhow::Result<dto::MerkleProof> {
+    ) -> AnyResult<dto::MerkleProof> {
         use pallet_gear_eth_bridge_rpc_runtime_api::Proof;
 
         let proof: Option<Proof> = self
@@ -622,13 +633,13 @@ impl GearApi {
     }
 
     /// Fetch queue merkle root for the given block.
-    pub async fn fetch_queue_merkle_root(&self, block: H256) -> anyhow::Result<H256> {
+    pub async fn fetch_queue_merkle_root(&self, block: H256) -> AnyResult<H256> {
         let block = (*self.api).blocks().at(block).await?;
         let set_id_address = gsdk::Api::storage_root(GearEthBridgeStorage::QueueMerkleRoot);
         Self::fetch_from_storage(&block, &set_id_address).await
     }
 
-    pub async fn message_queued_events(&self, block: H256) -> anyhow::Result<Vec<dto::Message>> {
+    pub async fn message_queued_events(&self, block: H256) -> AnyResult<Vec<dto::Message>> {
         let events = self.api.get_events_at(Some(block)).await?;
 
         let events = events.into_iter().filter_map(|event| {
@@ -657,7 +668,7 @@ impl GearApi {
         from_program: H256,
         to_user: H256,
         block: H256,
-    ) -> anyhow::Result<Vec<dto::UserMessageSent>> {
+    ) -> AnyResult<Vec<dto::UserMessageSent>> {
         let events = self.api.get_events_at(Some(block)).await?;
 
         let events = events.into_iter().filter_map(|event| {
@@ -693,7 +704,7 @@ impl GearApi {
         &self,
         pallete: &str,
         constant: &str,
-    ) -> anyhow::Result<DecodedValueThunk> {
+    ) -> AnyResult<DecodedValueThunk> {
         let addr = subxt::dynamic::constant(pallete, constant);
         let res = self
             .api
@@ -704,7 +715,7 @@ impl GearApi {
     }
 
     /* todo(playX18): some version mismatch between relayer and this crate does not allow us to return AccountId32 as is, return raw bytes for now */
-    pub async fn bridge_admin(&self) -> anyhow::Result<[u8; 32]> {
+    pub async fn bridge_admin(&self) -> AnyResult<[u8; 32]> {
         self.get_constant("GearEthBridge", "BridgeAdmin")
             .await
             .and_then(|res| {
@@ -714,7 +725,7 @@ impl GearApi {
             })
     }
 
-    pub async fn bridge_pauser(&self) -> anyhow::Result<[u8; 32]> {
+    pub async fn bridge_pauser(&self) -> AnyResult<[u8; 32]> {
         self.get_constant("GearEthBridge", "BridgePauser")
             .await
             .and_then(|res| {

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -54,6 +54,7 @@ subxt.workspace = true
 gsdk.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+actix-web.workspace = true
 async-trait.workspace = true
 
 [build-dependencies]

--- a/relayer/src/cli/mod.rs
+++ b/relayer/src/cli/mod.rs
@@ -124,7 +124,7 @@ pub enum GearEthTokensCommands {
         web_server_token: String,
 
         /// Socket address for web-server
-        #[arg(long, env, default_value = "127.0.0.1:8443",)]
+        #[arg(long, env, default_value = "127.0.0.1:8443")]
         web_server_address: String,
     },
 }

--- a/relayer/src/cli/mod.rs
+++ b/relayer/src/cli/mod.rs
@@ -118,6 +118,14 @@ pub enum GearEthTokensCommands {
         /// Address of the bridging-payment program
         #[arg(long = "bridging-payment-address", env = "BRIDGING_PAYMENT_ADDRESS")]
         bridging_payment_address: String,
+
+        /// Authorization token for web-server
+        #[arg(long, env)]
+        web_server_token: String,
+
+        /// Socket address for web-server
+        #[arg(long, env, default_value = "127.0.0.1:8443",)]
+        web_server_address: String,
     },
 }
 

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -7,3 +7,4 @@ pub mod message_relayer;
 pub mod proof_storage;
 pub mod prover_interface;
 pub mod relay_merkle_roots;
+pub mod server;

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -20,8 +20,9 @@ use proof_storage::{FileSystemProofStorage, GearProofStorage, ProofStorage};
 use prover::proving::GenesisConfig;
 use relay_merkle_roots::MerkleRootRelayer;
 use relayer::*;
-use std::{collections::HashSet, str::FromStr, time::Duration};
+use std::{collections::HashSet, str::FromStr, time::Duration, net::TcpListener};
 use utils_prometheus::MetricsBuilder;
+use tokio::{sync::mpsc, task, time};
 
 #[tokio::main]
 async fn main() -> AnyResult<()> {
@@ -123,6 +124,7 @@ async fn main() -> AnyResult<()> {
             api_provider.spawn();
             kill_switch.run().await.expect("Kill switch relayer failed");
         }
+
         CliCommands::GearEthTokens(args) => {
             let eth_api = create_eth_signer_client(&args.ethereum_args).await;
 
@@ -132,15 +134,13 @@ async fn main() -> AnyResult<()> {
                 vara_rpc_retries: args.gear_args.retries,
             };
 
-            let mut metrics_builder = MetricsBuilder::new();
-
             let provider = ApiProvider::new(
                 gsdk_args.vara_domain.clone(),
                 gsdk_args.vara_port,
                 gsdk_args.vara_rpc_retries,
             )
             .await
-            .expect("Failed to create API provider");
+            .context("Failed to create API provider")?;
 
             let api = provider.connection().client();
 
@@ -201,17 +201,35 @@ async fn main() -> AnyResult<()> {
                     .await
                     .unwrap();
 
-                    metrics_builder = metrics_builder.register_service(&relayer);
+                    MetricsBuilder::new().register_service(&relayer).build()
+                        .run(args.prometheus_args.endpoint)
+                        .await;
 
                     provider.spawn();
                     relayer.run().await;
+
+                    loop {
+                        // relayer.run() spawns thread and exits, so we need to add this loop after calling run.
+                        time::sleep(Duration::from_secs(1)).await;
+                    }
                 }
+
                 GearEthTokensCommands::PaidTokenTransfers {
                     bridging_payment_address,
+                    web_server_token,
+                    web_server_address,
                 } => {
                     let bridging_payment_address =
                         hex_utils::decode_h256(&bridging_payment_address)
-                            .expect("Failed to parse address");
+                            .context("Failed to parse address")?;
+
+                    // spawn web-server
+                    let tcp_listener = TcpListener::bind(web_server_address)?;
+                    let (sender, _receiver) = mpsc::unbounded_channel();
+                    let web_server = server::create(tcp_listener, web_server_token, sender)
+                        .context("Failed to create web server")?;
+                    let handle_server = web_server.handle();
+                    task::spawn(web_server);
 
                     let relayer = gear_to_eth::paid_token_transfers::Relayer::new(
                         eth_api,
@@ -226,20 +244,17 @@ async fn main() -> AnyResult<()> {
                     .await
                     .unwrap();
 
-                    metrics_builder = metrics_builder.register_service(&relayer);
+                    MetricsBuilder::new().register_service(&relayer).build()
+                        .run(args.prometheus_args.endpoint)
+                        .await;
+
                     provider.spawn();
                     relayer.run().await;
+
+                    tokio::signal::ctrl_c().await?;
+
+                    handle_server.stop(true).await;
                 }
-            }
-
-            metrics_builder
-                .build()
-                .run(args.prometheus_args.endpoint)
-                .await;
-
-            loop {
-                // relayer.run() spawns thread and exits, so we need to add this loop after calling run.
-                std::thread::sleep(Duration::from_millis(100));
             }
         }
         CliCommands::EthGearCore(args) => {
@@ -467,7 +482,7 @@ async fn main() -> AnyResult<()> {
 
             loop {
                 // relay() spawns thread and exits, so we need to add this loop after calling run.
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                time::sleep(Duration::from_secs(1)).await;
             }
         }
 

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -225,7 +225,7 @@ async fn main() -> AnyResult<()> {
 
                     // spawn web-server
                     let tcp_listener = TcpListener::bind(web_server_address)?;
-                    let (sender, _receiver) = mpsc::unbounded_channel();
+                    let (sender, receiver) = mpsc::unbounded_channel();
                     let web_server = server::create(tcp_listener, web_server_token, sender)
                         .context("Failed to create web server")?;
                     let handle_server = web_server.handle();
@@ -240,6 +240,7 @@ async fn main() -> AnyResult<()> {
                         args.confirmations_status
                             .unwrap_or(DEFAULT_COUNT_CONFIRMATIONS),
                         excluded_from_fees,
+                        receiver,
                     )
                     .await
                     .unwrap();

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -20,9 +20,9 @@ use proof_storage::{FileSystemProofStorage, GearProofStorage, ProofStorage};
 use prover::proving::GenesisConfig;
 use relay_merkle_roots::MerkleRootRelayer;
 use relayer::*;
-use std::{collections::HashSet, str::FromStr, time::Duration, net::TcpListener};
-use utils_prometheus::MetricsBuilder;
+use std::{collections::HashSet, net::TcpListener, str::FromStr, time::Duration};
 use tokio::{sync::mpsc, task, time};
+use utils_prometheus::MetricsBuilder;
 
 #[tokio::main]
 async fn main() -> AnyResult<()> {
@@ -201,7 +201,9 @@ async fn main() -> AnyResult<()> {
                     .await
                     .unwrap();
 
-                    MetricsBuilder::new().register_service(&relayer).build()
+                    MetricsBuilder::new()
+                        .register_service(&relayer)
+                        .build()
                         .run(args.prometheus_args.endpoint)
                         .await;
 
@@ -245,7 +247,9 @@ async fn main() -> AnyResult<()> {
                     .await
                     .unwrap();
 
-                    MetricsBuilder::new().register_service(&relayer).build()
+                    MetricsBuilder::new()
+                        .register_service(&relayer)
+                        .build()
                         .run(args.prometheus_args.endpoint)
                         .await;
 

--- a/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
@@ -11,7 +11,7 @@ use futures::{
 };
 use prometheus::IntGauge;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use utils::{MerkleRoots, Messages, AddStatus};
+use utils::{AddStatus, MerkleRoots, Messages};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 /// Struct accumulates gear-eth messages and required merkle roots.
@@ -52,18 +52,11 @@ impl Accumulator {
         }
     }
 
-    pub fn spawn(
-        mut self,
-    ) -> UnboundedReceiver<(MessageInBlock, RelayedMerkleRoot)> {
+    pub fn spawn(mut self) -> UnboundedReceiver<(MessageInBlock, RelayedMerkleRoot)> {
         let (mut messages_out, receiver) = mpsc::unbounded_channel();
         tokio::task::spawn(async move {
             loop {
-                match run_inner(
-                    &mut self,
-                    &mut messages_out,
-                )
-                .await
-                {
+                match run_inner(&mut self, &mut messages_out).await {
                     Ok(_) => break,
                     Err(e) => {
                         log::error!("{e:?}");

--- a/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
@@ -11,7 +11,7 @@ use futures::{
 };
 use prometheus::IntGauge;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use utils::{AddStatus, MerkleRoots, Messages};
+use utils::{Added, MerkleRoots, Messages};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 /// Struct accumulates gear-eth messages and required merkle roots.
@@ -111,9 +111,9 @@ async fn run_inner(
 
             Either::Right((Some(merkle_root), _)) => {
                 match this.merkle_roots.add(merkle_root) {
-                    Ok(AddStatus::Ok | AddStatus::Overwritten(_)) => {}
+                    Ok(Added::Ok | Added::Overwritten(_)) => {}
 
-                    Ok(AddStatus::Removed(merkle_root_old)) => {
+                    Ok(Added::Removed(merkle_root_old)) => {
                         log::warn!("Removing merkle root = {merkle_root_old:?}");
                         let messages = this.messages.drain(&merkle_root_old);
                         for message in messages {
@@ -122,7 +122,7 @@ async fn run_inner(
                     }
 
                     Err(_i) => {
-                        // log::warn!("There is already a merkle root: root_old = {:?}, merkle_root = {merkle_root:?}", this.merkle_roots.get(i));
+                        // There is already a corresponding merkle root at the position.
                         continue;
                     }
                 }

--- a/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
@@ -181,17 +181,13 @@ impl MerkleRoots {
             (None, i)
         } else {
             // adjust insertion index
-            let i = if i >= self.0.len() {
-                i - 1
-            } else {
-                i
-            };
+            let i = if i >= self.0.len() { i - 1 } else { i };
 
             (self.0.pop(), i)
         };
 
         self.0.insert(i, root_new);
-        
+
         Ok(match result {
             Some(root) => AddStatus::Removed(root),
             None => AddStatus::Ok,
@@ -227,9 +223,15 @@ mod tests {
         let data = [
             RelayedMerkleRoot {
                 block: GearBlockNumber(18_676_002),
-                block_hash: hex!("8d6286038e2ac0bea811e9d99d821084f0271a59b621b4eef52cd85b2fd6c3cb").into(),
+                block_hash: hex!(
+                    "8d6286038e2ac0bea811e9d99d821084f0271a59b621b4eef52cd85b2fd6c3cb"
+                )
+                .into(),
                 authority_set_id: AuthoritySetId(1_308),
-                merkle_root: hex!("00c39a437f0331e49a996433f95ca3955a9caf77b8bf6a1f10b2d5214326bd91").into(),
+                merkle_root: hex!(
+                    "00c39a437f0331e49a996433f95ca3955a9caf77b8bf6a1f10b2d5214326bd91"
+                )
+                .into(),
             },
             RelayedMerkleRoot {
                 block: GearBlockNumber(16_883_172),
@@ -318,11 +320,15 @@ mod tests {
             },
             RelayedMerkleRoot {
                 block: GearBlockNumber(16_888_714),
-                block_hash: hex!("b592a0ec4212c81eccee43cfdce35de08ddd705361dc01c557a615ebd74200a0")
-                    .into(),
+                block_hash: hex!(
+                    "b592a0ec4212c81eccee43cfdce35de08ddd705361dc01c557a615ebd74200a0"
+                )
+                .into(),
                 authority_set_id: AuthoritySetId(1_183),
-                merkle_root: hex!("1636e359c8f975261880b14abaeb511626bfc80e4cab8446448b12d6ce8275b6")
-                    .into(),
+                merkle_root: hex!(
+                    "1636e359c8f975261880b14abaeb511626bfc80e4cab8446448b12d6ce8275b6"
+                )
+                .into(),
             },
         ];
 
@@ -335,9 +341,8 @@ mod tests {
 
         let mut merkle_roots = MerkleRoots::new(CAPACITY);
 
-        for i in 0..data.len() {
-            let root = data[i];
-            let result = merkle_roots.add(root);
+        for (i, root) in data.iter().enumerate() {
+            let result = merkle_roots.add(*root);
 
             if i < 2 {
                 assert!(matches!(result, Ok(AddStatus::Ok)));

--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -40,7 +40,12 @@ impl_metered_service! {
 }
 
 impl MerkleRootExtractor {
-    pub fn new(eth_api: EthApi, api_provider: ApiProviderConnection, confirmations: u64, sender: UnboundedSender<RelayedMerkleRoot>,) -> Self {
+    pub fn new(
+        eth_api: EthApi,
+        api_provider: ApiProviderConnection,
+        confirmations: u64,
+        sender: UnboundedSender<RelayedMerkleRoot>,
+    ) -> Self {
         Self {
             eth_api,
             api_provider,
@@ -111,9 +116,7 @@ async fn task(mut this: MerkleRootExtractor) {
     }
 }
 
-async fn task_inner(
-    this: &MerkleRootExtractor,
-) -> anyhow::Result<()> {
+async fn task_inner(this: &MerkleRootExtractor) -> anyhow::Result<()> {
     let gear_api = this.api_provider.client();
     let subscription = this.eth_api.subscribe_logs().await?;
 

--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -12,13 +12,14 @@ use alloy::{
 use ethereum_client::{abi::IRelayer::MerkleRoot, EthApi};
 use futures::StreamExt;
 use prometheus::IntGauge;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::UnboundedSender;
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 pub struct MerkleRootExtractor {
     eth_api: EthApi,
     api_provider: ApiProviderConnection,
     confirmations: u64,
+    sender: UnboundedSender<RelayedMerkleRoot>,
 
     metrics: Metrics,
 }
@@ -39,30 +40,31 @@ impl_metered_service! {
 }
 
 impl MerkleRootExtractor {
-    pub fn new(eth_api: EthApi, api_provider: ApiProviderConnection, confirmations: u64) -> Self {
+    pub fn new(eth_api: EthApi, api_provider: ApiProviderConnection, confirmations: u64, sender: UnboundedSender<RelayedMerkleRoot>,) -> Self {
         Self {
             eth_api,
             api_provider,
             confirmations,
+            sender,
 
             metrics: Metrics::new(),
         }
     }
 
-    pub fn spawn(self) -> UnboundedReceiver<RelayedMerkleRoot> {
-        let (sender, receiver) = unbounded_channel();
+    pub fn sender(&self) -> &UnboundedSender<RelayedMerkleRoot> {
+        &self.sender
+    }
 
-        tokio::task::spawn(task(self, sender));
-
-        receiver
+    pub fn spawn(self) {
+        tokio::task::spawn(task(self));
     }
 }
 
-async fn task(mut this: MerkleRootExtractor, sender: UnboundedSender<RelayedMerkleRoot>) {
+async fn task(mut this: MerkleRootExtractor) {
     let mut attempts = 0;
 
     loop {
-        let res = task_inner(&this, &sender).await;
+        let res = task_inner(&this).await;
         if let Err(err) = res {
             attempts += 1;
             log::error!(
@@ -111,7 +113,6 @@ async fn task(mut this: MerkleRootExtractor, sender: UnboundedSender<RelayedMerk
 
 async fn task_inner(
     this: &MerkleRootExtractor,
-    sender: &UnboundedSender<RelayedMerkleRoot>,
 ) -> anyhow::Result<()> {
     let gear_api = this.api_provider.client();
     let subscription = this.eth_api.subscribe_logs().await?;
@@ -166,7 +167,7 @@ async fn task_inner(
             (root.blockNumber, root.merkleRoot),
         );
 
-        sender.send(RelayedMerkleRoot {
+        this.sender.send(RelayedMerkleRoot {
             block: GearBlockNumber(block_number_gear),
             block_hash,
             authority_set_id,

--- a/relayer/src/message_relayer/common/gear/block_listener.rs
+++ b/relayer/src/message_relayer/common/gear/block_listener.rs
@@ -1,7 +1,4 @@
-use crate::message_relayer::{
-    common::GearBlock,
-    eth_to_gear::api_provider::ApiProviderConnection,
-};
+use crate::message_relayer::{common::GearBlock, eth_to_gear::api_provider::ApiProviderConnection};
 use futures::StreamExt;
 use gsdk::subscription::BlockEvents;
 use prometheus::IntGauge;

--- a/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
@@ -1,4 +1,4 @@
-use crate::message_relayer::common::{GearBlock, EthereumSlotNumber};
+use crate::message_relayer::common::{EthereumSlotNumber, GearBlock};
 use checkpoint_light_client_client::{
     service_replay_back::events::ServiceReplayBackEvents,
     service_sync_update::events::ServiceSyncUpdateEvents,

--- a/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/checkpoints_extractor.rs
@@ -1,4 +1,4 @@
-use crate::message_relayer::common::{gear::block_listener::GearBlock, EthereumSlotNumber};
+use crate::message_relayer::common::{GearBlock, EthereumSlotNumber};
 use checkpoint_light_client_client::{
     service_replay_back::events::ServiceReplayBackEvents,
     service_sync_update::events::ServiceSyncUpdateEvents,

--- a/relayer/src/message_relayer/common/gear/message_data_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_data_extractor.rs
@@ -1,0 +1,191 @@
+use crate::message_relayer::{
+    common::{self, GearBlock, AuthoritySetId, GearBlockNumber, MessageInBlock, web_request::Message},
+    eth_to_gear::api_provider::ApiProviderConnection,
+};
+use gsdk::subscription::BlockEvents;
+use tokio::{
+    sync::{
+    mpsc::{UnboundedReceiver, UnboundedSender},
+},
+    task,
+};
+use anyhow::Result as AnyResult;
+use std::{ops::Deref, cmp::Ordering};
+use ethereum_common::U256;
+
+pub type BlockData = (GearBlock, AuthoritySetId);
+
+pub struct MessageDataExtractor {
+    api_provider: ApiProviderConnection,
+    sender: UnboundedSender<MessageInBlock>,
+    receiver: UnboundedReceiver<Message>,
+    blocks: BlockDataList,
+}
+
+impl MessageDataExtractor {
+    pub fn new(api_provider: ApiProviderConnection, sender: UnboundedSender<MessageInBlock>, receiver: UnboundedReceiver<Message>,) -> Self {
+        Self {
+            api_provider,
+            sender,
+            receiver,
+            blocks: BlockDataList::new(1_000),
+        }
+    }
+
+    pub fn sender(&self) -> &UnboundedSender<MessageInBlock> {
+        &self.sender
+    }
+
+    pub fn spawn(
+        self,
+    ) {
+        task::spawn(self::task(self));
+    }
+
+    async fn run_inner(
+        &mut self,
+    ) -> anyhow::Result<()> {
+        loop {
+            let Some(message) = self.receiver.recv().await else {
+                return Ok(());
+            };
+
+            log::trace!(r#"Processing message: "{message:?}""#);
+
+            let block_data = match self.find_block_data(message.block) {
+                Some(block_data) => block_data,
+                None => self.retreive_block_data(message.block).await?,
+            };
+
+            log::trace!(r#"Found data for the message block: "{block_data:?}""#);
+            
+            self.process_message_block(message, block_data).await?;
+        }
+    }
+
+    fn find_block_data(&self, block_number: u32) -> Option<BlockData> {
+        self.blocks.find_by_block_number(block_number).cloned()
+    }
+
+    async fn retreive_block_data(&mut self, block_number: u32) -> AnyResult<BlockData> {
+        let gear_api = self.api_provider.client();
+
+        let block_hash = gear_api.block_number_to_hash(block_number).await?;
+        let block = gear_api.get_block_at(block_hash).await?;
+        let authority_set_id = gear_api.signed_by_authority_set_id(block_hash).await?;
+
+        let header = block.header().clone();
+        let block_events = BlockEvents::new(block).await?;
+        let events = block_events.events()?;
+
+        let block_data = (GearBlock::new(header, events), AuthoritySetId(authority_set_id));
+        self.blocks.push(block_data.clone());
+
+        Ok(block_data)
+    }
+
+    async fn process_message_block(
+        &self,
+        message: Message,
+        block_data: BlockData,
+    ) -> anyhow::Result<()> {
+        let (block, authority_set_id) = block_data;
+        let messages = common::message_queued_events_of(&block);
+        let block_hash = block.hash();
+        for message_queued in messages {
+            if U256::from_little_endian(&message_queued.nonce_le) != message.nonce {
+                continue;
+            }
+
+            self.sender.send(MessageInBlock {
+                message: message_queued,
+                block: GearBlockNumber(block.number()),
+                block_hash,
+                authority_set_id,
+            })?;
+
+            break;
+        }
+
+        Ok(())
+    }
+}
+
+async fn task(mut this: MessageDataExtractor) {
+    loop {
+        let result = this.run_inner().await;
+        let Err(e) = result else {
+            log::trace!("Message data extractor exiting...");
+            return;
+        };
+        
+        log::error!("Message data extractor failed: {e}");
+
+        match this.api_provider.reconnect().await {
+            Ok(_) => {
+                log::info!("Message queued extractor reconnected");
+            }
+
+            Err(e) => {
+                log::error!("Message queued extractor unable to reconnect: {e:?}");
+                return;
+            }
+        }
+    }
+}
+
+struct BlockDataList(Vec<BlockData>);
+
+impl BlockDataList {
+    fn compare(
+        block_data: &BlockData,
+        block_number: u32,
+    ) -> Ordering {
+        let (block, _authority_set_id) = block_data;
+
+        block_number.cmp(&block.number())
+    }
+
+    pub fn new(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity))
+    }
+
+    pub fn push(&mut self, block_data_new: BlockData) {
+        // remove the oldest block
+        if self.len() >= self.0.capacity() {
+            self.0.pop();
+        }
+
+        let Err(i) = self.binary_search_by(|block_data| {
+            Self::compare(
+                block_data,
+                block_data_new.0.number(),
+            )
+        }) else {
+            return;
+        };
+
+        self.0.insert(i, block_data_new);
+    }
+
+    pub fn find_by_block_number(&self, block_number: u32) -> Option<&BlockData> {
+        let Ok(i) = self.binary_search_by(|block_data| {
+            Self::compare(
+                block_data,
+                block_number,
+            )
+        }) else {
+            return None
+        };
+
+        self.get(i)
+    }
+}
+
+impl Deref for BlockDataList {
+    type Target = [BlockData];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0[..]
+    }
+}

--- a/relayer/src/message_relayer/common/gear/message_paid_event_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_paid_event_extractor.rs
@@ -9,7 +9,7 @@ use tokio::sync::{
 };
 use utils_prometheus::{impl_metered_service, MeteredService};
 
-use crate::message_relayer::common::{gear::block_listener::GearBlock, PaidMessage};
+use crate::message_relayer::common::{GearBlock, PaidMessage};
 
 pub struct MessagePaidEventExtractor {
     bridging_payment_address: H256,

--- a/relayer/src/message_relayer/common/gear/mod.rs
+++ b/relayer/src/message_relayer/common/gear/mod.rs
@@ -1,5 +1,6 @@
 pub mod block_listener;
 pub mod checkpoints_extractor;
 pub mod merkle_proof_fetcher;
+pub mod message_data_extractor;
 pub mod message_paid_event_extractor;
 pub mod message_queued_event_extractor;

--- a/relayer/src/message_relayer/common/mod.rs
+++ b/relayer/src/message_relayer/common/mod.rs
@@ -1,6 +1,6 @@
 use ethereum_client::TxHash;
 use gear_rpc_client::dto::{MerkleProof, Message};
-use primitive_types::H256;
+use primitive_types::{H256, U256};
 use serde::{Deserialize, Serialize};
 use gsdk::{
     config::Header,
@@ -157,4 +157,19 @@ fn message_queued_events_of(
         }
         _ => None,
     })
+}
+
+pub mod web_request {
+    use super::*;
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub struct Message {
+        pub block: u32,
+        pub nonce: U256,
+    }
+
+    #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+    pub struct Messages {
+        pub messages: Vec<Message>,
+    }
 }

--- a/relayer/src/message_relayer/common/mod.rs
+++ b/relayer/src/message_relayer/common/mod.rs
@@ -1,17 +1,17 @@
 use ethereum_client::TxHash;
+use ethereum_common::Hash256;
 use gear_rpc_client::dto::{MerkleProof, Message};
-use primitive_types::{H256, U256};
-use serde::{Deserialize, Serialize};
 use gsdk::{
     config::Header,
     metadata::{
         gear::Event as GearEvent,
-        runtime_types::{gear_core::message::user::UserMessage, gprimitives::ActorId},
         gear_eth_bridge::Event as GearEthBridgeEvent,
+        runtime_types::{gear_core::message::user::UserMessage, gprimitives::ActorId},
     },
 };
+use primitive_types::{H256, U256};
+use serde::{Deserialize, Serialize};
 use subxt::config::Header as _;
-use ethereum_common::Hash256;
 
 pub mod ethereum;
 pub mod gear;

--- a/relayer/src/message_relayer/common/mod.rs
+++ b/relayer/src/message_relayer/common/mod.rs
@@ -94,7 +94,7 @@ pub struct Data {
     pub proof: MerkleProof,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GearBlock {
     pub header: Header,
     pub events: Vec<gsdk::Event>,

--- a/relayer/src/message_relayer/common/mod.rs
+++ b/relayer/src/message_relayer/common/mod.rs
@@ -2,6 +2,16 @@ use ethereum_client::TxHash;
 use gear_rpc_client::dto::{MerkleProof, Message};
 use primitive_types::H256;
 use serde::{Deserialize, Serialize};
+use gsdk::{
+    config::Header,
+    metadata::{
+        gear::Event as GearEvent,
+        runtime_types::{gear_core::message::user::UserMessage, gprimitives::ActorId},
+        gear_eth_bridge::Event as GearEthBridgeEvent,
+    },
+};
+use subxt::config::Header as _;
+use ethereum_common::Hash256;
 
 pub mod ethereum;
 pub mod gear;
@@ -82,4 +92,69 @@ pub struct Data {
     pub message: MessageInBlock,
     pub relayed_root: RelayedMerkleRoot,
     pub proof: MerkleProof,
+}
+
+#[derive(Clone)]
+pub struct GearBlock {
+    pub header: Header,
+    pub events: Vec<gsdk::Event>,
+}
+
+impl GearBlock {
+    pub fn new(header: Header, events: Vec<gsdk::Event>) -> Self {
+        Self { header, events }
+    }
+
+    pub fn number(&self) -> u32 {
+        self.header.number()
+    }
+
+    pub fn hash(&self) -> Hash256 {
+        self.header.hash()
+    }
+
+    pub fn events(&self) -> &[gsdk::Event] {
+        &self.events
+    }
+
+    pub fn user_message_sent_events(
+        &self,
+        from_program: H256,
+        to_user: H256,
+    ) -> impl Iterator<Item = &[u8]> + use<'_> {
+        self.events.iter().filter_map(move |event| match event {
+            gclient::Event::Gear(GearEvent::UserMessageSent {
+                message:
+                    UserMessage {
+                        source,
+                        destination,
+                        payload,
+                        ..
+                    },
+                ..
+            }) if source == &ActorId(from_program.0) && destination == &ActorId(to_user.0) => {
+                Some(payload.0.as_ref())
+            }
+            _ => None,
+        })
+    }
+}
+
+fn message_queued_events_of(
+    block: &GearBlock,
+) -> impl Iterator<Item = gear_rpc_client::dto::Message> + use<'_> {
+    block.events().iter().filter_map(|event| match event {
+        gclient::Event::GearEthBridge(GearEthBridgeEvent::MessageQueued { message, .. }) => {
+            let mut nonce_le = [0; 32];
+            primitive_types::U256(message.nonce.0).to_little_endian(&mut nonce_le);
+
+            Some(gear_rpc_client::dto::Message {
+                nonce_le,
+                source: message.source.0,
+                destination: message.destination.0,
+                payload: message.payload.clone(),
+            })
+        }
+        _ => None,
+    })
 }

--- a/relayer/src/message_relayer/common/paid_messages_filter.rs
+++ b/relayer/src/message_relayer/common/paid_messages_filter.rs
@@ -1,13 +1,13 @@
+use super::{MessageInBlock, PaidMessage};
 use futures::{
     future::{self, Either},
     pin_mut,
 };
 use gclient::ext::sp_runtime::AccountId32;
+use prometheus::IntGauge;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use prometheus::IntGauge;
 use utils_prometheus::{impl_metered_service, MeteredService};
-use super::{MessageInBlock, PaidMessage};
 
 pub struct PaidMessagesFilter {
     pending_messages: HashMap<[u8; 32], MessageInBlock>,

--- a/relayer/src/message_relayer/eth_to_gear/api_provider.rs
+++ b/relayer/src/message_relayer/eth_to_gear/api_provider.rs
@@ -67,6 +67,11 @@ impl ApiProviderConnection {
             .map_err(|e| anyhow::anyhow!("failed to set suri: {}", e))
     }
 
+    /// Request a new API connection from the [`ApiProvider`].
+    pub fn gclient(&mut self) -> gclient::GearApi {
+        gclient::GearApi::from(self.api.clone())
+    }
+
     pub fn client(&self) -> GearApi {
         GearApi::from(self.api.clone())
     }

--- a/relayer/src/message_relayer/gear_to_eth/all_token_transfers.rs
+++ b/relayer/src/message_relayer/gear_to_eth/all_token_transfers.rs
@@ -1,6 +1,3 @@
-use std::iter;
-use ethereum_client::EthApi;
-use utils_prometheus::MeteredService;
 use crate::{
     common::MAX_RETRIES,
     message_relayer::{
@@ -18,7 +15,10 @@ use crate::{
         eth_to_gear::api_provider::ApiProviderConnection,
     },
 };
+use ethereum_client::EthApi;
+use std::iter;
 use tokio::sync::mpsc;
+use utils_prometheus::MeteredService;
 
 pub struct Relayer {
     gear_block_listener: GearBlockListener,
@@ -56,7 +56,8 @@ impl Relayer {
         let gear_block_listener = GearBlockListener::new(api_provider.clone());
 
         let (message_queued_sender, message_queued_receiver) = mpsc::unbounded_channel();
-        let listener_message_queued = MessageQueuedEventExtractor::new(api_provider.clone(), message_queued_sender);
+        let listener_message_queued =
+            MessageQueuedEventExtractor::new(api_provider.clone(), message_queued_sender);
 
         let (roots_sender, roots_receiver) = mpsc::unbounded_channel();
         let merkle_root_extractor = MerkleRootExtractor::new(

--- a/relayer/src/message_relayer/gear_to_eth/all_token_transfers.rs
+++ b/relayer/src/message_relayer/gear_to_eth/all_token_transfers.rs
@@ -1,8 +1,6 @@
 use std::iter;
-
 use ethereum_client::EthApi;
 use utils_prometheus::MeteredService;
-
 use crate::{
     common::MAX_RETRIES,
     message_relayer::{
@@ -20,26 +18,29 @@ use crate::{
         eth_to_gear::api_provider::ApiProviderConnection,
     },
 };
+use tokio::sync::mpsc;
 
 pub struct Relayer {
     gear_block_listener: GearBlockListener,
 
-    message_sent_listener: MessageQueuedEventExtractor,
+    listener_message_queued: MessageQueuedEventExtractor,
 
     merkle_root_extractor: MerkleRootExtractor,
     message_sender: MessageSender,
 
     proof_fetcher: MerkleProofFetcher,
     status_fetcher: StatusFetcher,
+    accumulator: Accumulator,
 }
 
 impl MeteredService for Relayer {
     fn get_sources(&self) -> impl IntoIterator<Item = Box<dyn prometheus::core::Collector>> {
         iter::empty()
             .chain(self.gear_block_listener.get_sources())
-            .chain(self.message_sent_listener.get_sources())
+            .chain(self.listener_message_queued.get_sources())
             .chain(self.merkle_root_extractor.get_sources())
             .chain(self.message_sender.get_sources())
+            .chain(self.accumulator.get_sources())
     }
 }
 
@@ -54,13 +55,18 @@ impl Relayer {
     ) -> anyhow::Result<Self> {
         let gear_block_listener = GearBlockListener::new(api_provider.clone());
 
-        let message_sent_listener = MessageQueuedEventExtractor::new(api_provider.clone());
+        let (message_queued_sender, message_queued_receiver) = mpsc::unbounded_channel();
+        let listener_message_queued = MessageQueuedEventExtractor::new(api_provider.clone(), message_queued_sender);
 
+        let (roots_sender, roots_receiver) = mpsc::unbounded_channel();
         let merkle_root_extractor = MerkleRootExtractor::new(
             eth_api.clone(),
             api_provider.clone(),
             confirmations_merkle_root,
+            roots_sender,
         );
+
+        let accumulator = Accumulator::new(roots_receiver, message_queued_receiver);
 
         let message_sender = MessageSender::new(MAX_RETRIES, eth_api.clone());
 
@@ -70,24 +76,23 @@ impl Relayer {
         Ok(Self {
             gear_block_listener,
 
-            message_sent_listener,
+            listener_message_queued,
 
             merkle_root_extractor,
             message_sender,
 
             proof_fetcher,
             status_fetcher,
+            accumulator,
         })
     }
 
     pub async fn run(self) {
         let [gear_blocks] = self.gear_block_listener.run().await;
 
-        let messages = self.message_sent_listener.run(gear_blocks).await;
-
-        let merkle_roots = self.merkle_root_extractor.spawn();
-        let accumulator = Accumulator::new();
-        let channel_messages = accumulator.run(messages, merkle_roots).await;
+        self.listener_message_queued.spawn(gear_blocks);
+        self.merkle_root_extractor.spawn();
+        let channel_messages = self.accumulator.spawn();
 
         let channel_message_data = self.proof_fetcher.spawn(channel_messages);
         let channel_tx_data = self.status_fetcher.spawn();

--- a/relayer/src/message_relayer/gear_to_eth/manual.rs
+++ b/relayer/src/message_relayer/gear_to_eth/manual.rs
@@ -106,11 +106,9 @@ pub async fn relay(
 
     let message_sender = MessageSender::new(1, eth_api.clone());
 
-    let accumulator = Accumulator::new();
     let (queued_messages_sender, queued_messages_receiver) = mpsc::unbounded_channel();
-    let channel_messages = accumulator
-        .run(queued_messages_receiver, merkle_roots_receiver)
-        .await;
+    let accumulator = Accumulator::new(merkle_roots_receiver, queued_messages_receiver);
+    let channel_messages = accumulator.spawn();
     let channel_message_data = MerkleProofFetcher::new(api_provider).spawn(channel_messages);
 
     let (sender, mut receiver) = mpsc::unbounded_channel();

--- a/relayer/src/relay_merkle_roots.rs
+++ b/relayer/src/relay_merkle_roots.rs
@@ -6,9 +6,7 @@ use crate::{
         self, submit_merkle_root_to_ethereum, sync_authority_set_id, SyncStepCount,
         BASE_RETRY_DELAY, MAX_RETRIES,
     },
-    message_relayer::{
-        common::GearBlock, eth_to_gear::api_provider::ApiProviderConnection,
-    },
+    message_relayer::{common::GearBlock, eth_to_gear::api_provider::ApiProviderConnection},
     proof_storage::ProofStorage,
     prover_interface::{self, FinalProof},
 };

--- a/relayer/src/relay_merkle_roots.rs
+++ b/relayer/src/relay_merkle_roots.rs
@@ -7,7 +7,7 @@ use crate::{
         BASE_RETRY_DELAY, MAX_RETRIES,
     },
     message_relayer::{
-        common::gear::block_listener::GearBlock, eth_to_gear::api_provider::ApiProviderConnection,
+        common::GearBlock, eth_to_gear::api_provider::ApiProviderConnection,
     },
     proof_storage::ProofStorage,
     prover_interface::{self, FinalProof},

--- a/relayer/src/server.rs
+++ b/relayer/src/server.rs
@@ -1,0 +1,166 @@
+use actix_web::{guard, web, middleware, HttpResponse, App, HttpServer, HttpRequest};
+use std::net::TcpListener;
+use crate::message_relayer::common::web_request::{Message, Messages};
+use tokio::sync::mpsc::UnboundedSender;
+
+const HEADER_TOKEN: &str = "X-Token";
+
+async fn relay_messages(
+    request: HttpRequest,
+    messages: web::Json<Messages>,
+    secret: web::Data<String>,
+    channel: web::Data<UnboundedSender<Message>>,
+) -> HttpResponse {
+    if !request.headers().get(HEADER_TOKEN)
+        .and_then(|h| h.to_str().ok())
+        .map(|t| t == secret.get_ref())
+        .unwrap_or(false)
+    {
+        return HttpResponse::Unauthorized().finish();
+    }
+
+    let messages = messages.into_inner().messages;
+    let len = messages.len();
+    let mut to_process = len;
+
+    for message in messages {
+        match channel.send(message.clone()) {
+            Ok(_) => to_process -= 1,
+
+            Err(e) => {
+                log::error!(r#"Unable to send message "{message:?}": {e:?}"#);
+            }
+        }
+    }
+
+    if to_process == 0 {
+        HttpResponse::Ok().finish()
+    } else if to_process == len {
+        HttpResponse::InternalServerError().finish()
+    } else {
+        HttpResponse::Accepted().finish()
+    }
+}
+
+pub fn create(
+    tcp_listener: TcpListener,
+    secret: String,
+    channel: UnboundedSender<Message>,
+) -> std::io::Result<actix_web::dev::Server> {
+    let channel = web::Data::new(channel);
+    let secret = web::Data::new(secret);
+
+    let server = HttpServer::new(move || {
+        App::new()
+            .app_data(secret.clone())
+            .app_data(channel.clone())
+            // enable logger
+            .wrap(middleware::Logger::default())
+            .app_data(
+                // 128 KiB
+                web::JsonConfig::default().limit(131_072)
+            )
+            .service(
+                web::resource("/relay_messages")
+                    .route(web::post().to(relay_messages))
+                    .route(
+                        web::route()
+                            .guard(guard::Any(guard::Get()).or(guard::Post()))
+                            .to(|| HttpResponse::Unauthorized()),
+                    ),
+
+            )
+    });
+
+    let server = server.listen(tcp_listener);
+
+    Ok(server?.disable_signals().run())
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::{ClientBuilder, header::{CONTENT_TYPE, HeaderValue}};
+    use std::{time::Duration, str::FromStr};
+    use ethereum_common::U256;
+    use tokio::{sync::mpsc, task};
+    use super::*;
+
+    #[tokio::test]
+    async fn test_server() {
+        let _ = pretty_env_logger::formatted_timed_builder()
+            .filter_level(log::LevelFilter::Debug)
+            .format_target(false)
+            .format_timestamp_secs()
+            .parse_default_env()
+            .try_init();
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        const SECRET: &str = "SECRET123";
+        let (channel, mut receiver) = mpsc::unbounded_channel();
+        let server = super::create(listener, SECRET.to_string(), channel).unwrap();
+
+        task::spawn(server);
+
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let url = format!("http://127.0.0.1:{port}/relay_messages");
+        let response = client.post(&url).json(&Messages::default()).send().await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+        assert!(receiver.try_recv().is_err());
+
+        let response = client.post(&url).json(&Messages::default())
+            .header(HEADER_TOKEN, SECRET)
+            .send().await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        assert!(receiver.try_recv().is_err());
+
+        //
+        let nonce_string = "0x0123";
+        let block = 2_111_333;
+        let body = format!(r#"{{"messages":[{{"block":{block},"nonce":"{nonce_string}"}}]}}"#);
+        let response = client.post(&url).body(body)
+            .header(HEADER_TOKEN, SECRET)
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .send().await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let message_received = receiver.recv().await.unwrap();
+        assert_eq!(block, message_received.block);
+        assert_eq!(U256::from_str(nonce_string).unwrap(), message_received.nonce);
+
+        assert!(receiver.try_recv().is_err());
+
+        let message = Message { block: 1_222_333, nonce: 123.into(), };
+        let messages = {
+            let mut messages = Messages::default();
+            messages.messages.push(message.clone());
+
+            messages
+        };
+
+        let response = client.post(&url).json(&messages)
+            .header(HEADER_TOKEN, SECRET)
+            .send().await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let message_received = receiver.recv().await.unwrap();
+        assert_eq!(message.block, message_received.block);
+        assert_eq!(message.nonce, message_received.nonce);
+
+        assert!(receiver.try_recv().is_err());
+
+        receiver.close();
+
+        let response = client.post(&url).json(&messages)
+            .header(HEADER_TOKEN, SECRET)
+            .send().await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
Resolves #519 

- new methods in gear-rpc-client & ApiProviderConnection
- refactor Accumulator, MerkleRootExtractor, MessageQueuedEventExtractor & PaidMessagesFilter
- refactor MerkleRoots collection
- move GearBlock & message_queued_event_of to the common module
- implement web server
- implement MessageDataExtractor. It gets all required data for the message requested to relay
- spawn fetch_merkle_roots task to get all required merkle roots

@gear-tech/dev 
