### PR TITLE
fix(relayer): fetch finality proof for blocks

### DIFF
--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -1041,19 +1041,18 @@ impl MerkleRootRelayer {
             .map(|root| (root.block_finality_hash, root.block_finality_proof.clone()))
         {
             Some((hash, proof)) => (hash, proof),
-            None => {
-                self.api_provider
-                    .client()
-                    .fetch_finality_proof(block.hash())
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "Failed to fetch finality proof for block #{} with merkle-root {}",
-                            block.number(),
-                            merkle_root
-                        )
-                    })?
-            }
+            None => self
+                .api_provider
+                .client()
+                .fetch_finality_proof(block.hash())
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to fetch finality proof for block #{} with merkle-root {}",
+                        block.number(),
+                        merkle_root
+                    )
+                })?,
         };
 
         let nonces = storage::message_queued_events_of(&block).collect::<Vec<_>>();


### PR DESCRIPTION
In case of authority set sync being too slow merkle-roots might be piled up for proof generation . Once authority set is synchronized these blocks would get latest finality proof for *authority set* rather than for block they were appeared first. 