### PR TITLE
refactor(relayer): better batching of priority requests

### DIFF
--- a/relayer/src/cli/mod.rs
+++ b/relayer/src/cli/mod.rs
@@ -86,6 +86,12 @@ pub struct GearEthCoreArgs {
     )]
     pub spike_timeout: Duration,
     #[arg(
+        help = "Timeout after which we start processing events if there is at least one priority event",
+        value_parser = humantime::parse_duration, default_value="10m"
+    )]
+    pub priority_spike_timeout: Duration,
+
+    #[arg(
         help = "After threshold is reached we enter \"spike\" mode
         where events are processed immediately",
         default_value = "8"


### PR DESCRIPTION
Adds a better batching of priority requests. Instead of instantly generating proof for priority request thus killing ability to batch them, changes timeout of processing from 30m to 5m for pending request queue if it has any priority request. 