### PR TITLE
fix: update `cc` to `1.2.34` to fix `rust-analyzer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "jobserver",
  "libc",


### PR DESCRIPTION
new version of `cc` has patch that allows it to work correctly with `clang-20`
this should also fix `rust-analyzer` on linux