### PR TITLE
fix(relayer): send AuthoritySetSynced response for every step

### DIFF
--- a/relayer/src/merkle_roots/authority_set_sync.rs
+++ b/relayer/src/merkle_roots/authority_set_sync.rs
@@ -218,7 +218,7 @@ impl AuthoritySetSync {
 
         log::info!("Syncing authority set #{authority_set_id}");
         loop {
-            let (sync_steps, _) = match blocks.recv().await {
+            let (sync_steps, authority_set_id) = match blocks.recv().await {
                 Ok(block) => self.sync_authority_set(&block).await?,
 
                 Err(RecvError::Closed) => {
@@ -233,6 +233,13 @@ impl AuthoritySetSync {
                     continue;
                 }
             };
+
+            responses
+                .send(Response::AuthoritySetSynced(
+                    authority_set_id,
+                    block.number(),
+                ))
+                .ok();
 
             if sync_steps == 0 {
                 break;


### PR DESCRIPTION
Fixes the bug which can occur when relayer is too far behind from synced authrotiy set *or* forced sync of authority set for specific block and there might be multiple steps of synchronization e.g when forced set #120, but relayer itself is on set #110, it would completely ignore sending `AuthoritySetSynced` for blocks 110..120