### PR TITLE
refactor(gear-rpc-client): use gsdk storage instead of hardcoded keys

### DIFF
--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -12,7 +12,6 @@ use dto::{AuthoritySetState, BranchNodeData};
 use futures_util::{Stream, StreamExt};
 use gsdk::{
     metadata::{
-        errors::Gear,
         gear::Event as GearEvent,
         gear_eth_bridge::Event as GearBridgeEvent,
         runtime_types::{gear_core::message::user::UserMessage, gprimitives::ActorId},


### PR DESCRIPTION
Resolves #691 
