### PR TITLE
refactor(relayer): add queue ID  and corresponding message nonces to merkle-roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9904,6 +9904,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "historical-proxy-client",
+ "humantime",
  "keccak-hash 0.10.0",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ clap = { version = "4.5.41", features = ["derive", "env"] }
 derive_more = "0.99.17"
 dotenv = "0.15.0"
 env_logger = "0.9.0"
+humantime = "2.2.0"
 ethereum-types = { version = "0.14.1", default-features = false, features = [
     "serialize",
     "codec",

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -31,6 +31,7 @@ ethereum-common.workspace = true
 futures.workspace = true
 gear-core.workspace = true
 gclient.workspace = true
+humantime.workspace = true
 hex.workspace = true
 keccak-hash.workspace = true
 lazy_static.workspace = true

--- a/relayer/src/cli/mod.rs
+++ b/relayer/src/cli/mod.rs
@@ -67,6 +67,22 @@ pub struct GearEthCoreArgs {
     /// Authority set id to start relaying from. If not specified equals to one from the latest finalized block
     #[arg(long, env = "START_AUTHORITY_SET_ID")]
     pub start_authority_set_id: Option<u64>,
+
+    #[arg(
+        help = "Spike window used to cutoff old events to not trigger false spikes",
+        value_parser = humantime::parse_duration, default_value="15m")]
+    pub spike_window: Duration,
+    #[arg(
+        help = "Timeout after which we start processing events",
+        value_parser = humantime::parse_duration, default_value="30m"
+    )]
+    pub spike_timeout: Duration,
+    #[arg(
+        help = "After threshold is reached we enter \"spike\" mode
+        where events are processed immediately",
+        default_value = "8"
+    )]
+    pub spike_threshold: usize,
 }
 
 #[derive(Args)]

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -66,10 +66,12 @@ impl Relayer {
         genesis_config: GenesisConfig,
         last_sealed: Option<u64>,
         confirmations: u64,
+        spike_config: SpikeConfig,
     ) -> Self {
         let block_listener = BlockListener::new(api_provider.clone(), storage.clone());
 
-        let merkle_roots = MerkleRootRelayer::new(api_provider.clone(), storage.clone()).await;
+        let merkle_roots =
+            MerkleRootRelayer::new(api_provider.clone(), storage.clone(), spike_config).await;
 
         let authority_set_sync = authority_set_sync::AuthoritySetSync::new(
             api_provider.clone(),
@@ -141,15 +143,26 @@ pub struct MerkleRootRelayer {
     waiting_for_authority_set_sync: BTreeMap<u64, Vec<GearBlock>>,
 
     save_interval: Interval,
+
+    main_interval: Interval,
+    spike: SpikeConfig,
+    first_pending_timestamp: Option<Instant>,
+
+    queued_root_timestamps: VecDeque<Instant>,
+    merkle_root_batch: Vec<PendingMerkleRoot>,
 }
 
 impl MerkleRootRelayer {
     pub async fn new(
         api_provider: ApiProviderConnection,
         storage: Arc<MerkleRootStorage>,
+        spike_config: SpikeConfig,
     ) -> MerkleRootRelayer {
         let mut save_interval = tokio::time::interval(Duration::from_secs(60));
         save_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        let mut main_interval = tokio::time::interval(Duration::from_secs(15));
+        main_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         MerkleRootRelayer {
             api_provider,
@@ -160,6 +173,26 @@ impl MerkleRootRelayer {
             waiting_for_authority_set_sync: BTreeMap::new(),
 
             save_interval,
+
+            main_interval,
+
+            spike: spike_config,
+            first_pending_timestamp: None,
+
+            queued_root_timestamps: VecDeque::with_capacity(8),
+            merkle_root_batch: Vec::with_capacity(8),
+        }
+    }
+
+    fn prune_old_timestamps(&mut self) {
+        let cutoff_time = Instant::now() - self.spike.window;
+
+        while let Some(&timestamp) = self.queued_root_timestamps.front() {
+            if timestamp < cutoff_time {
+                self.queued_root_timestamps.pop_front();
+            } else {
+                break;
+            }
         }
     }
 
@@ -201,107 +234,99 @@ impl MerkleRootRelayer {
         let gear_api = self.api_provider.client();
 
         for (hash, merkle_root) in roots.drain() {
+            let block_number = merkle_root.block_number;
+            let block_hash = merkle_root.block_hash;
+
+            let mut reinstate = |status: MerkleRootStatus| {
+                self.roots.insert(
+                    hash,
+                    MerkleRoot {
+                        queue_id: 0,
+                        block_number,
+                        block_hash,
+                        status,
+                        message_nonces: Vec::new(),
+                    },
+                );
+            };
+
             match &merkle_root.status {
                 // most likely will need to wait for era sealing rather than authority set sync
                 MerkleRootStatus::WaitForAuthoritySetSync(id, _) => {
                     log::info!(
-                        "Merkle root {} for block #{} is waiting for authority set sync with id {}",
-                        hash,
-                        merkle_root.block_number,
-                        id
+                        "Merkle root {hash} for block #{block_number} is waiting for authority set sync with id {id}"
                     );
 
-                    let block = gear_api.get_block_at(merkle_root.block_hash).await?;
+                    let block = gear_api.get_block_at(block_hash).await?;
                     let block = GearBlock::from_subxt_block(block).await?;
 
-                    let authority_set_proof = self
+                    match self
                         .storage
                         .proofs
                         .get_proof_for_authority_set_id(*id)
-                        .await;
-                    if let Ok(authority_set_proof) = authority_set_proof {
-                        self.roots.insert(
-                            hash,
-                            MerkleRoot {
-                                block_number: merkle_root.block_number,
-                                block_hash: merkle_root.block_hash,
-                                status: MerkleRootStatus::GenerateProof,
-                            },
-                        );
-                        if !prover.prove(
-                            merkle_root.block_number,
-                            merkle_root.block_hash,
-                            hash,
-                            authority_set_proof,
-                        ) {
-                            log::error!("Prover connection closed, exiting...");
-                            return Ok(());
+                        .await
+                    {
+                        Ok(authority_set_proof) => {
+                            reinstate(MerkleRootStatus::GenerateProof);
+
+                            if !prover.prove(
+                                block_number,
+                                block_hash,
+                                hash,
+                                authority_set_proof,
+                                merkle_root.queue_id,
+                            ) {
+                                log::error!("Prover connection closed, exiting...");
+                                return Ok(());
+                            }
                         }
-                    } else {
-                        log::warn!(
-                            "Authority set proof for #{id} not found, waiting for authority set sync",
-                        );
-                        self.roots.insert(
-                            hash,
-                            MerkleRoot {
-                                block_number: merkle_root.block_number,
-                                block_hash: merkle_root.block_hash,
-                                status: MerkleRootStatus::WaitForAuthoritySetSync(
-                                    *id,
-                                    block.number(),
-                                ),
-                            },
-                        );
+                        Err(_) => {
+                            log::warn!("Authority set proof for #{id} not found, waiting for authority set sync");
 
-                        // if authority set is older than last sealed era we need to seal this
-                        // authority set first.
-                        if *id <= last_sealed {
-                            last_sealed = *id - 1;
+                            reinstate(MerkleRootStatus::WaitForAuthoritySetSync(
+                                *id,
+                                block.number(),
+                            ));
+
+                            // if authority set is older than last sealed era we need to seal this
+                            // authority set first.
+                            if *id <= last_sealed {
+                                last_sealed = *id - 1;
+                            }
+
+                            let force_sync = self
+                                .storage
+                                .proofs
+                                .get_latest_authority_set_id()
+                                .await
+                                .map_or(false, |latest| *id > latest)
+                                && *id > last_sealed;
+
+                            self.waiting_for_authority_set_sync
+                                .entry(*id)
+                                .or_insert_with(|| {
+                                    if force_sync {
+                                        authority_set_sync.send(block.clone());
+                                    }
+                                    Vec::new()
+                                })
+                                .push(block);
                         }
-
-                        let force_sync = self
-                            .storage
-                            .proofs
-                            .get_latest_authority_set_id()
-                            .await
-                            .filter(|latest| *id > *latest)
-                            .is_some()
-                            && *id > last_sealed;
-
-                        self.waiting_for_authority_set_sync
-                            .entry(*id)
-                            .or_insert_with(|| {
-                                if force_sync {
-                                    authority_set_sync.send(block.clone());
-                                }
-                                Vec::new()
-                            })
-                            .push(block);
                     }
                 }
 
                 MerkleRootStatus::GenerateProof => {
-                    self.roots.insert(
-                        hash,
-                        MerkleRoot {
-                            block_number: merkle_root.block_number,
-                            block_hash: merkle_root.block_hash,
-                            status: MerkleRootStatus::GenerateProof,
-                        },
-                    );
+                    reinstate(MerkleRootStatus::GenerateProof);
 
                     log::info!(
-                        "Merkle root {} for block #{} is waiting for proof generation",
-                        hash,
-                        merkle_root.block_number
+                        "Merkle root {hash} for block #{block_number} is waiting for proof generation"
                     );
 
                     // if merkle root was saved in `generate proof` phase, it means
                     // that proof for authority set id is already generated and thus should be available in storage.
                     // If it is not found that is a hard error and storage should be fixed.
-                    let signed_by_authority_set_id = gear_api
-                        .signed_by_authority_set_id(merkle_root.block_hash)
-                        .await?;
+                    let signed_by_authority_set_id =
+                        gear_api.signed_by_authority_set_id(block_hash).await?;
                     let inner_proof = self
                         .storage
                         .proofs
@@ -310,10 +335,11 @@ impl MerkleRootRelayer {
                         .with_context(|| format!("Proof for authority set #{signed_by_authority_set_id} not found, please clean-up your storage and restart relayer"))?;
 
                     if !prover.prove(
-                        merkle_root.block_number,
-                        merkle_root.block_hash,
+                        block_number,
+                        block_hash,
                         hash,
                         inner_proof,
+                        merkle_root.queue_id,
                     ) {
                         log::error!("Prover connection closed, exiting...");
                         return Ok(());
@@ -322,60 +348,27 @@ impl MerkleRootRelayer {
 
                 MerkleRootStatus::SubmitProof(proof) => {
                     log::info!(
-                        "Merkle root {} for block #{} is waiting for proof submission",
-                        hash,
-                        merkle_root.block_number
+                        "Merkle root {hash} for block #{block_number} is waiting for proof submission"
                     );
 
-                    self.roots.insert(
-                        hash,
-                        MerkleRoot {
-                            block_number: merkle_root.block_number,
-                            block_hash: merkle_root.block_hash,
-                            status: MerkleRootStatus::SubmitProof(proof.clone()),
-                        },
-                    );
+                    reinstate(MerkleRootStatus::SubmitProof(proof.clone()));
 
-                    if !submitter.submit_merkle_root(merkle_root.block_number, hash, proof.clone())
-                    {
+                    if !submitter.submit_merkle_root(block_number, hash, proof.clone()) {
                         log::error!("Proof submitter connection closed, exiting");
                         return Ok(());
                     }
                 }
 
-                MerkleRootStatus::Failed(ref err) => {
-                    self.roots.insert(
-                        hash,
-                        MerkleRoot {
-                            block_number: merkle_root.block_number,
-                            block_hash: merkle_root.block_hash,
-                            status: MerkleRootStatus::Failed(err.clone()),
-                        },
-                    );
+                MerkleRootStatus::Failed(err) => {
+                    reinstate(MerkleRootStatus::Failed(err.clone()));
 
-                    log::error!(
-                        "Merkle root {} for block #{} failed: {}",
-                        hash,
-                        merkle_root.block_number,
-                        err
-                    );
+                    log::error!("Merkle root {hash} for block #{block_number} failed: {err}");
                 }
 
                 MerkleRootStatus::Finalized => {
-                    self.roots.insert(
-                        hash,
-                        MerkleRoot {
-                            block_number: merkle_root.block_number,
-                            block_hash: merkle_root.block_hash,
-                            status: MerkleRootStatus::Finalized,
-                        },
-                    );
+                    reinstate(MerkleRootStatus::Finalized);
 
-                    log::info!(
-                        "Merkle root {} for block #{} is finalized",
-                        hash,
-                        merkle_root.block_number
-                    );
+                    log::info!("Merkle root {hash} for block #{block_number} is finalized");
                 }
             }
         }
@@ -487,10 +480,37 @@ impl MerkleRootRelayer {
                 }
             }
 
+            _ = self.main_interval.tick() => {
+                // prune old timestamps to not trigger spike when not necessary
+                self.prune_old_timestamps();
+
+                let is_spike = self.merkle_root_batch.iter().map(|root| root.nonces_count).sum::<usize>() >= self.spike.threshold;
+                let is_timeout = self.first_pending_timestamp
+                    .is_some_and(|t| t.elapsed() >= self.spike.timeout);
+
+                if is_spike || is_timeout {
+                    let batch_size = self.merkle_root_batch.len();
+                    log::info!("Triggering proof generation. Batch size: {batch_size}, Reason: Spike={is_spike}, Timeout={is_timeout}");
+                    // do not group blocks by authority set id, prover will do this for us.
+                    for pending in self.merkle_root_batch.drain(..) {
+                        if !prover.prove(
+                            pending.block_number,
+                            pending.block_hash,
+                            pending.merkle_root,
+                            pending.inner_proof,
+                            pending.queue_id,
+                        ) {
+                            log::warn!("Prover connection closed, exiting");
+                            return Ok(false);
+                        }
+                    }
+                }
+            }
+
             block = blocks_rx.recv() => {
                 match block {
                     Ok(block) => {
-                        if !self.try_proof_merkle_root(prover, authority_set_sync, block).await? {
+                        if !self.try_proof_merkle_root(prover, authority_set_sync, block, true).await? {
                             return Ok(false);
                         }
                     }
@@ -595,7 +615,7 @@ impl MerkleRootRelayer {
 
                         log::info!("Authority set #{id} is synced, submitting {} blocks", to_submit.len());
                         while let Some(block) = to_submit.pop() {
-                            if !self.try_proof_merkle_root(prover, authority_set_sync, block).await? {
+                            if !self.try_proof_merkle_root(prover, authority_set_sync, block, false).await? {
                                 return Ok(false);
                             }
                         }
@@ -664,10 +684,17 @@ impl MerkleRootRelayer {
         prover: &mut FinalityProverIo,
         authority_set_sync: &mut AuthoritySetSyncIo,
         block: GearBlock,
+        batch: bool,
     ) -> anyhow::Result<bool> {
         let Some(merkle_root) = storage::queue_merkle_root_changed(&block) else {
             return Ok(true);
         };
+
+        // TODO: Wait for @breathx to finish his pallet-eth-bridge refactor.
+        let queue_id = 0;
+
+        let nonces = storage::message_queued_events_of(&block).collect::<Vec<_>>();
+
         // mark root processed so that we don't process the entire block again.
         self.storage.merkle_root_processed(block.number()).await;
 
@@ -699,17 +726,40 @@ impl MerkleRootRelayer {
             .await
         {
             Ok(inner_proof) => {
-                let number = block.number();
+                let block_number = block.number();
+                let block_hash = block.hash();
+                let nonces_count = nonces.len();
                 self.roots.insert(
                     merkle_root,
                     MerkleRoot {
-                        block_number: number,
-                        block_hash: block.hash(),
+                        queue_id: 0,
+                        block_number,
+                        block_hash,
                         status: MerkleRootStatus::GenerateProof,
+                        message_nonces: nonces,
                     },
                 );
+                if batch {
+                    let now = Instant::now();
+
+                    if self.merkle_root_hash.is_empty() {
+                        self.first_pending_timestamp = Some(now);
+                    }
+
+                    log::info!("Merkle-root #{merkle_root} at block #{block_number} is enqueued for batch processing");
+
+                    self.queued_root_timestamps.push_back(now);
+                    self.merkle_root_batch.push(PendingMerkleRoot {
+                        block_hash,
+                        block_number,
+                        merkle_root,
+                        inner_proof,
+                        nonces_count: nonces_count,
+                    });
+                    return Ok(true);
+                }
                 log::info!("Proof for authority set #{signed_by_authority_set_id} is found, generating proof for merkle-root {merkle_root} at block #{number}");
-                if !prover.prove(block.number(), block.hash(), merkle_root, inner_proof) {
+                if !prover.prove(block_number, block_hash, merkle_root, inner_proof, queue_id) {
                     log::error!("Prover connection closed, exiting...");
                     return Ok(false);
                 }
@@ -725,12 +775,14 @@ impl MerkleRootRelayer {
                 self.roots.insert(
                     merkle_root,
                     MerkleRoot {
+                        queue_id: 0,
                         block_number: block.number(),
                         block_hash: block.hash(),
                         status: MerkleRootStatus::WaitForAuthoritySetSync(
                             signed_by_authority_set_id,
                             block.number(),
                         ),
+                        message_nonces: nonces,
                     },
                 );
 
@@ -757,9 +809,11 @@ impl MerkleRootRelayer {
                 self.roots.insert(
                     merkle_root,
                     MerkleRoot {
+                        queue_id: 0,
                         block_number: block.number(),
                         block_hash: block.hash(),
                         status: MerkleRootStatus::Failed(err.to_string()),
+                        message_nonces: nonces,
                     },
                 );
                 log::error!(
@@ -777,6 +831,8 @@ impl MerkleRootRelayer {
 pub struct MerkleRoot {
     pub block_number: u32,
     pub block_hash: H256,
+    pub queue_id: u64,
+    pub message_nonces: Vec<[u8; 32]>,
     pub status: MerkleRootStatus,
 }
 
@@ -787,4 +843,35 @@ pub enum MerkleRootStatus {
     SubmitProof(FinalProof),
     Finalized,
     Failed(String),
+}
+
+pub struct SpikeConfig {
+    /// Timeout after which we start relaying merkle-root
+    pub timeout: Duration,
+    /// Spike window, used to cutoff old merkle-roots
+    pub window: Duration,
+    /// Spike threshold: after threshold is reached we enter "spike"
+    /// mode where proofs are generated immediately.
+    pub threshold: usize,
+}
+
+impl Default for SpikeConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(30 * 60),
+            window: Duration::from_secs(15 * 60),
+            threshold: 8,
+        }
+    }
+}
+
+pub struct PendingMerkleRoot {
+    pub block_hash: H256,
+    pub block_number: u32,
+    pub merkle_root: H256,
+    pub inner_proof: ProofWithCircuitData,
+    /// Number of message nonces that are being bridged to Ethereum.
+    ///
+    /// Used to check for spike.
+    pub nonces_count: usize,
 }

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use crate::{
@@ -18,6 +18,7 @@ pub struct Request {
     pub block_number: u32,
     pub block_hash: H256,
     pub merkle_root: H256,
+    pub queue_id: u64,
     pub inner_proof: ProofWithCircuitData,
 }
 
@@ -60,6 +61,7 @@ impl FinalityProverIo {
         block_hash: H256,
         merkle_root: H256,
         inner_proof: ProofWithCircuitData,
+        queue_id: u64,
     ) -> bool {
         self.requests
             .send(Request {
@@ -67,6 +69,7 @@ impl FinalityProverIo {
                 block_hash,
                 merkle_root,
                 inner_proof,
+                queue_id,
             })
             .is_ok()
     }
@@ -117,57 +120,70 @@ impl FinalityProver {
     ) -> anyhow::Result<()> {
         let gear_api = self.api_provider.client();
 
-        // ~13 minutes worth of blocks
-        // Why 13 minutes aka 256 blocks? Under heavy load (many merkle-root changes == many finality proof requests)
-        // we don't want to generate proof for every single request since it would suffice to generate
-        // the proof for the latest block in each authority set and use it for all blocks
-        // in that set.
-        const BATCH_SIZE: usize = 256;
+        // Batch size which is equal approximately to 2 full queues.
+        const BATCH_SIZE: usize = 2048;
 
         let mut batch_vec = Vec::with_capacity(BATCH_SIZE);
-        // Group requests by authority set ID, storing all blocks for each set
-        let mut authority_groups: HashMap<u64, BatchProofRequest> = HashMap::new();
+        // Group requests by authority set ID and queue ID, storing all blocks for each set
+        let mut request_groups: HashMap<(u64, u64), BatchProofRequest> = HashMap::new();
 
         loop {
+            // Receives messages into `batch_vec` but has one big downside requiring another `recv_many`
+            // down below: will receive only one element first *and* only then will receive the full batch.
             let n = requests.recv_many(&mut batch_vec, BATCH_SIZE).await;
             if n == 0 {
                 log::info!("Requests channel closed, exiting");
                 break;
             }
 
-            if n == 1 {
-                log::info!("Only one request received, processing it immediately");
-                let request = batch_vec.pop().unwrap();
-                let proof = self
-                    .generate_proof(
-                        &gear_api,
-                        request.block_number,
-                        request.block_hash,
-                        request.merkle_root,
-                        request.inner_proof,
-                    )
-                    .await?;
+            let n = if n == 1 {
+                // attempt to receive more requests in 10 second timeout.
+                let rest = tokio::time::timeout(
+                    Duration::from_secs(10),
+                    requests.recv_many(&mut batch_vec, BATCH_SIZE - 1),
+                )
+                .await;
+                match rest {
+                    Err(_) => {
+                        log::info!("Only one request received, processing it immediately");
+                        let request = batch_vec.pop().unwrap();
+                        let proof = self
+                            .generate_proof(
+                                &gear_api,
+                                request.block_number,
+                                request.block_hash,
+                                request.merkle_root,
+                                request.inner_proof,
+                            )
+                            .await?;
 
-                if responses
-                    .send(Response::Single {
-                        block_number: request.block_number,
-                        merkle_root: request.merkle_root,
-                        proof,
-                    })
-                    .is_err()
-                {
-                    log::warn!("Response channel closed, exiting");
-                    return Ok(());
+                        if responses
+                            .send(Response::Single {
+                                block_number: request.block_number,
+                                merkle_root: request.merkle_root,
+                                proof,
+                            })
+                            .is_err()
+                        {
+                            log::warn!("Response channel closed, exiting");
+                            return Ok(());
+                        }
+
+                        continue;
+                    }
+
+                    // received more requests, process them in batch
+                    Ok(rest) => rest + 1,
                 }
-
-                continue;
-            }
+            } else {
+                n
+            };
 
             log::info!("Received {n} requests, grouping by authority set...");
 
             for request in batch_vec.drain(..) {
                 let authority_set_id = gear_api.authority_set_id(request.block_hash).await?;
-                match authority_groups.entry(authority_set_id) {
+                match request_groups.entry((authority_set_id, request.queue_id)) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().add_request(request);
                     }
@@ -177,13 +193,14 @@ impl FinalityProver {
                 }
             }
 
-            for (authority_set_id, request) in authority_groups.drain() {
+            for ((authority_set_id, queue_id), request) in request_groups.drain() {
                 let BatchProofRequest {
                     block_number,
                     block_hash,
                     merkle_root,
                     inner_proof,
                     batch_roots,
+                    queue_id,
                 } = request;
                 log::info!(
                     "Proving finality for latest block #{block_number} with authority set #{authority_set_id} and merkle-root {merkle_root} (will apply to {} blocks)",
@@ -247,7 +264,7 @@ struct BatchProofRequest {
     block_hash: H256,
     merkle_root: H256,
     inner_proof: ProofWithCircuitData,
-
+    queue_id: u64,
     batch_roots: Vec<H256>,
 }
 
@@ -259,6 +276,7 @@ impl BatchProofRequest {
             merkle_root: init.merkle_root,
             inner_proof: init.inner_proof,
             batch_roots: Vec::new(),
+            queue_id: init.queue_id,
         }
     }
 

--- a/relayer/src/merkle_roots/storage.rs
+++ b/relayer/src/merkle_roots/storage.rs
@@ -48,6 +48,15 @@ pub(super) fn queue_merkle_root_changed(block: &GearBlock) -> Option<H256> {
     })
 }
 
+pub(super) fn message_queued_events_of(block: &GearBlock) -> impl Iterator<Item = [u8; 32]> {
+    block.events().iter().filter_map(|event| match event {
+        gclient::Event::GearEthBridge(GearEthBridgeEvent::MessageQueued { message, .. }) => {
+            Some(message.nonce)
+        }
+        _ => None,
+    })
+}
+
 pub(super) fn authority_set_changed(block: &GearBlock) -> bool {
     block
         .events()


### PR DESCRIPTION
@gshep, @breathx 

- Added queue ID to merkle-roots which allows them to batch more effectively and also supports resetting the queue mid processing. 
- Merkle-root now also stores nonces of messages being relayed to Ethereum. At the moment only used for spike detection (superseeds #558). In the future can be used to implement priority proof generation (superseeds #564)