### PR TITLE
fix(relayer): remove unecessary check for merkle-root generation

### DIFF
--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -790,9 +790,7 @@ impl MerkleRootRelayer {
             log::error!("Failed to save block storage state: {err:?}");
         }
 
-        if self.roots.contains_key(&merkle_root)
-            || self.storage.is_merkle_root_submitted(merkle_root).await
-        {
+        if self.storage.is_merkle_root_submitted(merkle_root).await {
             log::info!(
                 "Skipping merkle root {} for block #{} as there were no new messages",
                 merkle_root,


### PR DESCRIPTION
After batching was introduced `self.roots.contains()` in `try_proof_merkle_proof` is not necessary anymore due to the fact that roots are checked appropriately when sending to prover. This check still could be triggered by roots in `WaitForAuthoritySetSync` state since they are not batched and still are stored in merkle_roots map. 