### PR TITLE
fix(relayer): exit merkle root extractor when api provider is dead rather than erroring

### DIFF
--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -128,7 +128,8 @@ async fn task_inner(this: &MerkleRootExtractor) -> anyhow::Result<()> {
         tokio::select! {
             _ = interval.tick() => {
                 if !this.api_provider.is_alive() {
-                    return Err(anyhow::anyhow!("Connection to ApiProvider is lost"));
+                    log::error!("ApiProvider connection is dead, exiting Merkle root extractor task");
+                    return Ok(());
                 }
             }
 


### PR DESCRIPTION
@gshep 