### PR TITLE
refactor(relayer): fetch inclusion proof from storage for merkle-roots when possible

### DIFF
--- a/relayer/src/merkle_roots/storage.rs
+++ b/relayer/src/merkle_roots/storage.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     proof_storage::ProofStorage,
 };
+use gear_rpc_client::dto::RawBlockInclusionProof;
 use primitive_types::{H256, U256};
 use sails_rs::events::EventIo;
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
@@ -31,9 +32,7 @@ pub struct Block {
     pub block_hash: H256,
     pub merkle_root_changed: Option<(u64, H256)>,
     pub authority_set_changed: bool,
-    pub finality_block: u32,
-    pub finality_proof: gear_rpc_client::dto::BlockFinalityProof,
-    pub finality_hash: H256,
+    pub inclusion_proof: RawBlockInclusionProof,
 }
 
 impl Block {
@@ -119,8 +118,7 @@ impl UnprocessedBlocksStorage for MerkleRootStorage {
         let proof = api
             .produce_finality_proof(&block.grandpa_justification)
             .await?;
-        let finality: (H256, gear_rpc_client::dto::BlockFinalityProof) =
-            (proof.block_hash, proof.into());
+
         let block_hash = block.hash();
         let block_number = block.number();
 
@@ -135,9 +133,7 @@ impl UnprocessedBlocksStorage for MerkleRootStorage {
                     block_hash,
                     merkle_root_changed,
                     authority_set_changed,
-                    finality_block: block.grandpa_justification.commit.target_number,
-                    finality_proof: finality.1,
-                    finality_hash: finality.0,
+                    inclusion_proof: proof,
                 });
             }
         }


### PR DESCRIPTION
@gshep 