### PR TITLE
fix(relayer): catch-up to max block number if last block >= max_block_number = timeout

### DIFF
--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -469,7 +469,9 @@ impl MerkleRootRelayer {
         } else {
             log::info!("No finalized merkle roots in storage");
         }
-
+        // set last submitted block to the max_block_number in storage OR to max_block_number from MQ contract
+        // in order to trigger catch-up logic in `run_inner` properly.
+        self.last_submitted_block = Some(max_block_number_in_storage.unwrap_or(max_block_number));
         if let CriticalThreshold::Timeout(timeout) = self.options.critical_threshold {
             if last_block >= max_block_number + timeout {
                 if let Some(max_stored) = max_block_number_in_storage {


### PR DESCRIPTION
@gshep 

Current logic was incorrect since it triggered catch-up to max block number only if last block is >= MAX_BLOCK_DISTANCE which is partly incorrect. Now catch-up will be triggered properly. 