### PR TITLE
refactor(relayer): Make merkle-root relayer more lazy

### DIFF
--- a/relayer/src/cli/mod.rs
+++ b/relayer/src/cli/mod.rs
@@ -59,6 +59,11 @@ pub struct GearEthCoreArgs {
     #[clap(flatten)]
     pub block_storage_args: BlockStorageArgs,
 
+    #[arg(
+        long,
+        help = "How many confirmations until merkle-root is considered relayed. Default is: {DEFAULT_COUNT_CONFIRMATIONS}"
+    )]
+    pub confirmations_merkle_root: Option<u64>,
     /// Authority set id to start relaying from. If not specified equals to one from the latest finalized block
     #[arg(long, env = "START_AUTHORITY_SET_ID")]
     pub start_authority_set_id: Option<u64>,

--- a/relayer/src/common.rs
+++ b/relayer/src/common.rs
@@ -81,7 +81,7 @@ pub(crate) async fn sync_authority_set_id(
 pub(crate) async fn submit_merkle_root_to_ethereum(
     eth_api: &EthApi,
     proof: FinalProof,
-) -> anyhow::Result<TxHash> {
+) -> Result<TxHash, ethereum_client::Error> {
     log::info!(
         "Submitting merkle root {} at block #{} to ethereum",
         hex::encode(proof.merkle_root),

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -27,6 +27,7 @@ fn main() -> AnyResult<()> {
     // we need at least 2 native threads to run some of the blocking tasks like proof composition
     // so lets set minimum to 4 threads or to available parallelism.
     tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
         .max_blocking_threads(std::thread::available_parallelism()?.get().max(4))
         .build()?
         .block_on(run())
@@ -79,6 +80,8 @@ async fn run() -> AnyResult<()> {
                 storage,
                 genesis_config,
                 args.start_authority_set_id,
+                args.confirmations_merkle_root
+                    .unwrap_or(DEFAULT_COUNT_CONFIRMATIONS),
             )
             .await;
 

--- a/relayer/src/merkle_roots/authority_set_sync.rs
+++ b/relayer/src/merkle_roots/authority_set_sync.rs
@@ -2,13 +2,11 @@ use crate::{
     common::{sync_authority_set_id, SyncStepCount},
     message_relayer::{common::GearBlock, eth_to_gear::api_provider::ApiProviderConnection},
     proof_storage::ProofStorage,
-    prover_interface::{self, FinalProof},
 };
-use ethereum_client::EthApi;
 use futures::executor::block_on;
 use prometheus::IntGauge;
 use prover::proving::GenesisConfig;
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 use tokio::sync::{
     broadcast::{error::RecvError, Receiver},
     mpsc::{UnboundedReceiver, UnboundedSender},
@@ -17,28 +15,19 @@ use utils_prometheus::{impl_metered_service, MeteredService};
 
 pub struct AuthoritySetSyncIo {
     response: UnboundedReceiver<Response>,
-    requests: UnboundedSender<GearBlock>,
 }
 
 pub enum Response {
     AuthoritySetSynced(u64, u32),
-    SealedEras(Vec<SealedNotFinalizedEra>),
 }
 
 impl AuthoritySetSyncIo {
-    pub fn new(
-        response: UnboundedReceiver<Response>,
-        requests: UnboundedSender<GearBlock>,
-    ) -> Self {
-        Self { response, requests }
+    pub fn new(response: UnboundedReceiver<Response>) -> Self {
+        Self { response }
     }
 
     pub async fn recv(&mut self) -> Option<Response> {
         self.response.recv().await
-    }
-
-    pub fn synchronize(&self, block: GearBlock) -> bool {
-        self.requests.send(block).is_ok()
     }
 }
 
@@ -64,36 +53,28 @@ pub struct AuthoritySetSync {
     api_provider: ApiProviderConnection,
     proof_storage: Arc<dyn ProofStorage>,
     genesis_config: GenesisConfig,
-    eras: Eras,
 
     metrics: Metrics,
 }
 
 impl MeteredService for AuthoritySetSync {
     fn get_sources(&self) -> impl IntoIterator<Item = Box<dyn prometheus::core::Collector>> {
-        self.metrics
-            .get_sources()
-            .into_iter()
-            .chain(self.eras.get_sources())
+        self.metrics.get_sources().into_iter()
     }
 }
 
 impl AuthoritySetSync {
     pub async fn new(
         api_provider: ApiProviderConnection,
-        eth_api: EthApi,
+
         proof_storage: Arc<dyn ProofStorage>,
-        last_sealed: Option<u64>,
+
         genesis_config: GenesisConfig,
     ) -> Self {
-        let eras = Eras::new(last_sealed, api_provider.clone(), eth_api, genesis_config)
-            .await
-            .unwrap_or_else(|err| panic!("Error while creating era storage: {err}"));
         Self {
             api_provider,
             proof_storage,
             genesis_config,
-            eras,
 
             metrics: Metrics::new(),
         }
@@ -101,14 +82,13 @@ impl AuthoritySetSync {
 
     pub fn run(mut self, mut blocks: Receiver<GearBlock>) -> AuthoritySetSyncIo {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let (req_tx, mut req_rx) = tokio::sync::mpsc::unbounded_channel();
 
-        let io = AuthoritySetSyncIo::new(rx, req_tx);
+        let io = AuthoritySetSyncIo::new(rx);
 
         tokio::task::spawn_blocking(move || {
             block_on(async move {
                 loop {
-                    if let Err(err) = self.process(&mut blocks, &mut req_rx, &tx).await {
+                    if let Err(err) = self.process(&mut blocks, &tx).await {
                         log::error!("Authority set sync task failed: {err}");
 
                         match self.api_provider.reconnect().await {
@@ -132,30 +112,17 @@ impl AuthoritySetSync {
     async fn process(
         &mut self,
         blocks: &mut Receiver<GearBlock>,
-        force_sync: &mut UnboundedReceiver<GearBlock>,
         responses: &UnboundedSender<Response>,
     ) -> anyhow::Result<()> {
         loop {
             tokio::select! {
-                sync = force_sync.recv() => {
-                    match sync {
-                        Some(block) => {
-                            log::info!("Force authority set sync for authority set in block #{}", block.number());
-
-                            let Some(_) = self.sync_authority_set_completely(&block, blocks, responses).await? else {
-                                return Ok(());
-                            };
-                        }
-
-                        None => return Ok(())
-                    }
-                }
                 block = blocks.recv() => {
                     match block {
                         Ok(block) => {
                             if super::storage::authority_set_hash_changed(&block).is_none() {
                                 continue;
                             }
+
 
                             let Some(_) = self.sync_authority_set_completely(&block, blocks, responses).await? else {
                                 return Ok(());
@@ -230,17 +197,6 @@ impl AuthoritySetSync {
             return Ok(None);
         }
 
-        self.eras.process(&self.proof_storage).await?;
-
-        if responses
-            .send(Response::SealedEras(std::mem::take(
-                &mut self.eras.sealed_not_finalized,
-            )))
-            .is_err()
-        {
-            return Ok(None);
-        }
-
         Ok(Some(authority_set_id))
     }
 
@@ -273,154 +229,5 @@ impl AuthoritySetSync {
             .await?,
             latest_authority_set_id,
         ))
-    }
-}
-
-struct Eras {
-    last_sealed: u64,
-    sealed_not_finalized: Vec<SealedNotFinalizedEra>,
-
-    api_provider: ApiProviderConnection,
-    eth_api: EthApi,
-
-    genesis_config: GenesisConfig,
-
-    metrics: EraMetrics,
-}
-
-#[derive(Clone)]
-pub struct SealedNotFinalizedEra {
-    pub era: u64,
-    pub merkle_root_block: u32,
-    pub proof: FinalProof,
-}
-
-impl MeteredService for Eras {
-    fn get_sources(&self) -> impl IntoIterator<Item = Box<dyn prometheus::core::Collector>> {
-        self.metrics.get_sources()
-    }
-}
-
-impl_metered_service! {
-    struct EraMetrics {
-        sealed_not_finalized_count: IntGauge = IntGauge::new(
-            "sealed_not_finalized_count",
-            "Amount of eras that have been sealed but tx is not yet finalized by ethereum",
-        ),
-        last_sealed_era: IntGauge = IntGauge::new("last_sealed_era", "Latest era that have been sealed"),
-    }
-}
-
-impl Eras {
-    pub async fn new(
-        last_sealed: Option<u64>,
-        api_provider: ApiProviderConnection,
-        eth_api: EthApi,
-        genesis_config: GenesisConfig,
-    ) -> anyhow::Result<Self> {
-        let last_sealed = if let Some(l) = last_sealed {
-            l
-        } else {
-            let gear_api = api_provider.client();
-            let latest = gear_api.latest_finalized_block().await?;
-            let set_id = gear_api.authority_set_id(latest).await?;
-            set_id.max(2) - 1
-        };
-
-        let metrics = EraMetrics::new();
-        metrics.sealed_not_finalized_count.set(0);
-        metrics.last_sealed_era.set(last_sealed as i64);
-
-        Ok(Self {
-            last_sealed,
-            sealed_not_finalized: vec![],
-            api_provider,
-            eth_api,
-
-            genesis_config,
-
-            metrics,
-        })
-    }
-
-    pub async fn process(&mut self, proof_storage: &Arc<dyn ProofStorage>) -> anyhow::Result<()> {
-        log::info!("Processing eras");
-        self.try_seal(proof_storage).await?;
-        log::info!("Eras processed");
-
-        Ok(())
-    }
-
-    async fn try_seal(&mut self, proof_storage: &Arc<dyn ProofStorage>) -> anyhow::Result<()> {
-        let gear_api = self.api_provider.client();
-        let latest = gear_api.latest_finalized_block().await?;
-        let current_era = gear_api.signed_by_authority_set_id(latest).await?;
-
-        while self.last_sealed + 2 <= current_era {
-            log::info!("Sealing era #{}", self.last_sealed + 1);
-            self.seal_era(self.last_sealed + 1, proof_storage).await?;
-            log::info!("Sealed era #{}", self.last_sealed + 1);
-
-            self.last_sealed += 1;
-
-            self.metrics.last_sealed_era.inc();
-        }
-
-        Ok(())
-    }
-
-    async fn seal_era(
-        &mut self,
-        authority_set_id: u64,
-        proof_storage: &Arc<dyn ProofStorage>,
-    ) -> anyhow::Result<()> {
-        let gear_api = self.api_provider.client();
-        let block = gear_api.find_era_first_block(authority_set_id + 1).await?;
-        let block_number = gear_api.block_hash_to_number(block).await?;
-
-        let queue_merkle_root = gear_api.fetch_queue_merkle_root(block).await?;
-        if queue_merkle_root.is_zero() {
-            log::info!("Message queue at block #{block_number} is empty. Skipping sealing");
-            return Ok(());
-        }
-
-        let root_exists = self
-            .eth_api
-            .read_finalized_merkle_root(block_number)
-            .await?
-            .is_some();
-
-        if root_exists {
-            log::info!("Merkle root for era #{authority_set_id} is already submitted",);
-            return Ok(());
-        }
-
-        let inner_proof = proof_storage
-            .get_proof_for_authority_set_id(authority_set_id)
-            .await?;
-
-        let instant = Instant::now();
-        let proof =
-            prover_interface::prove_final(&gear_api, inner_proof, self.genesis_config, block)
-                .await?;
-        let elapsed_proof = instant.elapsed();
-        log::info!("prover_interface::prove_final took {elapsed_proof:?} for block_number = #{block_number}, authority_set_id = #{authority_set_id}");
-
-        assert_eq!(
-            proof.block_number, block_number,
-            "It was expected that prover_interface::prove_final 
-            will not change the block number for the proof 
-            in the case of the first block in the era"
-        );
-
-        self.sealed_not_finalized.push(SealedNotFinalizedEra {
-            era: authority_set_id,
-            merkle_root_block: block_number,
-            proof,
-        });
-
-        self.metrics.sealed_not_finalized_count.inc();
-
-        Ok(())
     }
 }

--- a/relayer/src/merkle_roots/authority_set_sync.rs
+++ b/relayer/src/merkle_roots/authority_set_sync.rs
@@ -148,7 +148,6 @@ impl AuthoritySetSync {
                     match block {
                         Ok(block) => {
                             if !super::storage::authority_set_changed(&block) {
-
                                 continue;
                             }
 

--- a/relayer/src/merkle_roots/eras.rs
+++ b/relayer/src/merkle_roots/eras.rs
@@ -1,0 +1,166 @@
+use crate::{
+    message_relayer::eth_to_gear::api_provider::ApiProviderConnection,
+    proof_storage::ProofStorage,
+    prover_interface::{self, FinalProof},
+};
+use ethereum_client::EthApi;
+use futures::executor::block_on;
+use prover::proving::GenesisConfig;
+use std::{sync::Arc, time::Instant};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+#[derive(Clone)]
+pub struct SealedNotFinalizedEra {
+    pub era: u64,
+    pub merkle_root_block: u32,
+    pub proof: FinalProof,
+}
+
+pub struct Eras {
+    last_sealed: u64,
+    sealed_not_finalized: Vec<SealedNotFinalizedEra>,
+
+    api_provider: ApiProviderConnection,
+    eth_api: EthApi,
+
+    genesis_config: GenesisConfig,
+}
+
+impl Eras {
+    pub async fn new(
+        last_sealed: Option<u64>,
+        api_provider: ApiProviderConnection,
+        eth_api: EthApi,
+        genesis_config: GenesisConfig,
+    ) -> anyhow::Result<Self> {
+        let last_sealed = if let Some(l) = last_sealed {
+            l
+        } else {
+            let gear_api = api_provider.client();
+            let latest = gear_api.latest_finalized_block().await?;
+            let set_id = gear_api.authority_set_id(latest).await?;
+            set_id.max(2) - 1
+        };
+
+        Ok(Self {
+            last_sealed,
+            sealed_not_finalized: vec![],
+            api_provider,
+            eth_api,
+
+            genesis_config,
+        })
+    }
+
+    pub fn seal(
+        mut self,
+        proof_storage: Arc<dyn ProofStorage>,
+    ) -> UnboundedReceiver<SealedNotFinalizedEra> {
+        let (tx, rx) = unbounded_channel();
+
+        tokio::task::spawn_blocking(move || {
+            block_on(async move {
+                if let Err(err) = self.try_seal(&proof_storage, &tx).await {
+                    log::error!("Error while sealing eras: {err}");
+                    return;
+                }
+                log::info!("Sealed {} era(s)", self.sealed_not_finalized.len());
+            })
+        });
+
+        rx
+    }
+
+    async fn try_seal(
+        &mut self,
+        proof_storage: &Arc<dyn ProofStorage>,
+        responses: &UnboundedSender<SealedNotFinalizedEra>,
+    ) -> anyhow::Result<()> {
+        let gear_api = self.api_provider.client();
+        let latest = gear_api.latest_finalized_block().await?;
+        let current_era = gear_api.signed_by_authority_set_id(latest).await?;
+
+        if self.last_sealed + 2 <= current_era {
+            log::info!(
+                "Last sealed era: {}, current era: {}, eras to seal: {}",
+                self.last_sealed,
+                current_era,
+                current_era - self.last_sealed - 1
+            );
+        } else {
+            log::info!(
+                "No new eras to seal. Last sealed era: {}, current era: {}",
+                self.last_sealed,
+                current_era
+            );
+            return Ok(());
+        }
+
+        while self.last_sealed + 2 <= current_era {
+            log::info!("Sealing era #{}", self.last_sealed + 1);
+            self.seal_era(self.last_sealed + 1, proof_storage, responses)
+                .await?;
+            log::info!("Sealed era #{}", self.last_sealed + 1);
+
+            self.last_sealed += 1;
+        }
+
+        Ok(())
+    }
+
+    async fn seal_era(
+        &mut self,
+        authority_set_id: u64,
+        proof_storage: &Arc<dyn ProofStorage>,
+        response: &UnboundedSender<SealedNotFinalizedEra>,
+    ) -> anyhow::Result<()> {
+        let gear_api = self.api_provider.client();
+        let block = gear_api.find_era_first_block(authority_set_id + 1).await?;
+        let block_number = gear_api.block_hash_to_number(block).await?;
+
+        let queue_merkle_root = gear_api.fetch_queue_merkle_root(block).await?;
+        if queue_merkle_root.is_zero() {
+            log::info!("Message queue at block #{block_number} is empty. Skipping sealing");
+            return Ok(());
+        }
+
+        let root_exists = self
+            .eth_api
+            .read_finalized_merkle_root(block_number)
+            .await?
+            .is_some();
+
+        if root_exists {
+            log::info!("Merkle root for era #{authority_set_id} is already submitted",);
+            return Ok(());
+        }
+
+        let inner_proof = proof_storage
+            .get_proof_for_authority_set_id(authority_set_id)
+            .await?;
+
+        let instant = Instant::now();
+        let proof =
+            prover_interface::prove_final(&gear_api, inner_proof, self.genesis_config, block)
+                .await?;
+        let elapsed_proof = instant.elapsed();
+        log::info!("prover_interface::prove_final took {elapsed_proof:?} for block_number = #{block_number}, authority_set_id = #{authority_set_id}");
+
+        assert_eq!(
+            proof.block_number, block_number,
+            "It was expected that prover_interface::prove_final 
+            will not change the block number for the proof 
+            in the case of the first block in the era"
+        );
+
+        response
+            .send(SealedNotFinalizedEra {
+                era: authority_set_id,
+                merkle_root_block: block_number,
+                proof,
+            })
+            .map_err(|_| anyhow::anyhow!("Failed to send sealed not finalized era"))?;
+
+        Ok(())
+    }
+}

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -534,6 +534,13 @@ impl MerkleRootRelayer {
                         H256::from(response.proof.merkle_root),
                         response.proof.block_number
                     );
+                    self.finalize_merkle_root(submitter::Response {
+                        merkle_root: H256::from(response.proof.merkle_root),
+                        merkle_root_block: response.proof.block_number,
+                        proof: response.proof,
+                        status: submitter::ResponseStatus::Submitted,
+                        era: None,
+                    }).await?;
                     return Ok(true);
                 }
 

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -480,8 +480,8 @@ impl MerkleRootRelayer {
         sealed_eras: &mut UnboundedReceiver<SealedNotFinalizedEra>,
     ) -> anyhow::Result<bool> {
         tokio::select! {
-            instant = self.save_interval.tick() => {
-                log::info!("{:.3} seconds passed, saving current state", instant.elapsed().as_secs_f64());
+            _ = self.save_interval.tick() => {
+                log::trace!("60 seconds passed, saving current state");
                 if let Err(err) = self.storage.save(&self.roots).await {
                     log::error!("Failed to save block state: {err:?}");
                 }

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -1,26 +1,36 @@
 use crate::{
     common::{BASE_RETRY_DELAY, MAX_RETRIES},
-    merkle_roots::{authority_set_sync::AuthoritySetSyncIo, prover::FinalityProverIo},
+    merkle_roots::{
+        authority_set_sync::AuthoritySetSyncIo, eras::SealedNotFinalizedEra,
+        prover::FinalityProverIo,
+    },
     message_relayer::{
         common::{gear::block_listener::BlockListener, GearBlock},
         eth_to_gear::api_provider::ApiProviderConnection,
     },
     proof_storage::ProofStorageError,
+    prover_interface::FinalProof,
 };
 use ::prover::proving::GenesisConfig;
+use anyhow::Context;
 use ethereum_client::EthApi;
 use primitive_types::H256;
+use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     sync::Arc,
     time::{Duration, Instant},
 };
 use storage::MerkleRootStorage;
 use submitter::SubmitterIo;
-use tokio::sync::broadcast::{error::RecvError, Receiver};
+use tokio::sync::{
+    broadcast::{error::RecvError, Receiver},
+    mpsc::UnboundedReceiver,
+};
 use utils_prometheus::MeteredService;
 
 pub mod authority_set_sync;
+pub mod eras;
 pub mod prover;
 pub mod storage;
 pub mod submitter;
@@ -30,6 +40,7 @@ pub struct Relayer {
     authority_set_sync: authority_set_sync::AuthoritySetSync,
     prover: prover::FinalityProver,
     submitter: submitter::MerkleRootSubmitter,
+    eras: eras::Eras,
     block_listener: BlockListener,
 }
 
@@ -49,10 +60,16 @@ impl Relayer {
         storage: Arc<MerkleRootStorage>,
         genesis_config: GenesisConfig,
         last_sealed: Option<u64>,
+        confirmations: u64,
     ) -> Self {
-        if let Err(err) = storage.load().await {
-            log::warn!("Failed to load unprocessed blocks for Merkle-Root relayer: {err:?}");
-        };
+        let eras = eras::Eras::new(
+            last_sealed,
+            api_provider.clone(),
+            eth_api.clone(),
+            genesis_config,
+        )
+        .await
+        .expect("Failed to create eras");
 
         let block_listener = BlockListener::new(api_provider.clone(), storage.clone());
 
@@ -60,16 +77,15 @@ impl Relayer {
 
         let authority_set_sync = authority_set_sync::AuthoritySetSync::new(
             api_provider.clone(),
-            eth_api.clone(),
             storage.proofs.clone(),
-            last_sealed,
             genesis_config,
         )
         .await;
 
         let prover = prover::FinalityProver::new(api_provider.clone(), genesis_config);
 
-        let submitter = submitter::MerkleRootSubmitter::new(eth_api.clone(), storage);
+        let submitter =
+            submitter::MerkleRootSubmitter::new(eth_api.clone(), storage, confirmations);
 
         Self {
             merkle_roots,
@@ -77,6 +93,7 @@ impl Relayer {
             prover,
             submitter,
             block_listener,
+            eras,
         }
     }
 
@@ -87,16 +104,18 @@ impl Relayer {
             prover,
             submitter,
             block_listener,
+            eras,
         } = self;
 
         let [blocks0, blocks1] = block_listener.run().await;
 
+        let sealed_eras = eras.seal(merkle_roots.storage.proofs.clone());
         let authority_set_sync = authority_set_sync.run(blocks1);
         let prover = prover.run();
         let submitter = submitter.run();
 
         merkle_roots
-            .run(blocks0, submitter, prover, authority_set_sync)
+            .run(blocks0, submitter, prover, authority_set_sync, sealed_eras)
             .await
     }
 }
@@ -107,6 +126,8 @@ pub struct MerkleRootRelayer {
     api_provider: ApiProviderConnection,
 
     storage: Arc<MerkleRootStorage>,
+
+    roots: HashMap<H256, MerkleRoot>,
 
     /// Set of blocks that are waiting for authority set sync.
     waiting_for_authority_set_sync: BTreeMap<u64, Vec<GearBlock>>,
@@ -120,6 +141,7 @@ impl MerkleRootRelayer {
         MerkleRootRelayer {
             api_provider,
 
+            roots: HashMap::new(),
             storage,
 
             waiting_for_authority_set_sync: BTreeMap::new(),
@@ -132,8 +154,101 @@ impl MerkleRootRelayer {
         mut submitter: SubmitterIo,
         mut prover: FinalityProverIo,
         mut authority_set_sync: AuthoritySetSyncIo,
+        mut sealed_eras: UnboundedReceiver<SealedNotFinalizedEra>,
     ) -> anyhow::Result<()> {
         log::info!("Starting relayer");
+        match self.storage.load().await {
+            Ok(roots) => {
+                self.roots = roots;
+            }
+            Err(err) => {
+                log::error!("Failed to load merkle roots from storage: {err}");
+            }
+        };
+
+        let gear_api = self.api_provider.client();
+
+        for (hash, merkle_root) in self.roots.iter() {
+            match &merkle_root.status {
+                // most likely will need to wait for era sealing rather than authority set sync
+                MerkleRootStatus::WaitForAuthoritySetSync(id, _) => {
+                    log::info!(
+                        "Merkle root {} for block #{} is waiting for authority set sync with id {}",
+                        hash,
+                        merkle_root.block_number,
+                        id
+                    );
+
+                    let block = gear_api.get_block_at(merkle_root.block_hash).await?;
+                    let block = GearBlock::from_subxt_block(block).await?;
+                    self.waiting_for_authority_set_sync
+                        .entry(*id)
+                        .or_default()
+                        .push(block);
+                }
+
+                MerkleRootStatus::GenerateProof => {
+                    log::info!(
+                        "Merkle root {} for block #{} is waiting for proof generation",
+                        hash,
+                        merkle_root.block_number
+                    );
+
+                    // if merkle root was saved in `generate proof` phase, it means
+                    // that proof for authority set id is already generated and thus should be available in storage.
+                    // If it is not found that is a hard error and storage should be fixed.
+                    let signed_by_authority_set_id = gear_api
+                        .signed_by_authority_set_id(merkle_root.block_hash)
+                        .await?;
+                    let inner_proof = self
+                        .storage
+                        .proofs
+                        .get_proof_for_authority_set_id(signed_by_authority_set_id)
+                        .await
+                        .with_context(|| format!("Proof for authority set #{signed_by_authority_set_id} not found, please clean-up your storage and restart relayer"))?;
+
+                    if !prover.prove(
+                        merkle_root.block_number,
+                        merkle_root.block_hash,
+                        *hash,
+                        inner_proof,
+                    ) {
+                        log::error!("Prover connection closed, exiting...");
+                        return Ok(());
+                    }
+                }
+
+                MerkleRootStatus::SubmitProof(proof) => {
+                    log::info!(
+                        "Merkle root {} for block #{} is waiting for proof submission",
+                        hash,
+                        merkle_root.block_number
+                    );
+
+                    if !submitter.submit_merkle_root(merkle_root.block_number, proof.clone()) {
+                        log::error!("Proof submitter connection closed, exiting");
+                        return Ok(());
+                    }
+                }
+
+                MerkleRootStatus::Failed(ref err) => {
+                    log::error!(
+                        "Merkle root {} for block #{} failed: {}",
+                        hash,
+                        merkle_root.block_number,
+                        err
+                    );
+                }
+
+                MerkleRootStatus::Finalized => {
+                    log::info!(
+                        "Merkle root {} for block #{} is finalized",
+                        hash,
+                        merkle_root.block_number
+                    );
+                }
+            }
+        }
 
         let mut attempts = 0;
 
@@ -142,11 +257,12 @@ impl MerkleRootRelayer {
             let now = Instant::now();
 
             if let Err(err) = self
-                .process(
+                .run_inner(
                     &mut submitter,
                     &mut prover,
                     &mut blocks_rx,
                     &mut authority_set_sync,
+                    &mut sealed_eras,
                 )
                 .await
             {
@@ -182,110 +298,188 @@ impl MerkleRootRelayer {
         }
     }
 
+    async fn run_inner(
+        &mut self,
+        submitter: &mut SubmitterIo,
+        prover: &mut FinalityProverIo,
+        blocks_rx: &mut Receiver<GearBlock>,
+        authority_set_sync: &mut AuthoritySetSyncIo,
+        sealed_eras: &mut UnboundedReceiver<SealedNotFinalizedEra>,
+    ) -> anyhow::Result<()> {
+        loop {
+            let result = self
+                .process(
+                    submitter,
+                    prover,
+                    blocks_rx,
+                    authority_set_sync,
+                    sealed_eras,
+                )
+                .await;
+
+            if let Err(err) = self.storage.save(&self.roots).await {
+                log::error!("Failed to save block state: {err:?}");
+            }
+
+            match result {
+                Ok(true) => continue,
+                Ok(false) => return Ok(()),
+                Err(err) => {
+                    log::error!("Error processing blocks: {err}");
+                    return Err(err);
+                }
+            }
+        }
+    }
+
     async fn process(
         &mut self,
         submitter: &mut SubmitterIo,
         prover: &mut FinalityProverIo,
         blocks_rx: &mut Receiver<GearBlock>,
         authority_set_sync: &mut AuthoritySetSyncIo,
-    ) -> anyhow::Result<()> {
-        loop {
-            tokio::select! {
-                block = blocks_rx.recv() => {
-                    match block {
-                        Ok(block) => {
-                            if !self.try_proof_merkle_root(prover, authority_set_sync, block).await? {
-                                return Ok(());
-                            }
-                        }
-
-                        Err(RecvError::Lagged(n)) => {
-                            log::warn!("Merkle root relayer lagged behind {n} blocks");
-                            continue;
-                        }
-
-                        Err(RecvError::Closed) => {
-                            log::warn!("Block listener connection closed, exiting");
-                            return Ok(());
+        sealed_eras: &mut UnboundedReceiver<SealedNotFinalizedEra>,
+    ) -> anyhow::Result<bool> {
+        tokio::select! {
+            block = blocks_rx.recv() => {
+                match block {
+                    Ok(block) => {
+                        if !self.try_proof_merkle_root(prover, block).await? {
+                            return Ok(false);
                         }
                     }
-                }
 
-                response = prover.recv() => {
-                    let Some(response) = response else {
-                        log::warn!("Finality prover connection closed, exiting");
-                        return Ok(());
-                    };
-
-                    if !submitter.submit_merkle_root(response.block_number, response.proof) {
-                        log::warn!("Proof submitter connection closed, exiting");
-                        return Ok(());
+                    Err(RecvError::Lagged(n)) => {
+                        log::warn!("Merkle root relayer lagged behind {n} blocks");
+                        return Ok(true);
                     }
-                }
 
-                response = authority_set_sync.recv() => {
-                    let Some(response) = response else {
-                        log::warn!("Authority set sync connection closed, exiting");
-                        return Ok(());
-                    };
-
-                    match response {
-                        authority_set_sync::Response::AuthoritySetSynced(id, block) => {
-                            self.storage.authority_set_processed(block).await;
-
-                            let Some(mut to_submit) = self.waiting_for_authority_set_sync.remove(&id) else {
-                                log::warn!("No blocks to sync for authority set #{id}");
-                                continue;
-                            };
-
-                            log::info!("Authority set #{id} is synced, submitting {} blocks", to_submit.len());
-                            while let Some(block) = to_submit.pop() {
-                                if !self.try_proof_merkle_root(prover, authority_set_sync, block).await? {
-                                    return Ok(());
-                                }
-                            }
-                        }
-
-                        authority_set_sync::Response::SealedEras(eras) => {
-                                for sealed_era in eras {
-                                let merkle_root = H256::from(sealed_era.proof.merkle_root);
-                                if self.storage.is_merkle_root_submitted(merkle_root).await {
-                                    log::info!("Merkle-root {:?} for era #{} is already submitted", sealed_era.era, merkle_root);
-                                    continue;
-                                }
-
-                                log::info!(
-                                    "Submitting merkle-root proof for era #{} at block #{}",
-                                    sealed_era.era,
-                                    sealed_era.merkle_root_block
-                                );
-
-                                if !submitter.submit_era_root(
-                                    sealed_era.era,
-                                    sealed_era.merkle_root_block,
-                                    sealed_era.proof) {
-                                    log::warn!("Proof submitter connection closed, exiting");
-                                    return Ok(());
-                                }
-                            }
-                        }
-                    }
-                }
-
-                response = submitter.recv() => {
-                    let Some(response) = response else {
-                        log::warn!("Proof submitter connection closed, exiting");
-                        return Ok(());
-                    };
-
-                    self.storage
-                        .merkle_root_processed(response.merkle_root_block).await;
-                    if let Err(err) = self.storage.save().await {
-                        log::error!("Failed to save block state: {err:?}");
+                    Err(RecvError::Closed) => {
+                        log::warn!("Block listener connection closed, exiting");
+                        return Ok(false);
                     }
                 }
             }
+
+            response = prover.recv() => {
+                let Some(response) = response else {
+                    log::warn!("Finality prover connection closed, exiting");
+                    return Ok(false);
+                };
+                let merkle_root_hash = H256::from(response.proof.merkle_root);
+                if let Some(merkle_root) = self.roots.get_mut(&merkle_root_hash) {
+                    merkle_root.status = MerkleRootStatus::SubmitProof(response.proof.clone());
+                    log::info!(
+                        "Merkle root {} for block #{} is ready for submission",
+                        merkle_root_hash,
+                        response.block_number
+                    );
+                } else {
+                    log::warn!(
+                        "Merkle root {} for block #{} not found in storage during SubmitProof phase",
+                        merkle_root_hash,
+                        response.block_number
+                    );
+
+                }
+
+                if !submitter.submit_merkle_root(response.block_number, response.proof) {
+                    log::warn!("Proof submitter connection closed, exiting");
+                    return Ok(false);
+                }
+            }
+
+
+            Some(sealed_era) = sealed_eras.recv(), if !sealed_eras.is_closed() => {
+                log::info!(
+                    "Sealed era #{} at block #{} with merkle root {} received",
+                    sealed_era.era,
+                    sealed_era.merkle_root_block,
+                    H256::from(sealed_era.proof.merkle_root)
+                );
+                if !submitter.submit_era_root(sealed_era.era, sealed_era.merkle_root_block, sealed_era.proof) {
+                    log::warn!("Proof submitter connection closed, exiting");
+                    return Ok(false);
+                }
+            }
+
+            response = authority_set_sync.recv() => {
+                let Some(response) = response else {
+                    log::warn!("Authority set sync connection closed, exiting");
+                    return Ok(false);
+                };
+
+                match response {
+                    authority_set_sync::Response::AuthoritySetSynced(id, block) => {
+                        self.storage.authority_set_processed(block).await;
+
+                        let Some(mut to_submit) = self.waiting_for_authority_set_sync.remove(&id) else {
+                            log::warn!("No blocks to sync for authority set #{id}");
+                            return Ok(true)
+                        };
+
+                        log::info!("Authority set #{id} is synced, submitting {} blocks", to_submit.len());
+                        while let Some(block) = to_submit.pop() {
+                            if !self.try_proof_merkle_root(prover, block).await? {
+                                return Ok(false);
+                            }
+                        }
+                    }
+                }
+            }
+
+            response = submitter.recv() => {
+                let Some(response) = response else {
+                    log::warn!("Proof submitter connection closed, exiting");
+                    return Ok(false);
+                };
+
+                self.finalize_merkle_root(response).await?;
+            }
         }
+        Ok(true)
+    }
+
+    async fn finalize_merkle_root(&mut self, response: submitter::Response) -> anyhow::Result<()> {
+        if let Some(era) = response.era {
+            log::info!(
+                "Era #{} merkle root {} for block #{} is finalized with status: {:?}",
+                era,
+                response.merkle_root,
+                response.merkle_root_block,
+                response.status,
+            );
+        }
+        if let Some(merkle_root) = self.roots.get_mut(&response.merkle_root) {
+            match response.status {
+                submitter::ResponseStatus::Submitted => {
+                    merkle_root.status = MerkleRootStatus::Finalized;
+                    log::info!(
+                        "Merkle root {} for block #{} is finalized",
+                        response.merkle_root,
+                        response.merkle_root_block
+                    );
+                }
+
+                submitter::ResponseStatus::Failed(err) => {
+                    merkle_root.status = MerkleRootStatus::Failed(err.to_string());
+                    log::error!(
+                        "Failed to finalize merkle root {} for block #{}: {}",
+                        response.merkle_root,
+                        response.merkle_root_block,
+                        err
+                    );
+                }
+            }
+        } else {
+            log::warn!(
+                "Merkle root {} for block #{} not found in storage",
+                response.merkle_root,
+                response.merkle_root_block
+            );
+        }
+
+        Ok(())
     }
 
     /// Attempt to create proof for merkle root of `block`. If authority set id
@@ -293,18 +487,21 @@ impl MerkleRootRelayer {
     async fn try_proof_merkle_root(
         &mut self,
         prover: &mut FinalityProverIo,
-        authority_set_sync: &AuthoritySetSyncIo,
         block: GearBlock,
     ) -> anyhow::Result<bool> {
         let Some(merkle_root) = storage::queue_merkle_root_changed(&block) else {
             return Ok(true);
         };
+        // mark root processed so that we don't process the entire block again.
+        self.storage.merkle_root_processed(block.number()).await;
 
-        if let Err(err) = self.storage.save().await {
+        if let Err(err) = self.storage.save(&self.roots).await {
             log::error!("Failed to save block storage state: {err:?}");
         }
 
-        if self.storage.is_merkle_root_submitted(merkle_root).await {
+        if self.roots.contains_key(&merkle_root)
+            || self.storage.is_merkle_root_submitted(merkle_root).await
+        {
             log::info!(
                 "Skipping merkle root {} for block #{} as there were no new messages",
                 merkle_root,
@@ -327,6 +524,14 @@ impl MerkleRootRelayer {
         {
             Ok(inner_proof) => {
                 let number = block.number();
+                self.roots.insert(
+                    merkle_root,
+                    MerkleRoot {
+                        block_number: number,
+                        block_hash: block.hash(),
+                        status: MerkleRootStatus::GenerateProof,
+                    },
+                );
                 log::info!("Proof for authority set #{signed_by_authority_set_id} is found, generating proof for merkle-root {merkle_root} at block #{number}");
                 if !prover.prove(block.number(), block.hash(), merkle_root, inner_proof) {
                     log::error!("Prover connection closed, exiting...");
@@ -341,16 +546,32 @@ impl MerkleRootRelayer {
                     block.number(),
                     signed_by_authority_set_id,
                 );
+                self.roots.insert(
+                    merkle_root,
+                    MerkleRoot {
+                        block_number: block.number(),
+                        block_hash: block.hash(),
+                        status: MerkleRootStatus::WaitForAuthoritySetSync(
+                            signed_by_authority_set_id,
+                            block.number(),
+                        ),
+                    },
+                );
                 self.waiting_for_authority_set_sync
                     .entry(signed_by_authority_set_id)
-                    .or_insert_with(|| {
-                        authority_set_sync.synchronize(block.clone());
-                        Default::default()
-                    })
+                    .or_default()
                     .push(block);
             }
 
             Err(err) => {
+                self.roots.insert(
+                    merkle_root,
+                    MerkleRoot {
+                        block_number: block.number(),
+                        block_hash: block.hash(),
+                        status: MerkleRootStatus::Failed(err.to_string()),
+                    },
+                );
                 log::error!(
                     "Failed to get proof for authority set id {signed_by_authority_set_id}: {err}"
                 );
@@ -360,4 +581,20 @@ impl MerkleRootRelayer {
 
         Ok(true)
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MerkleRoot {
+    pub block_number: u32,
+    pub block_hash: H256,
+    pub status: MerkleRootStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MerkleRootStatus {
+    WaitForAuthoritySetSync(u64, u32),
+    GenerateProof,
+    SubmitProof(FinalProof),
+    Finalized,
+    Failed(String),
 }

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -149,7 +149,7 @@ impl MerkleRootRelayer {
         storage: Arc<MerkleRootStorage>,
     ) -> MerkleRootRelayer {
         let mut save_interval = tokio::time::interval(Duration::from_secs(60));
-        save_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        save_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         MerkleRootRelayer {
             api_provider,

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -482,8 +482,8 @@ impl MerkleRootRelayer {
         Ok(())
     }
 
-    /// Attempt to create proof for merkle root of `block`. If authority set id
-    /// that signed `block`, proof generation will be delayed until authority set is synced.
+    /// Attempt to create proof for merkle root of `block`. If authority set that signed `block`
+    /// is not yet proven, proof generation will be delayed until authority set is synced.
     async fn try_proof_merkle_root(
         &mut self,
         prover: &mut FinalityProverIo,

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -135,7 +135,7 @@ impl FinalityProver {
 
         if proof.merkle_root != merkle_root.0 {
             log::info!("Merkle root {} at block #{} is valid under the proof with merkle root {} at block #{}",
-                merkle_root, block_number, H256::from(proof.merkle_root), block_number);
+                merkle_root, block_number, H256::from(proof.merkle_root), proof.block_number);
         }
 
         Ok(proof)

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -123,6 +123,7 @@ impl FinalityProver {
         log::info!("Generating merkle root proof for block #{block_number}");
 
         log::info!("Proving merkle root({merkle_root}) presence in block #{block_number}");
+
         let start = Instant::now();
         let proof =
             prover_interface::prove_final(gear_api, inner_proof, self.genesis_config, block_hash)
@@ -131,6 +132,12 @@ impl FinalityProver {
             "Proof for {merkle_root} generated (block #{block_number}) in {} seconds",
             start.elapsed().as_secs_f64()
         );
+
+        if proof.merkle_root != merkle_root.0 {
+            log::info!("Merkle root {} at block #{} is valid under the proof with merkle root {} at block #{}",
+                merkle_root, block_number, H256::from(proof.merkle_root), block_number);
+        }
+
         Ok(proof)
     }
 }

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use crate::{
     message_relayer::eth_to_gear::api_provider::ApiProviderConnection,
     prover_interface::{self, FinalProof},
@@ -121,11 +123,14 @@ impl FinalityProver {
         log::info!("Generating merkle root proof for block #{block_number}");
 
         log::info!("Proving merkle root({merkle_root}) presence in block #{block_number}");
-
+        let start = Instant::now();
         let proof =
             prover_interface::prove_final(gear_api, inner_proof, self.genesis_config, block_hash)
                 .await?;
-        log::info!("Proof for {merkle_root} generated (block #{block_number})");
+        log::info!(
+            "Proof for {merkle_root} generated (block #{block_number}) in {} seconds",
+            start.elapsed().as_secs_f64()
+        );
         Ok(proof)
     }
 }

--- a/relayer/src/merkle_roots/storage.rs
+++ b/relayer/src/merkle_roots/storage.rs
@@ -122,6 +122,10 @@ impl MerkleRootStorage {
         self.submitted_roots.write().await.insert(merkle_root);
     }
 
+    pub async fn submission_failed(&self, merkle_root: H256) {
+        self.submitted_roots.write().await.remove(&merkle_root);
+    }
+
     pub async fn merkle_root_processed(&self, block_number: u32) {
         let mut blocks = self.blocks.write().await;
 

--- a/relayer/src/merkle_roots/submitter.rs
+++ b/relayer/src/merkle_roots/submitter.rs
@@ -1,5 +1,8 @@
-use anyhow::Context;
-use ethereum_client::{EthApi, TxHash, TxStatus};
+use alloy::{
+    providers::{PendingTransactionBuilder, PendingTransactionError, Provider},
+    rpc::types::TransactionReceipt,
+};
+use ethereum_client::{EthApi, TxHash};
 use futures::{stream::FuturesUnordered, StreamExt};
 use primitive_types::H256;
 use prometheus::{Gauge, IntCounter, IntGauge};
@@ -23,6 +26,14 @@ pub struct Request {
 pub struct Response {
     pub era: Option<u64>,
     pub merkle_root_block: u32,
+    pub merkle_root: H256,
+    pub status: ResponseStatus,
+}
+
+#[derive(Debug)]
+pub enum ResponseStatus {
+    Submitted,
+    Failed(String),
 }
 
 pub struct SubmitterIo {
@@ -64,38 +75,43 @@ impl SubmitterIo {
 }
 
 struct SubmittedMerkleRoot {
-    eth_api: EthApi,
-    tx_hash: TxHash,
     era: Option<u64>,
     merkle_root_block: u32,
-    proof: FinalProof,
-    retried: bool,
-    status: TxStatus,
+    merkle_root: H256,
+    receipt: TransactionReceipt,
+}
+
+struct SubmissionError {
+    era: Option<u64>,
+    merkle_root_block: u32,
+    merkle_root: H256,
+    error: PendingTransactionError,
 }
 
 impl SubmittedMerkleRoot {
-    fn new(
-        eth_api: EthApi,
+    async fn new(
+        eth_api: &EthApi,
         tx_hash: TxHash,
         era: Option<u64>,
         merkle_root_block: u32,
-        proof: FinalProof,
-        retried: bool,
-    ) -> Self {
-        Self {
+        merkle_root: H256,
+        confirmations: u64,
+    ) -> Result<Self, SubmissionError> {
+        Ok(Self {
             merkle_root_block,
-            eth_api,
-            tx_hash,
+            merkle_root,
             era,
-            proof,
-            retried,
-            status: TxStatus::Pending,
-        }
-    }
-
-    async fn finalize(mut self) -> anyhow::Result<Self> {
-        self.status = self.eth_api.get_tx_status(self.tx_hash).await?;
-        Ok(self)
+            receipt: PendingTransactionBuilder::new(eth_api.raw_provider().root().clone(), tx_hash)
+                .with_required_confirmations(confirmations)
+                .get_receipt()
+                .await
+                .map_err(|error| SubmissionError {
+                    era,
+                    merkle_root_block,
+                    merkle_root,
+                    error,
+                })?,
+        })
     }
 }
 
@@ -126,7 +142,7 @@ impl_metered_service!(
 pub struct MerkleRootSubmitter {
     eth_api: EthApi,
     storage: Arc<MerkleRootStorage>,
-
+    confirmations: u64,
     metrics: Metrics,
 }
 
@@ -137,10 +153,11 @@ impl MeteredService for MerkleRootSubmitter {
 }
 
 impl MerkleRootSubmitter {
-    pub fn new(eth_api: EthApi, storage: Arc<MerkleRootStorage>) -> Self {
+    pub fn new(eth_api: EthApi, storage: Arc<MerkleRootStorage>, confirmations: u64) -> Self {
         Self {
             eth_api,
             storage,
+            confirmations,
             metrics: Metrics::new(),
         }
     }
@@ -164,72 +181,123 @@ impl MerkleRootSubmitter {
                         log::info!("No more proofs to process, exiting");
                         return Ok(());
                     };
-                    self.storage.submitted_merkle_root(H256::from(request.proof.merkle_root)).await;
+
+                    let root_exists = self.eth_api
+                        .read_finalized_merkle_root(request.merkle_root_block)
+                        .await?
+                        .is_some();
+
+                    if root_exists {
+                        if responses.send(Response {
+                            era: request.era,
+                            merkle_root_block: request.merkle_root_block,
+                            merkle_root: H256::from(request.proof.merkle_root),
+                            status: ResponseStatus::Submitted,
+                        }).is_err() {
+                            return Ok(());
+                        };
+                        log::info!("Merkle root {} for block #{} is already submitted", H256::from(request.proof.merkle_root), request.merkle_root_block);
+                        continue;
+                    }
+
+
                     let tx_hash = submit_merkle_root_to_ethereum(&self.eth_api, request.proof.clone()).await?;
                     log::info!("Submitted merkle root to Ethereum, tx hash: {tx_hash}");
                     self.metrics.total_submissions.inc();
                     pending_transactions.push(SubmittedMerkleRoot::new(
-                        self.eth_api.clone(),
+                        &self.eth_api,
                         tx_hash,
                         request.era,
                         request.merkle_root_block,
-                        request.proof,
-                        true
-                    ).finalize());
+                        H256::from(request.proof.merkle_root),
+                        self.confirmations,
+                    ));
 
 
                 },
 
-                Some(root) = pending_transactions.next() => {
-                    let root = root.context("Failed to check transaction status")?;
-                    match root.status {
-                        TxStatus::Pending => {
-                            log::trace!("Merkle root submission is still pending, tx hash: {}", root.tx_hash);
-                            pending_transactions.push(root.finalize());
-                        }
-                        TxStatus::Finalized => {
-                            log::info!("Merkle root submission confirmed, tx hash: {}", root.tx_hash);
+                Some(result) = pending_transactions.next() => {
+                    match result {
+                        Ok(submitted) => {
+                            if !submitted.receipt.status() {
+                                let root_exists = self.eth_api
+                                    .read_finalized_merkle_root(submitted.merkle_root_block)
+                                    .await?
+                                    .is_some();
+
+                                if root_exists {
+                                    if responses.send(Response {
+                                        era: submitted.era,
+                                        merkle_root_block: submitted.merkle_root_block,
+                                        merkle_root: submitted.merkle_root,
+                                        status: ResponseStatus::Submitted,
+                                    }).is_err() {
+                                        return Ok(());
+                                    };
+                                    log::info!("Merkle root {} for block #{} is already submitted", submitted.merkle_root, submitted.merkle_root_block);
+                                    continue;
+                                }
+
+                                if responses.send(Response {
+                                    era: submitted.era,
+                                    merkle_root_block: submitted.merkle_root_block,
+                                    merkle_root: submitted.merkle_root,
+                                    status: ResponseStatus::Failed(format!("Transaction {} failed", submitted.receipt.transaction_hash)),
+                                }).is_err() {
+                                    return Ok(());
+                                };
+                            }
+
                             if responses.send(Response {
-                                era: root.era,
-                                merkle_root_block: root.merkle_root_block,
+                                era: submitted.era,
+                                merkle_root_block: submitted.merkle_root_block,
+                                merkle_root: submitted.merkle_root,
+                                status: ResponseStatus::Submitted,
                             }).is_err() {
                                 return Ok(());
-                            }
+                            };
+
+                            self.storage.submitted_merkle_root(submitted.merkle_root).await;
+
+                            log::info!(
+                                "Merkle root {} for block #{} submission confirmed after {} confirmations",
+                                submitted.merkle_root,
+                                submitted.merkle_root_block,
+                                self.confirmations
+                            );
+                            self.metrics.pending_submissions.dec();
                         }
-                        TxStatus::Failed => {
+
+                        Err(err) => {
                             let root_exists = self.eth_api
-                                .read_finalized_merkle_root(root.merkle_root_block)
+                                .read_finalized_merkle_root(err.merkle_root_block)
                                 .await?
                                 .is_some();
 
                             if root_exists {
-                                log::info!("Merkle root at block #{} is already finalized", root.merkle_root_block);
                                 if responses.send(Response {
-                                    era: root.era,
-                                    merkle_root_block: root.merkle_root_block,
+                                    era: err.era,
+                                    merkle_root_block: err.merkle_root_block,
+                                    merkle_root: err.merkle_root,
+                                    status: ResponseStatus::Submitted,
                                 }).is_err() {
                                     return Ok(());
                                 };
+                                log::info!("Merkle root {} for block #{} is already submitted", err.merkle_root, err.merkle_root_block);
                                 continue;
                             }
 
-                            log::error!("Merkle root submission failed, tx hash: {}", root.tx_hash);
-                            if !root.retried {
-                                log::info!("Retrying merkle root submission, tx hash: {}", root.tx_hash);
-                                let tx_hash = submit_merkle_root_to_ethereum(&self.eth_api, root.proof.clone()).await?;
-                                pending_transactions.push(SubmittedMerkleRoot::new(
-                                    self.eth_api.clone(),
-                                    tx_hash,
-                                    root.era,
-                                    root.merkle_root_block,
-                                    root.proof,
-                                    true,
-                                ).finalize());
-                            } else {
-                                self.metrics.failed_submissions.inc();
-                                log::error!("Merkle root submission failed again, giving up, tx hash: {}", root.tx_hash);
-                            }
-
+                            log::error!("Failed to submit merkle root {}: {}", err.merkle_root, err.error);
+                            self.metrics.pending_submissions.dec();
+                            self.metrics.failed_submissions.inc();
+                            if responses.send(Response {
+                                era: err.era,
+                                merkle_root_block: err.merkle_root_block,
+                                merkle_root: err.merkle_root,
+                                status: ResponseStatus::Failed(err.error.to_string()),
+                            }).is_err() {
+                                return Ok(());
+                            };
                         }
                     }
                 }

--- a/relayer/src/message_relayer/common/gear/block_listener.rs
+++ b/relayer/src/message_relayer/common/gear/block_listener.rs
@@ -54,7 +54,7 @@ impl BlockListener {
         // Capacity for the channel. At the moment merkle-root relayer might lag behind
         // during proof generation or era sync, so we need to have enough capacity
         // to not drop any blocks. 14400 is how many blocks are produced in 1 era.
-        const CAPACITY: usize = 14400;
+        const CAPACITY: usize = 14_400;
         let (tx, _) = broadcast::channel(CAPACITY);
         let tx2 = tx.clone();
         tokio::task::spawn(async move {

--- a/relayer/src/message_relayer/common/gear/block_listener.rs
+++ b/relayer/src/message_relayer/common/gear/block_listener.rs
@@ -6,7 +6,6 @@ use crate::message_relayer::{
     eth_to_gear::api_provider::ApiProviderConnection,
 };
 use futures::StreamExt;
-use gsdk::subscription::BlockEvents;
 use primitive_types::H256;
 use prometheus::IntGauge;
 use std::sync::Arc;
@@ -53,9 +52,9 @@ impl BlockListener {
         mut self,
     ) -> [broadcast::Receiver<GearBlock>; RECEIVER_COUNT] {
         // Capacity for the channel. At the moment merkle-root relayer might lag behind
-        // during proof generation, so we need to ensure that we can queue up
-        // enough blocks to process them later.
-        const CAPACITY: usize = 10000;
+        // during proof generation or era sync, so we need to have enough capacity
+        // to not drop any blocks. 14400 is how many blocks are produced in 1 era.
+        const CAPACITY: usize = 14400;
         let (tx, _) = broadcast::channel(CAPACITY);
         let tx2 = tx.clone();
         tokio::task::spawn(async move {
@@ -147,11 +146,9 @@ impl BlockListener {
             log::trace!("Fetching unprocessed block #{block_number} (hash: {block_hash})");
             let block = gear_api.api.blocks().at(block_hash).await?;
 
-            let header = block.header().clone();
-            let block_events = BlockEvents::new(block).await?;
-            let events = block_events.events()?;
+            let gear_block = GearBlock::from_subxt_block(block).await?;
 
-            match tx.send(GearBlock::new(header, events)) {
+            match tx.send(gear_block) {
                 Ok(_) => (),
                 Err(broadcast::error::SendError(_)) => {
                     log::error!("No active receivers for Gear block listener, stopping");
@@ -170,11 +167,8 @@ impl BlockListener {
 
                 Some(Ok(block)) => {
                     self.metrics.latest_block.set(block.number() as i64);
-                    let header = block.header().clone();
-                    let block_events = BlockEvents::new(block).await?;
-                    let events = block_events.events()?;
 
-                    let block = GearBlock::new(header, events);
+                    let block = GearBlock::from_subxt_block(block).await?;
                     self.block_storage.add_block(&block).await;
 
                     match tx.send(block) {

--- a/relayer/src/message_relayer/common/mod.rs
+++ b/relayer/src/message_relayer/common/mod.rs
@@ -8,10 +8,12 @@ use gsdk::{
         gear_eth_bridge::Event as GearEthBridgeEvent,
         runtime_types::{gear_core::message::user::UserMessage, gprimitives::ActorId},
     },
+    subscription::BlockEvents,
+    GearConfig,
 };
 use primitive_types::{H256, U256};
 use serde::{Deserialize, Serialize};
-use subxt::config::Header as _;
+use subxt::{blocks::Block, config::Header as _, OnlineClient};
 
 pub mod ethereum;
 pub mod gear;
@@ -137,6 +139,15 @@ impl GearBlock {
             }
             _ => None,
         })
+    }
+
+    pub async fn from_subxt_block(
+        block: Block<GearConfig, OnlineClient<GearConfig>>,
+    ) -> anyhow::Result<Self> {
+        let header = block.header().clone();
+        let events = BlockEvents::new(block).await?;
+        let events = events.events()?;
+        Ok(Self::new(header, events))
     }
 }
 

--- a/relayer/src/prover_interface.rs
+++ b/relayer/src/prover_interface.rs
@@ -1,5 +1,6 @@
 use std::{str::FromStr, time::Instant};
 
+use serde::{Deserialize, Serialize};
 use utils_prometheus::MeteredService;
 
 use gear_rpc_client::{dto, GearApi};
@@ -106,7 +107,7 @@ pub async fn prove_validator_set_change(
     Ok(proof)
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FinalProof {
     pub proof: Vec<u8>,
     pub block_number: u32,


### PR DESCRIPTION
Latest refactor for merkle-root relayer proven to be faulty esp. during era changes. This PR should improve the situation:
- Sealing of old eras now is only performed during startup without blocking authority set sync for new blocks
- Submitter task was changed to consider merkle-root submitted after 8 confirmations by default. Also added checks to not submit root if it is already on Ethereum.
- Merkle-root relayer was updated to use TxManaged like approach from eth-gear but for merkle-roots: now status of each merkle root we're relaying will be saved in storage. 
- Small refactor of block-listener to add `GearBlock::from_subxt_block` 

@gshep 