### PR TITLE
feat(relayer): Add ApiProviderConnection::is_alive

### DIFF
--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -122,7 +122,7 @@ async fn task_inner(this: &MerkleRootExtractor) -> anyhow::Result<()> {
 
     let mut stream = subscription.into_result_stream();
     // check periodically that the connection to ApiProvider is alive
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
 
     loop {
         tokio::select! {

--- a/relayer/src/message_relayer/eth_to_gear/api_provider.rs
+++ b/relayer/src/message_relayer/eth_to_gear/api_provider.rs
@@ -46,10 +46,6 @@ impl ApiProviderConnection {
     /// When this function errors it indicates that the provider
     /// has failed and no further connections can be made.
     pub async fn reconnect(&mut self) -> anyhow::Result<()> {
-        if !self.is_alive() {
-            return Err(anyhow::anyhow!("API provider connection is dead"));
-        }
-
         let (tx, rx) = oneshot::channel();
         let request = ApiConnectionRequest {
             session: self.session,


### PR DESCRIPTION
Alternative to #766 which properly fixes the problem of not restarting relayer for a while. 

@gshep 
