### PR TITLE
refactor(relayer): total refactor of gear-eth relayer analogous to eth-gear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5376,6 +5376,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "sc-consensus-grandpa",
+ "serde",
  "sp-consensus-grandpa",
  "sp-core 34.0.0 (git+https://github.com/gear-tech/polkadot-sdk.git?branch=gear-polkadot-stable2409-wasm32v1-none)",
  "sp-runtime 39.0.1",

--- a/gear-rpc-client/Cargo.toml
+++ b/gear-rpc-client/Cargo.toml
@@ -20,3 +20,4 @@ sp-trie.workspace = true
 sp-core.workspace = true
 pallet-gear-eth-bridge-rpc-runtime-api.workspace = true
 primitive-types.workspace = true
+serde.workspace = true

--- a/gear-rpc-client/src/dto.rs
+++ b/gear-rpc-client/src/dto.rs
@@ -1,4 +1,5 @@
 use parity_scale_codec::{Decode, Encode};
+use serde::{Deserialize, Serialize};
 
 const ED25519_PUBLIC_KEY_SIZE: usize = 32;
 const ED25519_SIGNATURE_SIZE: usize = 64;
@@ -43,6 +44,7 @@ pub struct MessageSentProof {
     pub storage_inclusion_proof: StorageInclusionProof,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MerkleProof {
     pub root: [u8; KECCAK_HASH_SIZE],
     pub proof: Vec<[u8; KECCAK_HASH_SIZE]>,
@@ -50,7 +52,7 @@ pub struct MerkleProof {
     pub leaf_index: u64,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Message {
     pub nonce_le: [u8; 32],
     pub source: [u8; 32],

--- a/relayer/src/cli/mod.rs
+++ b/relayer/src/cli/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Args, Parser, Subcommand};
 
 mod common;
@@ -116,6 +118,9 @@ pub struct GearEthTokensArgs {
         value_parser = parse_fee_payers,
     )]
     pub no_fee: Option<FeePayers>,
+
+    #[arg(long = "storage-path", env = "ETH_GEAR_TX_STORAGE_PATH")]
+    pub storage_path: PathBuf,
 }
 
 #[derive(Subcommand)]

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -15,7 +15,7 @@ use message_relayer::{
     eth_to_gear::{self, api_provider::ApiProvider},
     gear_to_eth,
 };
-use primitive_types::U256;
+
 use proof_storage::{FileSystemProofStorage, GearProofStorage, ProofStorage};
 use prover::proving::GenesisConfig;
 use relayer::*;
@@ -199,7 +199,7 @@ async fn run() -> AnyResult<()> {
 
             match args.command {
                 GearEthTokensCommands::AllTokenTransfers => {
-                    let relayer = gear_to_eth::all_token_transfers::Relayer::new(
+                    /*let relayer = gear_to_eth::all_token_transfers::Relayer::new(
                         eth_api,
                         provider.connection(),
                         args.confirmations_merkle_root
@@ -222,7 +222,7 @@ async fn run() -> AnyResult<()> {
                     loop {
                         // relayer.run() spawns thread and exits, so we need to add this loop after calling run.
                         time::sleep(Duration::from_secs(1)).await;
-                    }
+                    }*/
                 }
 
                 GearEthTokensCommands::PaidTokenTransfers {
@@ -252,6 +252,7 @@ async fn run() -> AnyResult<()> {
                             .unwrap_or(DEFAULT_COUNT_CONFIRMATIONS),
                         excluded_from_fees,
                         receiver,
+                        args.storage_path.clone(),
                     )
                     .await
                     .unwrap();
@@ -264,8 +265,6 @@ async fn run() -> AnyResult<()> {
 
                     provider.spawn();
                     relayer.run().await;
-
-                    tokio::signal::ctrl_c().await?;
 
                     handle_server.stop(true).await;
                 }
@@ -404,8 +403,8 @@ async fn run() -> AnyResult<()> {
                 }
             }
         }
-        CliCommands::GearEthManual(args) => {
-            let nonce =
+        CliCommands::GearEthManual(_args) => {
+            /*let nonce =
                 hex_utils::decode_byte_vec(&args.nonce).expect("Failed to parse message nonce");
             let nonce = U256::from_big_endian(&nonce[..]);
             let eth_api = create_eth_signer_client(&args.ethereum_args).await;
@@ -429,7 +428,7 @@ async fn run() -> AnyResult<()> {
                 args.confirmations_status
                     .unwrap_or(DEFAULT_COUNT_CONFIRMATIONS),
             )
-            .await;
+            .await;*/
         }
 
         CliCommands::EthGearManual(EthGearManualArgs {

--- a/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
@@ -1,26 +1,94 @@
-mod utils;
+pub mod utils;
 
 use super::*;
-use crate::{
-    common::BASE_RETRY_DELAY,
-    message_relayer::common::{AuthoritySetId, MessageInBlock},
-};
+use crate::{common::BASE_RETRY_DELAY, message_relayer::common::AuthoritySetId};
 use futures::{
     future::{self, Either},
     pin_mut,
 };
+use primitive_types::H256;
 use prometheus::IntGauge;
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use std::sync::Arc;
+use tokio::sync::{
+    mpsc::{self, UnboundedReceiver, UnboundedSender},
+    RwLock,
+};
 use utils::{Added, MerkleRoots, Messages};
 use utils_prometheus::{impl_metered_service, MeteredService};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Request {
+    pub authority_set_id: AuthoritySetId,
+    pub block: GearBlockNumber,
+    pub block_hash: H256,
+    pub tx_uuid: Uuid,
+}
+
+pub enum Response {
+    /// Merkle-root was relayed and the message can be processed further.
+    Success {
+        authority_set_id: AuthoritySetId,
+        block: GearBlockNumber,
+        tx_uuid: Uuid,
+        merkle_root: RelayedMerkleRoot,
+    },
+
+    /// Accumulator buffer is full and the message cannot be processed.
+    Overflowed(Request),
+
+    /// Message is stuck and cannot be processed.
+    Stuck {
+        authority_set_id: AuthoritySetId,
+        block: GearBlockNumber,
+        tx_uuid: Uuid,
+        merkle_root: RelayedMerkleRoot,
+    },
+}
+
+pub struct AccumulatorIo {
+    messages_with_roots: UnboundedReceiver<Response>,
+    messages: UnboundedSender<Request>,
+}
+
+impl AccumulatorIo {
+    pub fn new(
+        messages_with_roots: UnboundedReceiver<Response>,
+        messages: UnboundedSender<Request>,
+    ) -> Self {
+        Self {
+            messages_with_roots,
+            messages,
+        }
+    }
+
+    pub fn send_message(
+        &self,
+        tx_uuid: Uuid,
+        authority_set_id: AuthoritySetId,
+        block: GearBlockNumber,
+        block_hash: H256,
+    ) -> bool {
+        let request = Request {
+            authority_set_id,
+            block,
+            block_hash,
+            tx_uuid,
+        };
+        self.messages.send(request).is_ok()
+    }
+
+    pub async fn recv_message(&mut self) -> Option<Response> {
+        self.messages_with_roots.recv().await
+    }
+}
 
 /// Struct accumulates gear-eth messages and required merkle roots.
 pub struct Accumulator {
     metrics: Metrics,
     messages: Messages,
-    merkle_roots: MerkleRoots,
+    merkle_roots: Arc<RwLock<MerkleRoots>>,
     receiver_roots: UnboundedReceiver<RelayedMerkleRoot>,
-    receiver_messages: UnboundedReceiver<MessageInBlock>,
 }
 
 impl MeteredService for Accumulator {
@@ -41,22 +109,23 @@ impl_metered_service! {
 impl Accumulator {
     pub fn new(
         receiver_roots: UnboundedReceiver<RelayedMerkleRoot>,
-        receiver_messages: UnboundedReceiver<MessageInBlock>,
+
+        merkle_roots: Arc<RwLock<MerkleRoots>>,
     ) -> Self {
         Self {
             metrics: Metrics::new(),
             messages: Messages::new(10_000),
-            merkle_roots: MerkleRoots::new(300),
+            merkle_roots,
             receiver_roots,
-            receiver_messages,
         }
     }
 
-    pub fn spawn(mut self) -> UnboundedReceiver<(MessageInBlock, RelayedMerkleRoot)> {
+    pub fn spawn(mut self) -> AccumulatorIo {
+        let (requests_in, mut requests_out) = mpsc::unbounded_channel();
         let (mut messages_out, receiver) = mpsc::unbounded_channel();
         tokio::task::spawn(async move {
             loop {
-                match run_inner(&mut self, &mut messages_out).await {
+                match run_inner(&mut self, &mut messages_out, &mut requests_out).await {
                     Ok(_) => break,
                     Err(e) => {
                         log::error!("{e:?}");
@@ -67,16 +136,17 @@ impl Accumulator {
             }
         });
 
-        receiver
+        AccumulatorIo::new(receiver, requests_in)
     }
 }
 
 async fn run_inner(
     this: &mut Accumulator,
-    messages_out: &mut UnboundedSender<(MessageInBlock, RelayedMerkleRoot)>,
+    messages_out: &mut UnboundedSender<Response>,
+    requests: &mut UnboundedReceiver<Request>,
 ) -> anyhow::Result<()> {
     loop {
-        let recv_messages = this.receiver_messages.recv();
+        let recv_messages = requests.recv();
         pin_mut!(recv_messages);
 
         let recv_merkle_roots = this.receiver_roots.recv();
@@ -94,11 +164,16 @@ async fn run_inner(
             }
 
             Either::Left((Some(message), _)) => {
-                if let Some(merkle_root) = this
-                    .merkle_roots
-                    .find(message.authority_set_id, message.block)
+                let merkle_roots = this.merkle_roots.read().await;
+                if let Some(merkle_root) =
+                    merkle_roots.find(message.authority_set_id, message.block)
                 {
-                    messages_out.send((message, *merkle_root))?;
+                    messages_out.send(Response::Success {
+                        authority_set_id: message.authority_set_id,
+                        block: message.block,
+                        tx_uuid: message.tx_uuid,
+                        merkle_root: merkle_root.clone(),
+                    })?;
                     continue;
                 }
 
@@ -106,11 +181,14 @@ async fn run_inner(
                     log::error!(
                         "Unable to add the message '{message:?}' since the capacity is full"
                     );
+
+                    messages_out.send(Response::Overflowed(message))?;
                 }
             }
 
             Either::Right((Some(merkle_root), _)) => {
-                match this.merkle_roots.add(merkle_root) {
+                let mut merkle_roots = this.merkle_roots.write().await;
+                match merkle_roots.add(merkle_root) {
                     Ok(Added::Ok | Added::Overwritten(_)) => {}
 
                     Ok(Added::Removed(merkle_root_old)) => {
@@ -118,6 +196,12 @@ async fn run_inner(
                         let messages = this.messages.drain(&merkle_root_old);
                         for message in messages {
                             log::error!("Remove stuck message = {message:?}");
+                            messages_out.send(Response::Stuck {
+                                authority_set_id: message.authority_set_id,
+                                block: message.block,
+                                tx_uuid: message.tx_uuid,
+                                merkle_root: merkle_root_old.clone(),
+                            })?;
                         }
                     }
 
@@ -128,7 +212,12 @@ async fn run_inner(
                 }
 
                 for message in this.messages.drain(&merkle_root) {
-                    messages_out.send((message, merkle_root))?;
+                    messages_out.send(Response::Success {
+                        authority_set_id: message.authority_set_id,
+                        block: message.block,
+                        tx_uuid: message.tx_uuid,
+                        merkle_root: merkle_root.clone(),
+                    })?;
                 }
             }
         }

--- a/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 use super::*;
 
-pub struct Messages(Vec<MessageInBlock>);
+pub struct Messages(Vec<accumulator::Request>);
 
 impl Messages {
     pub fn new(capacity: usize) -> Self {
@@ -25,7 +27,7 @@ impl Messages {
     }
 
     // None -> the inner vector is full so the message is rejected
-    pub fn add(&mut self, message_new: MessageInBlock) -> Option<()> {
+    pub fn add(&mut self, message_new: accumulator::Request) -> Option<()> {
         if self.0.len() >= self.0.capacity() {
             return None;
         }
@@ -44,7 +46,7 @@ impl Messages {
         Some(())
     }
 
-    pub fn drain(&mut self, merkle_root: &RelayedMerkleRoot) -> Drain<'_, MessageInBlock> {
+    pub fn drain(&mut self, merkle_root: &RelayedMerkleRoot) -> Drain<'_, accumulator::Request> {
         let index_end = match self.0.binary_search_by(|message| {
             Self::compare(
                 message.authority_set_id,
@@ -85,6 +87,7 @@ pub enum Added {
     Overwritten(GearBlockNumber),
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct MerkleRoots(Vec<RelayedMerkleRoot>);
 
 impl MerkleRoots {
@@ -447,41 +450,41 @@ mod tests {
                 .into(),
         };
         let data = [
-            MessageInBlock {
+            accumulator::Request {
                 block: GearBlockNumber(16_883_172),
                 block_hash: hex!(
                     "38f753a5d02c81e91ff8b3950c2cd03c526ced9abc0b6ef29803ee4250a0df85"
                 )
                 .into(),
                 authority_set_id: AuthoritySetId(1_180),
-                message: Default::default(),
+                tx_uuid: Uuid::now_v7(),
             },
-            MessageInBlock {
+            accumulator::Request {
                 block: GearBlockNumber(16_883_289),
                 block_hash: hex!(
                     "74dcef50f0cf4299a0774b147a748f3d5961d913afb9d0e74868a298255edea2"
                 )
                 .into(),
                 authority_set_id: AuthoritySetId(1_183),
-                message: Default::default(),
+                tx_uuid: Uuid::now_v7(),
             },
-            MessageInBlock {
+            accumulator::Request {
                 block: GearBlockNumber(16_881_824),
                 block_hash: hex!(
                     "24b437d833fc6b7e9aea9d987ca1411ae293d340427da57dd7d9888fda8b16a2"
                 )
                 .into(),
                 authority_set_id: AuthoritySetId(1_183),
-                message: Default::default(),
+                tx_uuid: Uuid::now_v7(),
             },
-            MessageInBlock {
+            accumulator::Request {
                 block: GearBlockNumber(16_883_636),
                 block_hash: hex!(
                     "410d4f4a053a00a32b3655350aa8bde8d458ff0d271ff9927a79fe0f7620f848"
                 )
                 .into(),
                 authority_set_id: AuthoritySetId(1_184),
-                message: Default::default(),
+                tx_uuid: Uuid::now_v7(),
             },
         ];
 

--- a/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
@@ -95,6 +95,12 @@ impl MerkleRoots {
         Self(Vec::with_capacity(capacity))
     }
 
+    pub fn extend(mut self, roots: impl IntoIterator<Item = RelayedMerkleRoot>) -> Self {
+        self.0.extend(roots);
+        self.0.sort_by(|a, b| Self::compare(a.authority_set_id, a.block, b.authority_set_id, b.block));
+        self
+    }
+
     fn compare(
         authority_set_id: AuthoritySetId,
         block_number: GearBlockNumber,

--- a/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
@@ -95,12 +95,6 @@ impl MerkleRoots {
         Self(Vec::with_capacity(capacity))
     }
 
-    pub fn extend(mut self, roots: impl IntoIterator<Item = RelayedMerkleRoot>) -> Self {
-        self.0.extend(roots);
-        self.0.sort_by(|a, b| Self::compare(a.authority_set_id, a.block, b.authority_set_id, b.block));
-        self
-    }
-
     fn compare(
         authority_set_id: AuthoritySetId,
         block_number: GearBlockNumber,

--- a/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
+++ b/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
@@ -1,18 +1,43 @@
-use crate::{
-    common::{self, BASE_RETRY_DELAY, MAX_RETRIES},
-    message_relayer::common::MessageInBlock,
-};
-use alloy::providers::{PendingTransactionBuilder, Provider};
+use crate::common::{self, BASE_RETRY_DELAY, MAX_RETRIES};
+use alloy::providers::{PendingTransactionBuilder, PendingTransactionError, Provider};
 use ethereum_client::{EthApi, TxHash};
+use futures::{stream::FuturesUnordered, StreamExt};
 use prometheus::{IntCounter, IntGauge};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
+use uuid::Uuid;
 
 pub struct StatusFetcher {
     eth_api: EthApi,
     confirmations: u64,
 
     metrics: Metrics,
+}
+
+pub struct Request {
+    pub tx_uuid: Uuid,
+    pub tx_hash: TxHash,
+}
+
+pub enum Response {
+    Success(Uuid, TxHash),
+    Failed(Uuid, PendingTransactionError),
+}
+
+pub struct StatusFetcherIo {
+    requests: UnboundedSender<Request>,
+    responses: UnboundedReceiver<Response>,
+}
+
+impl StatusFetcherIo {
+    pub fn send_request(&self, tx_uuid: Uuid, tx_hash: TxHash) -> bool {
+        let request = Request { tx_uuid, tx_hash };
+        self.requests.send(request).is_ok()
+    }
+
+    pub async fn recv_message(&mut self) -> Option<Response> {
+        self.responses.recv().await
+    }
 }
 
 impl MeteredService for StatusFetcher {
@@ -44,19 +69,26 @@ impl StatusFetcher {
         }
     }
 
-    pub fn spawn(self) -> UnboundedSender<(TxHash, MessageInBlock)> {
-        let (sender, receiver) = mpsc::unbounded_channel();
-        tokio::task::spawn(task(self, receiver));
+    pub fn spawn(self) -> StatusFetcherIo {
+        let (requests, responses) = (mpsc::unbounded_channel(), mpsc::unbounded_channel());
+        tokio::task::spawn(task(self, requests.1, responses.0));
 
-        sender
+        StatusFetcherIo {
+            requests: requests.0,
+            responses: responses.1,
+        }
     }
 }
 
-async fn task(mut this: StatusFetcher, mut channel: UnboundedReceiver<(TxHash, MessageInBlock)>) {
+async fn task(
+    mut this: StatusFetcher,
+    mut channel: UnboundedReceiver<Request>,
+    responses: UnboundedSender<Response>,
+) {
     let mut attempts = 0;
 
     loop {
-        match task_inner(&mut this, &mut channel).await {
+        match task_inner(&mut this, &mut channel, &responses).await {
             Ok(_) => break,
             Err(e) => {
                 attempts += 1;
@@ -88,36 +120,51 @@ async fn task(mut this: StatusFetcher, mut channel: UnboundedReceiver<(TxHash, M
 
 async fn task_inner(
     this: &mut StatusFetcher,
-    channel: &mut UnboundedReceiver<(TxHash, MessageInBlock)>,
+    channel: &mut UnboundedReceiver<Request>,
+    responses: &UnboundedSender<Response>,
 ) -> anyhow::Result<()> {
-    while let Some((tx_hash, _message)) = channel.recv().await {
-        this.metrics.pending_tx_count.inc();
+    let mut txs = FuturesUnordered::new();
 
-        let metrics = this.metrics.clone();
+    tokio::select! {
+        message = channel.recv() => {
+            let Some(request) = message else {
+                log::info!("No more messages to process, exiting");
+                return Ok(());
+            };
 
-        tokio::spawn(get_tx_status(
-            this.eth_api.clone(),
-            metrics,
-            tx_hash,
-            this.confirmations,
-        ));
+            let Request { tx_uuid, tx_hash, .. } = request;
+
+            this.metrics.pending_tx_count.inc();
+
+            let pending = PendingTransactionBuilder::new(
+                this.eth_api.raw_provider().root().clone(),
+                tx_hash,
+            );
+
+            txs.push(async move {
+                Ok((tx_uuid, pending.with_required_confirmations(this.confirmations).watch().await.map_err(|e| (tx_uuid, e))?))
+            });
+        }
+
+        tx = txs.next() => {
+            let Some(tx) = tx else {
+                log::info!("No more transactions to process, exiting");
+                return Ok(());
+            };
+
+            match tx {
+                Ok((uuid, tx_hash)) => {
+                    this.metrics.pending_tx_count.dec();
+                    responses.send(Response::Success(uuid, tx_hash))?;
+                }
+                Err((uuid, e)) => {
+                    this.metrics.total_failed_txs.inc();
+                    log::error!("Failed to get transaction {uuid} status: {e}");
+                    responses.send(Response::Failed(uuid, e))?;
+                }
+            }
+        }
     }
 
     Ok(())
-}
-
-async fn get_tx_status(eth_api: EthApi, metrics: Metrics, tx_hash: TxHash, confirmations: u64) {
-    let pending = PendingTransactionBuilder::new(eth_api.raw_provider().root().clone(), tx_hash);
-
-    if let Err(e) = pending
-        .with_required_confirmations(confirmations)
-        .watch()
-        .await
-    {
-        metrics.total_failed_txs.inc();
-        log::error!("Failed to finalize transaction {tx_hash}: {e:?}");
-    } else {
-        metrics.pending_tx_count.dec();
-        log::info!("Transaction {tx_hash} has {confirmations} confirmation(s)");
-    }
 }

--- a/relayer/src/message_relayer/common/mod.rs
+++ b/relayer/src/message_relayer/common/mod.rs
@@ -1,6 +1,6 @@
 use ethereum_client::TxHash;
 use ethereum_common::Hash256;
-use gear_rpc_client::dto::{MerkleProof, Message};
+use gear_rpc_client::dto::Message;
 use gsdk::{
     config::Header,
     metadata::{
@@ -19,10 +19,34 @@ pub mod ethereum;
 pub mod gear;
 pub mod paid_messages_filter;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, derive_more::Display)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Debug,
+    derive_more::Display,
+    Serialize,
+    Deserialize,
+)]
 pub struct AuthoritySetId(pub u64);
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, derive_more::Display)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Debug,
+    derive_more::Display,
+    Serialize,
+    Deserialize,
+)]
 pub struct GearBlockNumber(pub u32);
 
 #[derive(
@@ -56,7 +80,7 @@ pub struct EthereumBlockNumber(pub u64);
 )]
 pub struct EthereumSlotNumber(pub u64);
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MessageInBlock {
     pub message: Message,
     pub block: GearBlockNumber,
@@ -69,7 +93,7 @@ pub struct PaidMessage {
     pub nonce: [u8; 32],
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RelayedMerkleRoot {
     pub block: GearBlockNumber,
     pub block_hash: H256,
@@ -88,12 +112,6 @@ pub struct GSdkArgs {
     pub vara_domain: String,
     pub vara_port: u16,
     pub vara_rpc_retries: u8,
-}
-
-pub struct Data {
-    pub message: MessageInBlock,
-    pub relayed_root: RelayedMerkleRoot,
-    pub proof: MerkleProof,
 }
 
 #[derive(Clone, Debug)]

--- a/relayer/src/message_relayer/gear_to_eth/mod.rs
+++ b/relayer/src/message_relayer/gear_to_eth/mod.rs
@@ -1,3 +1,5 @@
-pub mod all_token_transfers;
-pub mod manual;
+//pub mod all_token_transfers;
+//pub mod manual;
 pub mod paid_token_transfers;
+pub mod storage;
+pub mod tx_manager;

--- a/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
+++ b/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
@@ -105,6 +105,9 @@ impl Relayer {
         let status_fetcher = StatusFetcher::new(eth_api.clone(), confirmations_status);
 
         let tx_manager = TransactionManager::new(Arc::new(JSONStorage::new(storage_path)));
+        if let Err(e) = tx_manager.load_from_storage().await {
+            log::warn!("Failed to load transaction manager state: {e}");
+        }
 
         let (messages_sender, messages_receiver) = mpsc::unbounded_channel();
         let accumulator = Accumulator::new(roots_receiver, tx_manager.merkle_roots.clone());

--- a/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
+++ b/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
@@ -173,9 +173,6 @@ impl Relayer {
         {
             log::error!("Transaction manager exited with error: {err:?}");
         }
-
-        /*self.message_sender
-        .spawn(channel_message_data, channel_tx_data);*/
     }
 }
 

--- a/relayer/src/message_relayer/gear_to_eth/storage.rs
+++ b/relayer/src/message_relayer/gear_to_eth/storage.rs
@@ -118,7 +118,7 @@ impl JSONStorage {
 
         let mut contents = String::new();
 
-        let mut file = tokio::fs::File::open(path.join(&tx_file))
+        let mut file = tokio::fs::File::open(path)
             .await
             .with_context(|| format!("Failed to open transaction file: {tx_file:?}"))?;
 

--- a/relayer/src/message_relayer/gear_to_eth/storage.rs
+++ b/relayer/src/message_relayer/gear_to_eth/storage.rs
@@ -236,9 +236,12 @@ impl Storage for JSONStorage {
                     let contents = tokio::fs::read_to_string(entry.path())
                         .await
                         .context("Failed to read 'merkle_roots' file")?;
-                    let merkle: MerkleRoots = serde_json::from_str(&contents)
+                    let merkle_roots: MerkleRoots = serde_json::from_str(&contents)
                         .context("Failed to parse 'merkle_roots'")?;
-                    *tx_manager.merkle_roots.write().await = merkle;
+                    for i in 0..merkle_roots.len() {
+                        let root = merkle_roots.get(i).expect("Root should exist");
+                        let _ = tx_manager.merkle_roots.write().await.add(root.clone());
+                    }
                 } else if entry.file_name().to_str() == Some("blocks") {
                 } else {
                     let tx = self.read_tx(entry.path(), entry.file_name()).await?;

--- a/relayer/src/message_relayer/gear_to_eth/storage.rs
+++ b/relayer/src/message_relayer/gear_to_eth/storage.rs
@@ -1,0 +1,258 @@
+#![allow(dead_code, unused_variables)]
+use std::{
+    collections::{BTreeMap, HashSet},
+    ffi::OsString,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::Context;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use uuid::Uuid;
+
+use crate::message_relayer::{
+    common::{ethereum::accumulator::utils::MerkleRoots, GearBlock},
+    gear_to_eth::tx_manager::{Transaction, TransactionManager},
+};
+
+pub struct BlockStorage {
+    blocks: BTreeMap<u32, GearBlock>,
+    n_to_keep: usize,
+}
+
+impl BlockStorage {
+    pub fn new() -> Self {
+        Self {
+            blocks: BTreeMap::new(),
+            n_to_keep: 100,
+        }
+    }
+
+    pub async fn save(&self, path: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+pub struct Block {
+    pub messages: HashSet<u64>,
+}
+
+#[async_trait::async_trait]
+pub trait Storage: Send + Sync {
+    fn block_storage(&self) -> &BlockStorage;
+
+    async fn save(&self, tx_manager: &TransactionManager) -> anyhow::Result<()>;
+    async fn load(&self, tx_manager: &TransactionManager) -> anyhow::Result<()>;
+    async fn save_blocks(&self) -> anyhow::Result<()>;
+}
+
+pub struct NoStorage(BlockStorage);
+
+impl Default for NoStorage {
+    fn default() -> Self {
+        Self(BlockStorage {
+            blocks: BTreeMap::new(),
+            n_to_keep: 0,
+        })
+    }
+}
+
+impl NoStorage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl Storage for NoStorage {
+    fn block_storage(&self) -> &BlockStorage {
+        &self.0
+    }
+
+    async fn save(&self, _tx_manager: &TransactionManager) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn load(&self, _tx_manager: &TransactionManager) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn save_blocks(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+pub struct JSONStorage {
+    path: PathBuf,
+    block_storage: BlockStorage,
+}
+
+impl JSONStorage {
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            block_storage: BlockStorage::new(),
+        }
+    }
+
+    async fn write_tx(&self, tx_uuid: &Uuid, tx: &Transaction) -> anyhow::Result<()> {
+        let filename = self.path.join(tx_uuid.to_string());
+        let mut file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(filename)
+            .await?;
+
+        let json = serde_json::to_string(&tx)?;
+        file.write_all(json.as_bytes()).await?;
+        file.flush().await?;
+        Ok(())
+    }
+
+    async fn read_tx(&self, path: PathBuf, tx_file: OsString) -> anyhow::Result<Transaction> {
+        let uuid = tx_file
+            .to_str()
+            .and_then(|s| Uuid::from_str(s).ok())
+            .ok_or_else(|| anyhow::anyhow!("Invalid UUID in file name: {tx_file:?}"))?;
+
+        let mut contents = String::new();
+
+        let mut file = tokio::fs::File::open(path.join(&tx_file))
+            .await
+            .with_context(|| format!("Failed to open transaction file: {tx_file:?}"))?;
+
+        file.read_to_string(&mut contents)
+            .await
+            .with_context(|| format!("Failed to read transaction file: {tx_file:?}"))?;
+
+        let tx: Transaction = serde_json::from_str(&contents)
+            .with_context(|| format!("Failed to deserialize transaction from file: {tx_file:?}"))?;
+
+        if tx.uuid != uuid {
+            return Err(anyhow::anyhow!(
+                "Transaction UUID mismatch: expected {}, found {}",
+                uuid,
+                tx.uuid
+            ));
+        }
+
+        Ok(tx)
+    }
+}
+
+#[async_trait::async_trait]
+impl Storage for JSONStorage {
+    fn block_storage(&self) -> &BlockStorage {
+        &self.block_storage
+    }
+
+    async fn save(&self, tx_manager: &TransactionManager) -> anyhow::Result<()> {
+        if !self.path.exists() {
+            tokio::fs::create_dir_all(&self.path)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to create storage directory: {}",
+                        self.path.display()
+                    )
+                })?;
+        }
+
+        let mut failed = BTreeMap::new();
+        let failed_map = tx_manager.failed.read().await;
+
+        for (tx_uuid, tx) in tx_manager.transactions.read().await.iter() {
+            self.write_tx(tx_uuid, tx).await?;
+            if let Some(reason) = failed_map.get(tx_uuid) {
+                failed.insert(*tx_uuid, reason.clone());
+            }
+        }
+
+        for (tx_uuid, tx) in tx_manager.completed.read().await.iter() {
+            self.write_tx(tx_uuid, tx).await?;
+        }
+
+        let mut failed_file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(self.path.join("failed"))
+            .await?;
+
+        let str = serde_json::to_string(&failed)
+            .with_context(|| "Failed to serialize failed transactions")?;
+
+        failed_file
+            .write_all(str.as_bytes())
+            .await
+            .with_context(|| "Failed to write failed transactions to file")?;
+
+        failed_file.flush().await?;
+
+        let merkle = tx_manager.merkle_roots.read().await;
+        let mut merkle_file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(self.path.join("merkle_roots"))
+            .await?;
+
+        let str =
+            serde_json::to_string(&*merkle).with_context(|| "Failed to serialize merkle roots")?;
+        merkle_file
+            .write_all(str.as_bytes())
+            .await
+            .with_context(|| "Failed to write merkle roots to file")?;
+        merkle_file.flush().await?;
+
+        self.block_storage.save(&self.path).await?;
+
+        Ok(())
+    }
+
+    async fn load(&self, tx_manager: &TransactionManager) -> anyhow::Result<()> {
+        if !self.path.exists() {
+            return Ok(());
+        }
+
+        let mut dir = tokio::fs::read_dir(&self.path).await?;
+
+        while let Some(entry) = dir.next_entry().await? {
+            if entry
+                .file_type()
+                .await
+                .context("directory entry is unaccessible")?
+                .is_file()
+            {
+                if entry.file_name().to_str() == Some("failed") {
+                    let contents = tokio::fs::read_to_string(entry.path())
+                        .await
+                        .context("Failed to read 'failed' transactions file")?;
+                    let map: BTreeMap<Uuid, String> = serde_json::from_str(&contents)
+                        .context("Failed to parse 'failed' transactions")?;
+                    tx_manager.failed.write().await.extend(map);
+                } else if entry.file_name().to_str() == Some("merkle_roots") {
+                    let contents = tokio::fs::read_to_string(entry.path())
+                        .await
+                        .context("Failed to read 'merkle_roots' file")?;
+                    let merkle: MerkleRoots = serde_json::from_str(&contents)
+                        .context("Failed to parse 'merkle_roots'")?;
+                    *tx_manager.merkle_roots.write().await = merkle;
+                } else if entry.file_name().to_str() == Some("blocks") {
+                } else {
+                    let tx = self.read_tx(entry.path(), entry.file_name()).await?;
+
+                    tx_manager.add_transaction(tx).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn save_blocks(&self) -> anyhow::Result<()> {
+        // Implement saving blocks logic here
+        Ok(())
+    }
+}

--- a/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
+++ b/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
@@ -1,0 +1,436 @@
+use ethereum_client::TxHash;
+use gear_rpc_client::dto::{MerkleProof, Message};
+use keccak_hash::keccak_256;
+use prometheus::IntCounter;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::sync::{mpsc::UnboundedReceiver, RwLock};
+use utils_prometheus::{impl_metered_service, MeteredService};
+use uuid::Uuid;
+
+use crate::message_relayer::{
+    common::{
+        ethereum::{
+            accumulator::{self, utils::MerkleRoots, AccumulatorIo},
+            message_sender::MessageSenderIo,
+            status_fetcher::{self, StatusFetcherIo},
+        },
+        gear::merkle_proof_fetcher::MerkleRootFetcherIo,
+        MessageInBlock, RelayedMerkleRoot,
+    },
+    gear_to_eth::storage::Storage,
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Transaction {
+    pub uuid: Uuid,
+    pub message: MessageInBlock,
+    pub message_hash: [u8; 32],
+    pub status: TxStatus,
+}
+
+impl Transaction {
+    pub fn new(message: MessageInBlock, status: TxStatus) -> Self {
+        let uuid = Uuid::now_v7();
+        Self {
+            uuid,
+            status,
+            message_hash: message_hash(&message.message),
+            message,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum TxStatus {
+    WaitForMerkleRoot,
+    FetchMerkleRoot(RelayedMerkleRoot),
+    SendMessage(RelayedMerkleRoot, MerkleProof),
+    WaitConfirmations(TxHash),
+    Completed,
+}
+
+impl_metered_service!(
+    struct Metrics {
+        total_transactions: IntCounter = IntCounter::new(
+            "eth_gear_transaction_manager_total_transactions",
+            "Total number of transactions processed by the transaction manager",
+        ),
+        completed_transactions: IntCounter = IntCounter::new(
+            "eth_gear_transaction_manager_completed_transactions",
+            "Total number of completed transactions",
+        ),
+        failed_transactions: IntCounter = IntCounter::new(
+            "eth_geartransaction_manager_failed_transactions",
+            "Total number of failed transactions",
+        ),
+    }
+);
+
+pub struct TransactionManager {
+    pub merkle_roots: Arc<RwLock<MerkleRoots>>,
+
+    pub transactions: RwLock<BTreeMap<Uuid, Transaction>>,
+    pub failed: RwLock<BTreeMap<Uuid, String>>,
+    pub completed: RwLock<BTreeMap<Uuid, Transaction>>,
+    pub storage: Arc<dyn Storage>,
+
+    metrics: Metrics,
+}
+
+impl MeteredService for TransactionManager {
+    fn get_sources(&self) -> impl IntoIterator<Item = Box<dyn prometheus::core::Collector>> {
+        self.metrics.get_sources()
+    }
+}
+
+impl TransactionManager {
+    pub fn new(storage: Arc<dyn Storage>) -> Self {
+        Self {
+            merkle_roots: Arc::new(RwLock::new(MerkleRoots::new(100))),
+            transactions: RwLock::new(BTreeMap::new()),
+            failed: RwLock::new(BTreeMap::new()),
+            completed: RwLock::new(BTreeMap::new()),
+            storage,
+
+            metrics: Metrics::new(),
+        }
+    }
+
+    pub async fn fail_transaction(&self, tx_uuid: Uuid, reason: String) {
+        self.failed.write().await.insert(tx_uuid, reason);
+        self.metrics.failed_transactions.inc();
+    }
+
+    pub async fn add_transaction(&self, tx: Transaction) {
+        self.metrics.total_transactions.inc();
+
+        match tx.status {
+            TxStatus::Completed => {
+                self.completed.write().await.insert(tx.uuid, tx.clone());
+                self.metrics.completed_transactions.inc();
+            }
+
+            _ => {
+                self.transactions.write().await.insert(tx.uuid, tx);
+            }
+        }
+    }
+
+    pub async fn update_storage(&self) {
+        if let Err(err) = self.storage.save(self).await {
+            log::error!("Failed to save transaction manager state: {err}");
+        }
+    }
+
+    async fn resume(
+        &self,
+        accumulator: &mut AccumulatorIo,
+        proof_fetcher: &mut MerkleRootFetcherIo,
+        message_sender: &mut MessageSenderIo,
+        status_fetcher: &mut StatusFetcherIo,
+    ) -> anyhow::Result<bool> {
+        let transactions = self.transactions.write().await;
+
+        for (_, tx) in transactions.iter() {
+            match tx.status {
+                TxStatus::WaitForMerkleRoot => {
+                    log::info!(
+                        "Transaction {}, nonce={} is waiting for merkle root",
+                        tx.uuid,
+                        hex::encode(&tx.message.message.nonce_le)
+                    );
+                    if !accumulator.send_message(
+                        tx.uuid,
+                        tx.message.authority_set_id,
+                        tx.message.block,
+                        tx.message.block_hash,
+                    ) {
+                        log::warn!("Accumulator stopped accepting messages, exiting");
+                        return Ok(false);
+                    }
+                }
+
+                TxStatus::FetchMerkleRoot(ref merkle_root) => {
+                    log::info!(
+                        "Transaction {}, nonce={} is fetching merkle root for block #{}",
+                        tx.uuid,
+                        hex::encode(&tx.message.message.nonce_le),
+                        merkle_root.block
+                    );
+                    if !proof_fetcher.send_request(
+                        tx.uuid,
+                        tx.message_hash,
+                        tx.message.message.nonce_le,
+                        merkle_root.clone(),
+                    ) {
+                        log::warn!("Merkle root fetcher stopped accepting requests, exiting");
+                        return Ok(false);
+                    }
+                }
+
+                TxStatus::SendMessage(ref relayed_merkle_root, ref proof) => {
+                    log::info!(
+                        "Transaction {}, nonce={} is being relayed with merkle root for block #{}",
+                        tx.uuid,
+                        hex::encode(&tx.message.message.nonce_le),
+                        relayed_merkle_root.block
+                    );
+                    if !message_sender.send(
+                        tx.message.message.clone(),
+                        relayed_merkle_root.clone(),
+                        proof.clone(),
+                        tx.uuid,
+                    ) {
+                        log::warn!("Message sender stopped accepting messages, exiting");
+                        return Ok(false);
+                    }
+                }
+
+                TxStatus::WaitConfirmations(tx_hash) => {
+                    log::info!(
+                        "Transaction {}, nonce={} is waiting for confirmations, tx_hash={}",
+                        tx.uuid,
+                        hex::encode(&tx.message.message.nonce_le),
+                        tx_hash
+                    );
+                    if !status_fetcher.send_request(tx.uuid, tx_hash) {
+                        log::warn!("Status fetcher stopped accepting requests, exiting");
+                        return Ok(false);
+                    }
+                }
+
+                TxStatus::Completed => {
+                    // Completed transactions do not need to be resumed
+                    continue;
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    pub async fn run(
+        self,
+        mut accumulator: AccumulatorIo,
+        mut queued_messages: UnboundedReceiver<MessageInBlock>,
+        mut proof_fetcher: MerkleRootFetcherIo,
+        mut message_sender: MessageSenderIo,
+        mut status_fetcher: StatusFetcherIo,
+    ) -> anyhow::Result<()> {
+        if let Err(err) = self.storage.load(&self).await {
+            log::warn!("Failed to load transaction manager state: {err}");
+        }
+
+        if !self
+            .resume(
+                &mut accumulator,
+                &mut proof_fetcher,
+                &mut message_sender,
+                &mut status_fetcher,
+            )
+            .await?
+        {
+            log::warn!("Failed to resume transaction manager, exiting");
+            return Ok(());
+        }
+
+        loop {
+            let result = self
+                .process(
+                    &mut accumulator,
+                    &mut queued_messages,
+                    &mut proof_fetcher,
+                    &mut message_sender,
+                    &mut status_fetcher,
+                )
+                .await;
+
+            self.update_storage().await;
+
+            match result {
+                Ok(false) => {
+                    log::warn!("No new transactions to process, exiting");
+                    break;
+                }
+
+                Ok(true) => continue,
+                Err(err) => {
+                    log::error!("Transaction manager error: {err}");
+                    return Err(err);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn process(
+        &self,
+        accumulator: &mut AccumulatorIo,
+        queued_messages: &mut UnboundedReceiver<MessageInBlock>,
+        proof_fetcher: &mut MerkleRootFetcherIo,
+        message_sender: &mut MessageSenderIo,
+        status_fetcher: &mut StatusFetcherIo,
+    ) -> anyhow::Result<bool> {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                log::info!("Received Ctrl+C signal, exiting");
+                return Ok(false);
+            }
+
+            message = queued_messages.recv() => {
+                let Some(message) = message else {
+                    log::info!("No more messages to process, exiting");
+                    return Ok(false);
+                };
+
+                let tx = Transaction::new(message, TxStatus::WaitForMerkleRoot);
+
+                let block_hash = tx.message.block_hash;
+                let authority_set_id = tx.message.authority_set_id;
+                let block = tx.message.block;
+                let uuid = tx.uuid;
+
+                self.add_transaction(tx).await;
+
+                if !accumulator.send_message(uuid, authority_set_id, block, block_hash) {
+                    log::warn!("Failed to send message to accumulator, exiting");
+                    return Ok(false);
+                }
+            }
+
+            message = accumulator.recv_message() => {
+                let Some(message) = message else {
+                    log::info!("No more messages from accumulator, exiting");
+                    return Ok(false);
+                };
+
+                match message {
+                    accumulator::Response::Success { tx_uuid, merkle_root, ..} => {
+                        if let Some(tx) = self.transactions.write().await.get_mut(&tx_uuid) {
+                            tx.status = TxStatus::FetchMerkleRoot(merkle_root.clone());
+                            if !proof_fetcher.send_request(
+                                tx_uuid,
+                                tx.message_hash,
+                                tx.message.message.nonce_le,
+                                merkle_root,
+                            ) {
+                                log::warn!("Merkle root fetcher stopped accepting requests, exiting");
+                                return Ok(false);
+                            }
+                        } else {
+                            log::warn!("Received success response for unknown transaction: {tx_uuid}");
+                        }
+                    }
+
+                    accumulator::Response::Overflowed(message) => {
+                        self.fail_transaction(message.tx_uuid, "Message overflowed".to_string()).await;
+                    }
+
+                    accumulator::Response::Stuck { tx_uuid, .. } => {
+
+                        self.fail_transaction(tx_uuid, "Message stuck".to_string()).await;
+                    }
+                }
+            }
+
+            message = proof_fetcher.recv_message() => {
+                let Some(message) = message else {
+                    log::info!("No more messages from proof fetcher, exiting");
+                    return Ok(false);
+                };
+
+                if let Some(tx) = self.transactions.write().await.get_mut(&message.tx_uuid) {
+                    tx.status = TxStatus::SendMessage(
+                        message.merkle_root.clone(),
+                        message.proof.clone(),
+                    );
+
+                    if !message_sender.send(
+                        tx.message.message.clone(),
+                        message.merkle_root,
+                        message.proof,
+                        tx.uuid,
+                    ) {
+                        log::warn!("Message sender stopped accepting messages, exiting");
+                        return Ok(false);
+                    }
+                } else {
+                    log::warn!("Received merkle proof for unknown transaction: {}", message.tx_uuid);
+                }
+            }
+
+            message = message_sender.recv() => {
+                let Some(message) = message else {
+                    log::info!("No more messages from message sender, exiting");
+                    return Ok(false);
+                };
+
+                if let Some(tx) = self.transactions.write().await.get_mut(&message.tx_uuid) {
+                    tx.status = TxStatus::WaitConfirmations(message.tx_hash);
+                } else {
+                    log::warn!("Received message for unknown transaction: {}", message.tx_uuid);
+                }
+
+                if !status_fetcher.send_request(message.tx_uuid, message.tx_hash) {
+                    log::warn!("Status fetcher stopped accepting requests, exiting");
+                    return Ok(false);
+                }
+            }
+
+            message = status_fetcher.recv_message() => {
+                let Some(status) = message else {
+                    log::info!("No more messages from status fetcher, exiting");
+                    return Ok(false);
+                };
+
+                match status {
+                    status_fetcher::Response::Success(uuid, tx_hash) => {
+                        if let Some(tx) = self.transactions.write().await.remove(&uuid) {
+                            let completed_tx = Transaction {
+                                uuid,
+                                message: tx.message,
+                                message_hash: tx.message_hash,
+                                status: TxStatus::Completed,
+                            };
+                            self.completed.write().await.insert(uuid, completed_tx);
+                            self.metrics.completed_transactions.inc();
+
+                            log::info!(
+                                "Transaction {uuid} completed successfully: tx_hash = {tx_hash}"
+                            );
+                        } else {
+                            log::warn!("Received success response for unknown transaction: {uuid}");
+                        }
+                    }
+
+                    status_fetcher::Response::Failed(uuid, e) => {
+                        if let Some(tx) = self.transactions.write().await.remove(&uuid) {
+                            self.fail_transaction(uuid, e.to_string()).await;
+                            let nonce = hex::encode(&tx.message.message.nonce_le);
+                            log::error!("Transaction {uuid}, nonce={nonce} failed: {e}", );
+                        } else {
+                            log::warn!("Received failure response for unknown transaction: {uuid}");
+                        }
+                    }
+                }
+            }
+        }
+        Ok(true)
+    }
+}
+
+fn message_hash(message: &Message) -> [u8; 32] {
+    let data = [
+        message.nonce_le.as_ref(),
+        message.source.as_ref(),
+        message.destination.as_ref(),
+        message.payload.as_ref(),
+    ]
+    .concat();
+
+    let mut hash = [0; 32];
+    keccak_256(&data, &mut hash);
+
+    hash
+}

--- a/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
+++ b/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
@@ -123,6 +123,10 @@ impl TransactionManager {
         }
     }
 
+    pub async fn load_from_storage(&self) -> anyhow::Result<()> {
+        self.storage.load(self).await
+    }
+
     async fn resume(
         &self,
         accumulator: &mut AccumulatorIo,
@@ -218,10 +222,6 @@ impl TransactionManager {
         mut message_sender: MessageSenderIo,
         mut status_fetcher: StatusFetcherIo,
     ) -> anyhow::Result<()> {
-        if let Err(err) = self.storage.load(&self).await {
-            log::warn!("Failed to load transaction manager state: {err}");
-        }
-
         if !self
             .resume(
                 &mut accumulator,


### PR DESCRIPTION
Resolves #420.

Refactored gear-eth relayer which makes it error prone: if some component fails, and relayer is forced to restart it does not cause transactions to be lost and does not require manually relaying them. 

## TODO
- Add block storage: at the moment, if block was not yet processed transaction in it might be lost, save unprocessed
  blocks to storage to fix this.