### PR TITLE
feat: improve relayer resilience with RPC retry infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10243,6 +10243,7 @@ dependencies = [
  "subxt",
  "thiserror 2.0.12",
  "tokio",
+ "toml 0.9.7",
  "url",
  "utils-prometheus",
  "uuid",
@@ -11935,6 +11936,19 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signed-block-id-tool"
+version = "1.2.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "cli-utils",
+ "dotenv",
+ "gear-rpc-client",
+ "primitive-types 0.13.1",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "tools/checkpoints-tool",
     "tools/vft-tool",
     "tools/governance",
+    "tools/signed-block-id-tool",
     "tests",
     "gear-common",
     "tools/vft-manager-tool",

--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -82,24 +82,53 @@ pub enum TxStatus {
 pub struct PollingEthApi {
     provider: RootProvider,
     url: Url,
+    ws_max_retry: Option<u32>,
+    ws_retry_interval: Option<Duration>,
 }
 
 impl PollingEthApi {
     pub async fn new(url: &str) -> AnyResult<Self> {
+        Self::new_with_retries(url, None, None).await
+    }
+
+    pub async fn new_with_retries(
+        url: &str,
+        ws_max_retry: Option<u32>,
+        ws_retry_interval: Option<Duration>,
+    ) -> AnyResult<Self> {
         let url = Url::parse(url).context("Provided url is not valid")?;
-        let ws = WsConnect::new(url.clone());
+        let mut ws = WsConnect::new(url.clone());
+        if let Some(ws_max_retry) = ws_max_retry {
+            ws = ws.with_max_retries(ws_max_retry);
+        }
+        if let Some(ws_retry_interval) = ws_retry_interval {
+            ws = ws.with_retry_interval(ws_retry_interval);
+        }
         let provider = RootProvider::builder().connect_ws(ws).await?;
 
-        Ok(Self { provider, url })
+        Ok(Self {
+            provider,
+            url,
+            ws_max_retry,
+            ws_retry_interval,
+        })
     }
 
     pub async fn reconnect(&self) -> AnyResult<Self> {
-        let ws = WsConnect::new(self.url.clone());
+        let mut ws = WsConnect::new(self.url.clone());
+        if let Some(ws_max_retry) = self.ws_max_retry {
+            ws = ws.with_max_retries(ws_max_retry);
+        }
+        if let Some(ws_retry_interval) = self.ws_retry_interval {
+            ws = ws.with_retry_interval(ws_retry_interval);
+        }
         let provider = RootProvider::builder().connect_ws(ws).await?;
 
         Ok(Self {
             provider,
             url: self.url.clone(),
+            ws_max_retry: self.ws_max_retry,
+            ws_retry_interval: self.ws_retry_interval,
         })
     }
 
@@ -224,6 +253,8 @@ pub struct EthApi {
     public_key: Address,
     wallet: EthereumWallet,
     url: Url,
+    ws_max_retry: Option<u32>,
+    ws_retry_interval: Option<Duration>,
 }
 
 impl EthApi {
@@ -301,11 +332,19 @@ impl EthApi {
             public_key,
             url,
             wallet,
+            ws_max_retry,
+            ws_retry_interval,
         })
     }
 
     pub async fn reconnect(&self) -> Result<EthApi, Error> {
-        let ws = WsConnect::new(self.url.clone());
+        let mut ws = WsConnect::new(self.url.clone());
+        if let Some(ws_max_retry) = self.ws_max_retry {
+            ws = ws.with_max_retries(ws_max_retry);
+        }
+        if let Some(ws_retry_interval) = self.ws_retry_interval {
+            ws = ws.with_retry_interval(ws_retry_interval);
+        }
         let provider: ProviderType = ProviderBuilder::new()
             .wallet(self.wallet.clone())
             .connect_ws(ws)
@@ -323,6 +362,8 @@ impl EthApi {
             public_key: self.public_key,
             url: self.url.clone(),
             wallet: self.wallet.clone(),
+            ws_max_retry: self.ws_max_retry,
+            ws_retry_interval: self.ws_retry_interval,
         })
     }
 

--- a/gear-common/src/api_provider.rs
+++ b/gear-common/src/api_provider.rs
@@ -8,8 +8,11 @@ use tokio::sync::{
     oneshot,
 };
 
-/// Timeout between reconnects. Default: 1m30s.
-const RECONNECT_TIMEOUT: Duration = Duration::from_secs(90);
+/// Reconnect backoff starts quickly so transient disconnects do not stall
+/// the whole relayer, but still caps at the historical 1m30s interval.
+const RECONNECT_BASE_TIMEOUT: Duration = Duration::from_secs(1);
+const RECONNECT_MAX_TIMEOUT: Duration = Duration::from_secs(90);
+const RECONNECT_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
 
 struct ApiConnectionRequest {
     session: u64,
@@ -131,28 +134,45 @@ impl ApiProvider {
     }
 
     async fn reconnect(&mut self) -> bool {
-        for attempt in 0..self.max_reconnect_attempts {
-            match Api::builder().uri(self.url.as_str()).build().await {
-                Ok(api) => {
+        let mut attempt: u64 = 1;
+        loop {
+            let url = self.url.clone();
+            let mut connect =
+                tokio::spawn(async move { Api::builder().uri(url.as_str()).build().await });
+
+            match tokio::time::timeout(RECONNECT_ATTEMPT_TIMEOUT, &mut connect).await {
+                Ok(Ok(Ok(api))) => {
                     self.api = api;
                     return true;
                 }
-                Err(err) => {
+                Ok(Ok(Err(err))) => {
                     log::error!(
-                        "Failed to create API connection (attempt {attempt}/{max_reconnect_attempts}): {err}",
-                        max_reconnect_attempts = self.max_reconnect_attempts
+                        "Failed to create API connection (runtime reconnect attempt {attempt}, initial max_reconnect_attempts={}): {err}",
+                        self.max_reconnect_attempts
                     );
 
-                    tokio::time::sleep(RECONNECT_TIMEOUT).await;
+                    tokio::time::sleep(reconnect_delay(attempt)).await;
+                }
+                Ok(Err(err)) => {
+                    log::error!(
+                        "API connection task failed (runtime reconnect attempt {attempt}, initial max_reconnect_attempts={}): {err}",
+                        self.max_reconnect_attempts
+                    );
+
+                    tokio::time::sleep(reconnect_delay(attempt)).await;
+                }
+                Err(_) => {
+                    connect.abort();
+                    log::error!(
+                        "Timed out creating API connection after {RECONNECT_ATTEMPT_TIMEOUT:?} (runtime reconnect attempt {attempt}, initial max_reconnect_attempts={})",
+                        self.max_reconnect_attempts
+                    );
+
+                    tokio::time::sleep(reconnect_delay(attempt)).await;
                 }
             }
+            attempt = attempt.saturating_add(1);
         }
-
-        log::error!(
-            "All {max_reconnect_attempts} attempts to connect to API failed. Giving up.",
-            max_reconnect_attempts = self.max_reconnect_attempts
-        );
-        false
     }
 
     pub fn spawn(mut self) {
@@ -214,5 +234,27 @@ impl ApiProvider {
                 }
             }
         });
+    }
+}
+
+fn reconnect_delay(attempt: u64) -> Duration {
+    let multiplier = 1u32
+        .checked_shl(attempt.saturating_sub(1).min(10) as u32)
+        .unwrap_or(1024);
+
+    RECONNECT_BASE_TIMEOUT
+        .saturating_mul(multiplier)
+        .min(RECONNECT_MAX_TIMEOUT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconnect_delay_is_fast_initially_and_capped() {
+        assert_eq!(reconnect_delay(1), Duration::from_secs(1));
+        assert_eq!(reconnect_delay(2), Duration::from_secs(2));
+        assert_eq!(reconnect_delay(10), Duration::from_secs(90));
     }
 }

--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -85,7 +85,7 @@ impl GearApi {
             .at(BlockRef::from_hash(block_hash))
             .await
             .map(|block| block.number())
-            .map_err(|err| anyhow!("Failed to get block number: {err}"))
+            .context("Failed to get block number")
     }
 
     pub async fn block_number_to_hash(&self, block: u32) -> AnyResult<H256> {
@@ -106,7 +106,7 @@ impl GearApi {
         self.api
             .storage_fetch_at(&addr, Some(block))
             .await
-            .map_err(|err| anyhow!("Failed to fetch authority set id: {err}"))
+            .context("Failed to fetch authority set id")
     }
 
     /// Get authority set state for specified block. If block is not specified

--- a/gnark-wrapper/main.go
+++ b/gnark-wrapper/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"path/filepath"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/kzg"
@@ -94,15 +95,25 @@ type ProofWithPublicInputs struct {
 	PublicInputs []string `json:"public_inputs"`
 }
 
+const defaultDataDir = "data"
+
+func dataFile(dataDir string, name string) string {
+	if dataDir == "" {
+		dataDir = defaultDataDir
+	}
+	return filepath.Join(dataDir, name)
+}
+
 //export prove
-func prove(circuitData *C.char) *C.char {
-	pk, err := loadProvingKey()
+func prove(circuitData *C.char, dataPath *C.char) *C.char {
+	dataDir := C.GoString(dataPath)
+	pk, err := loadProvingKey(dataDir)
 	if err != nil {
-		compile(circuitData)
-		pk, _ = loadProvingKey()
+		compile(circuitData, dataDir)
+		pk, _ = loadProvingKey(dataDir)
 	}
 
-	r1cs := loadR1CS()
+	r1cs := loadR1CS(dataDir)
 
 	assignment, err := deserializeCircuit(C.GoString(circuitData))
 	if err != nil {
@@ -116,7 +127,7 @@ func prove(circuitData *C.char) *C.char {
 		panic(errorString)
 	}
 
-	vk := loadVerifyingKey()
+	vk := loadVerifyingKey(dataDir)
 	publicWitness, err := witness.Public()
 	if err != nil {
 		panic(err)
@@ -132,7 +143,7 @@ func prove(circuitData *C.char) *C.char {
 	return C.CString(rawProof)
 }
 
-func compile(circuitData *C.char) {
+func compile(circuitData *C.char, dataDir string) {
 	circuit, err := deserializeCircuit(C.GoString(circuitData))
 	if err != nil {
 		panic(err)
@@ -144,7 +155,7 @@ func compile(circuitData *C.char) {
 		os.Exit(1)
 	}
 
-	srs := loadSRS()
+	srs := loadSRS(dataDir)
 
 	pk, vk, err := plonk.Setup(r1cs, srs)
 	if err != nil {
@@ -152,19 +163,19 @@ func compile(circuitData *C.char) {
 		os.Exit(1)
 	}
 
-	fR1CS, _ := os.Create("data/r1cs")
+	fR1CS, _ := os.Create(dataFile(dataDir, "r1cs"))
 	r1cs.WriteTo(fR1CS)
 	fR1CS.Close()
 
-	fPK, _ := os.Create("data/proving.key")
+	fPK, _ := os.Create(dataFile(dataDir, "proving.key"))
 	pk.WriteRawTo(fPK)
 	fPK.Close()
 
-	fVK, _ := os.Create("data/verifying.key")
+	fVK, _ := os.Create(dataFile(dataDir, "verifying.key"))
 	vk.WriteRawTo(fVK)
 	fVK.Close()
 
-	fSolidity, _ := os.Create("data/verifier.sol")
+	fSolidity, _ := os.Create(dataFile(dataDir, "verifier.sol"))
 	_ = vk.ExportSolidity(fSolidity)
 }
 
@@ -279,8 +290,8 @@ func compressPublicInputs(pis []gl.Variable) []frontend.Variable {
 	return compressedPis
 }
 
-func loadVerifyingKey() plonk.VerifyingKey {
-	vkFile, err := os.Open("data/verifying.key")
+func loadVerifyingKey(dataDir string) plonk.VerifyingKey {
+	vkFile, err := os.Open(dataFile(dataDir, "verifying.key"))
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -294,8 +305,8 @@ func loadVerifyingKey() plonk.VerifyingKey {
 	return vk
 }
 
-func loadProvingKey() (plonk.ProvingKey, error) {
-	pkFile, err := os.Open("data/proving.key")
+func loadProvingKey(dataDir string) (plonk.ProvingKey, error) {
+	pkFile, err := os.Open(dataFile(dataDir, "proving.key"))
 	if err != nil {
 		return nil, err
 	}
@@ -310,9 +321,9 @@ func loadProvingKey() (plonk.ProvingKey, error) {
 	return pk, nil
 }
 
-func loadR1CS() constraint.ConstraintSystem {
+func loadR1CS(dataDir string) constraint.ConstraintSystem {
 	r1cs := plonk.NewCS(ecc.BN254)
-	r1csFile, err := os.Open("data/r1cs")
+	r1csFile, err := os.Open(dataFile(dataDir, "r1cs"))
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -326,9 +337,9 @@ func loadR1CS() constraint.ConstraintSystem {
 	return r1cs
 }
 
-func loadSRS() kzg.SRS {
+func loadSRS(dataDir string) kzg.SRS {
 	fmt.Println("Running circuit setup")
-	fileName := "data/srs_setup"
+	fileName := dataFile(dataDir, "srs_setup")
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		trusted_setup.DownloadAndSaveAztecIgnitionSrs(174, fileName)
 	}

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -53,6 +53,7 @@ serde_json.workspace = true
 sled.workspace = true
 thiserror = { workspace = true, features = ["std"] }
 tokio.workspace = true
+toml.workspace = true
 utils-prometheus.workspace = true
 url.workspace = true
 subxt.workspace = true

--- a/relayer/config.toml.example
+++ b/relayer/config.toml.example
@@ -1,0 +1,89 @@
+[prometheus]
+endpoint = "0.0.0.0:9090"
+
+[relayers.mainnet]
+priority = 100
+
+[relayers.mainnet.gear]
+endpoint = "wss://vara.example"
+max_reconnect_attempts = 3
+
+[relayers.mainnet.ethereum]
+endpoint = "wss://ethereum.example"
+message_queue_address = "0x1111111111111111111111111111111111111111"
+fee_payer = "0x2222222222222222222222222222222222222222222222222222222222222222"
+max_retries = 3
+retry_interval_ms = 2000
+max_fee_per_gas = 2000000000
+max_priority_fee_per_gas = 500000000
+
+[relayers.mainnet.genesis]
+authority_set_hash = "0x3333333333333333333333333333333333333333333333333333333333333333"
+authority_set_id = 123
+
+[relayers.mainnet.http]
+address = "127.0.0.1:8443"
+token = "mainnet-secret"
+
+[relayers.mainnet.storage]
+block_storage = "/var/lib/gear-bridges/mainnet/merkle-roots.json"
+
+[relayers.mainnet.proof_storage]
+kind = "filesystem"
+filesystem_path = "/var/lib/gear-bridges/mainnet/proofs"
+
+[relayers.mainnet.options]
+confirmations_merkle_root = 8
+start_authority_set_id = 123
+bridging_payment_address = "0x4444444444444444444444444444444444444444444444444444444444444444"
+thread_count = 24
+critical_threshold = "4h"
+startup_sync_strategy = "critical-threshold"
+startup_sync_blocks = []
+spike_window = "15m"
+spike_timeout = "30m"
+priority_spike_timeout = "10m"
+spike_threshold = 8
+save_interval = "30m"
+check_interval = "30s"
+
+[relayers.testnet]
+priority = 50
+
+[relayers.testnet.gear]
+endpoint = "wss://testnet-vara.example"
+max_reconnect_attempts = 3
+
+[relayers.testnet.ethereum]
+endpoint = "wss://testnet-ethereum.example"
+message_queue_address = "0x5555555555555555555555555555555555555555"
+fee_payer = "0x6666666666666666666666666666666666666666666666666666666666666666"
+
+[relayers.testnet.genesis]
+authority_set_hash = "0x7777777777777777777777777777777777777777777777777777777777777777"
+authority_set_id = 456
+
+[relayers.testnet.http]
+address = "127.0.0.1:8444"
+token = "testnet-secret"
+
+[relayers.testnet.storage]
+block_storage = "/var/lib/gear-bridges/testnet/merkle-roots.json"
+
+[relayers.testnet.proof_storage]
+kind = "gear"
+gear_fee_payer = "//testnet-relayer"
+config_dir = "/var/lib/gear-bridges/testnet/onchain-proof-storage"
+
+[relayers.testnet.options]
+confirmations_merkle_root = 4
+thread_count = "auto"
+critical_threshold = "authority_set_change"
+startup_sync_strategy = "blocks"
+startup_sync_blocks = [100, 101, 102]
+spike_window = "15m"
+spike_timeout = "30m"
+priority_spike_timeout = "10m"
+spike_threshold = 8
+save_interval = "30m"
+check_interval = "30s"

--- a/relayer/src/cli/mod.rs
+++ b/relayer/src/cli/mod.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Parser, Subcommand};
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 mod common;
 
@@ -70,12 +70,16 @@ pub struct UpdateVerifierSolArgs {
 
 #[derive(Args)]
 pub struct GearEthCoreArgs {
+    /// Path to gear-eth-core TOML config. When present, per-relayer settings are read from this file.
+    #[arg(long = "config", env = "RELAYER_CONFIG")]
+    pub config: Option<PathBuf>,
+
     #[clap(flatten)]
     pub gear_args: GearArgs,
     #[clap(flatten)]
-    pub ethereum_args: EthereumSignerArgs,
+    pub ethereum_args: GearEthCoreEthereumSignerArgs,
     #[clap(flatten)]
-    pub genesis_config_args: GenesisConfigArgs,
+    pub genesis_config_args: GearEthCoreGenesisConfigArgs,
     #[clap(flatten)]
     pub prometheus_args: PrometheusArgs,
     #[clap(flatten)]
@@ -130,7 +134,7 @@ pub struct GearEthCoreArgs {
 
     /// Authorization token for web-server
     #[arg(long, env)]
-    pub web_server_token: String,
+    pub web_server_token: Option<String>,
 
     /// Socket address for web-server
     #[arg(long, env, default_value = "127.0.0.1:8443")]
@@ -165,6 +169,50 @@ pub struct GearEthCoreArgs {
         help = "Block numbers to sync at startup (used when startup-sync-strategy=blocks)"
     )]
     pub startup_sync_blocks: Vec<u32>,
+}
+
+#[derive(Args)]
+pub struct GearEthCoreEthereumSignerArgs {
+    /// Address of the ethereum endpoint
+    #[arg(long = "ethereum-endpoint", env = "ETH_RPC")]
+    pub ethereum_endpoint: Option<String>,
+
+    /// Number of retries for the ethereum endpoint
+    #[arg(long = "eth-max-retries", env = "ETH_RPC_MAX_RETRIES")]
+    pub max_retries: Option<u32>,
+
+    /// Interval in milliseconds between retries for the ethereum endpoint
+    #[arg(long = "eth-retry-interval-ms", env = "ETH_RPC_RETRY_INTERVAL_MS")]
+    pub retry_interval_ms: Option<u64>,
+
+    /// Max fee per gas (in wei) for transactions sent to Ethereum.
+    #[arg(long = "max-fee-per-gas", env = "ETH_MAX_FEE_PER_GAS")]
+    pub max_fee_per_gas: Option<u128>,
+
+    /// Max priority fee per gas (in wei) for transactions sent to Ethereum.
+    #[arg(
+        long = "max-priority-fee-per-gas",
+        env = "ETH_MAX_PRIORITY_FEE_PER_GAS"
+    )]
+    pub max_priority_fee_per_gas: Option<u128>,
+
+    /// Ethereum address of message queue contract
+    #[arg(long = "mq-address", env = "ETH_MESSAGE_QUEUE_ADDRESS")]
+    pub mq_address: Option<String>,
+
+    /// Private key for fee payer
+    #[arg(long = "eth-fee-payer", env = "ETH_FEE_PAYER")]
+    pub eth_fee_payer: Option<String>,
+}
+
+#[derive(Args)]
+pub struct GearEthCoreGenesisConfigArgs {
+    /// Authority set hash used in genesis config
+    #[arg(long, env = "GENESIS_CONFIG_AUTHORITY_SET_HASH")]
+    pub authority_set_hash: Option<String>,
+    /// Authority set id used in genesis config
+    #[arg(long, env = "GENESIS_CONFIG_AUTHORITY_SET_ID")]
+    pub authority_set_id: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -480,4 +528,54 @@ fn parse_thread_count(s: &str) -> anyhow::Result<ThreadCount> {
     }
 
     Ok(s.parse::<usize>().map(ThreadCount::Manual)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::EffectiveConfig;
+
+    #[test]
+    fn gear_eth_core_config_mode_parses_without_legacy_required_flags() {
+        let cli = Cli::try_parse_from([
+            "relayer",
+            "gear-eth-core",
+            "--config",
+            "relayer/config.toml.example",
+        ])
+        .unwrap();
+
+        match cli.command {
+            CliCommands::GearEthCore(args) => {
+                assert_eq!(
+                    args.config.unwrap(),
+                    PathBuf::from("relayer/config.toml.example")
+                );
+            }
+            _ => panic!("expected gear-eth-core command"),
+        }
+    }
+
+    #[test]
+    fn gear_eth_core_no_config_mode_keeps_runtime_required_fields() {
+        let cli = Cli::try_parse_from([
+            "relayer",
+            "gear-eth-core",
+            "--config",
+            "relayer/config.toml.example",
+        ])
+        .unwrap();
+
+        let CliCommands::GearEthCore(mut args) = cli.command else {
+            panic!("expected gear-eth-core command");
+        };
+        args.config = None;
+        args.ethereum_args.ethereum_endpoint = None;
+
+        let err = match EffectiveConfig::from_cli(&args) {
+            Ok(_) => panic!("legacy mode unexpectedly accepted missing Ethereum endpoint"),
+            Err(err) => err.to_string(),
+        };
+        assert!(err.contains("--ethereum-endpoint/ETH_RPC"));
+    }
 }

--- a/relayer/src/common.rs
+++ b/relayer/src/common.rs
@@ -13,6 +13,7 @@ use crate::{
     merkle_roots::authority_set_sync,
     proof_storage::ProofStorage,
     prover_interface::{self, FinalProof},
+    rpc::{self, RetryDecision},
 };
 
 use ethereum_client::{EthApi, TxHash};
@@ -125,20 +126,14 @@ pub(crate) async fn send_challege_root_to_ethereum(
 }
 
 pub(crate) fn is_rpc_transport_error_recoverable(err: &RpcError<TransportErrorKind>) -> bool {
-    match err {
-        RpcError::Transport(transport) => match transport {
-            TransportErrorKind::MissingBatchResponse(_) => true,
-            TransportErrorKind::BackendGone => true,
-            TransportErrorKind::PubsubUnavailable => false,
-            TransportErrorKind::HttpError(_) => false,
-            TransportErrorKind::Custom(_) => false,
-            _ => false,
-        },
-        _ => false,
-    }
+    rpc::classify_alloy_rpc(err) == RetryDecision::Retry
 }
 
 pub(crate) fn is_transport_error_recoverable(err: &anyhow::Error) -> bool {
+    if rpc::classify_anyhow(err) == RetryDecision::Retry {
+        return true;
+    }
+
     if let Some(ethereum_client::Error::ErrorInHTTPTransport(err)) =
         err.downcast_ref::<ethereum_client::Error>()
     {

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -19,6 +19,7 @@ const DEFAULT_PROMETHEUS_ENDPOINT: &str = "0.0.0.0:9090";
 const DEFAULT_RELAYER_ID: &str = "default";
 const DEFAULT_FILE_SYSTEM_PROOF_STORAGE: &str = "./proof_storage";
 const DEFAULT_GEAR_PROOF_STORAGE_CONFIG: &str = "./onchain_proof_storage_data";
+const DEFAULT_GNARK_DATA_PATH: &str = "data";
 
 #[derive(Clone)]
 pub struct EffectiveConfig {
@@ -137,6 +138,7 @@ impl EffectiveConfig {
             spike_threshold: args.spike_threshold,
             save_interval: args.save_interval,
             check_interval: args.check_interval,
+            gnark_data_path: PathBuf::from(DEFAULT_GNARK_DATA_PATH),
             authority_set_hash,
             authority_set_id,
         })?;
@@ -208,6 +210,8 @@ struct RawRelayerConfig {
     storage: RawStorageConfig,
     proof_storage: RawProofStorageConfig,
     #[serde(default)]
+    gnark: RawGnarkConfig,
+    #[serde(default)]
     options: RawOptionsConfig,
 }
 
@@ -256,6 +260,20 @@ enum RawProofStorageConfig {
         gear_fee_payer: String,
         config_dir: PathBuf,
     },
+}
+
+#[derive(Deserialize)]
+struct RawGnarkConfig {
+    #[serde(default = "default_gnark_data_path")]
+    data_path: PathBuf,
+}
+
+impl Default for RawGnarkConfig {
+    fn default() -> Self {
+        Self {
+            data_path: PathBuf::from(DEFAULT_GNARK_DATA_PATH),
+        }
+    }
 }
 
 #[derive(Default, Deserialize)]
@@ -317,6 +335,7 @@ impl RawConfig {
                 .with_context(|| format!("relayer {id}: http.address is invalid"))?;
             validate_non_empty(&relayer.http.token, &id, "http.token")?;
             validate_block_storage_path(&relayer.storage.block_storage, &id)?;
+            validate_non_empty_path(&relayer.gnark.data_path, &id, "gnark.data_path")?;
 
             let thread_count = match relayer.options.thread_count {
                 Some(raw) => Some(parse_thread_count(raw, &id)?).flatten(),
@@ -408,6 +427,7 @@ impl RawConfig {
                 spike_threshold: relayer.options.spike_threshold.unwrap_or(8),
                 save_interval,
                 check_interval,
+                gnark_data_path: relayer.gnark.data_path.clone(),
                 authority_set_hash: &relayer.genesis.authority_set_hash,
                 authority_set_id: relayer.genesis.authority_set_id,
             })?;
@@ -465,6 +485,7 @@ struct OptionSource<'a> {
     spike_threshold: usize,
     save_interval: Duration,
     check_interval: Duration,
+    gnark_data_path: PathBuf,
     authority_set_hash: &'a str,
     authority_set_id: u64,
 }
@@ -541,6 +562,7 @@ fn build_options(source: OptionSource<'_>) -> anyhow::Result<MerkleRootRelayerOp
         bridging_payment_address,
         critical_threshold,
         startup_sync_strategy,
+        gnark_data_path: source.gnark_data_path,
     })
 }
 
@@ -710,6 +732,10 @@ fn default_max_reconnect_attempts() -> u8 {
     3
 }
 
+fn default_gnark_data_path() -> PathBuf {
+    PathBuf::from(DEFAULT_GNARK_DATA_PATH)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -750,6 +776,9 @@ block_storage = "/tmp/mainnet-blocks.json"
 [relayers.mainnet.proof_storage]
 kind = "filesystem"
 filesystem_path = "/tmp/mainnet-proofs"
+
+[relayers.mainnet.gnark]
+data_path = "/tmp/mainnet-gnark"
 
 [relayers.mainnet.options]
 confirmations_merkle_root = 8
@@ -803,6 +832,9 @@ block_storage = "{block_storage}"
 [relayers.testnet.proof_storage]
 kind = "filesystem"
 filesystem_path = "{proof_storage}"
+
+[relayers.testnet.gnark]
+data_path = "/tmp/testnet-gnark"
 "#,
             "44".repeat(32),
             "55".repeat(32),
@@ -820,7 +852,36 @@ filesystem_path = "{proof_storage}"
         assert_eq!(relayer.gear.endpoint, "wss://gear.example");
         assert_eq!(relayer.gear.max_reconnect_attempts, 4);
         assert_eq!(relayer.ethereum.max_retries, Some(5));
+        assert_eq!(
+            relayer.options.gnark_data_path,
+            PathBuf::from("/tmp/mainnet-gnark")
+        );
         assert_eq!(relayer.options.count_thread, None);
+    }
+
+    #[test]
+    fn defaults_gnark_data_path_to_data() {
+        let config = valid_config().replace(
+            "\n[relayers.mainnet.gnark]\ndata_path = \"/tmp/mainnet-gnark\"\n",
+            "\n",
+        );
+
+        let config = EffectiveConfig::from_toml_str(&config).unwrap();
+
+        assert_eq!(
+            config.relayers[0].options.gnark_data_path,
+            PathBuf::from("data")
+        );
+    }
+
+    #[test]
+    fn rejects_empty_gnark_data_path() {
+        let config =
+            valid_config().replace("data_path = \"/tmp/mainnet-gnark\"", "data_path = \"\"");
+
+        let err = config_error(&config);
+
+        assert!(err.contains("gnark.data_path"));
     }
 
     #[test]

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -1,0 +1,977 @@
+use crate::{
+    cli::{self, GearEthCoreArgs, DEFAULT_COUNT_CONFIRMATIONS, DEFAULT_COUNT_THREADS},
+    merkle_roots::{CriticalThreshold, MerkleRootRelayerOptions, SpikeConfig, StartupSyncStrategy},
+};
+use anyhow::{anyhow, Context};
+use primitive_types::H256;
+use prover::{consts::BLAKE2_DIGEST_SIZE, proving::GenesisConfig};
+use serde::Deserialize;
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use url::Url;
+
+const DEFAULT_PROMETHEUS_ENDPOINT: &str = "0.0.0.0:9090";
+const DEFAULT_RELAYER_ID: &str = "default";
+const DEFAULT_FILE_SYSTEM_PROOF_STORAGE: &str = "./proof_storage";
+const DEFAULT_GEAR_PROOF_STORAGE_CONFIG: &str = "./onchain_proof_storage_data";
+
+#[derive(Clone)]
+pub struct EffectiveConfig {
+    pub prometheus_endpoint: String,
+    pub relayers: Vec<EffectiveRelayerConfig>,
+}
+
+#[derive(Clone)]
+pub struct EffectiveRelayerConfig {
+    pub id: String,
+    pub priority: i64,
+    pub gear: EffectiveGearConfig,
+    pub ethereum: EffectiveEthereumConfig,
+    pub http: EffectiveHttpConfig,
+    pub storage: EffectiveStorageConfig,
+    pub proof_storage: EffectiveProofStorageConfig,
+    pub options: MerkleRootRelayerOptions,
+}
+
+#[derive(Clone)]
+pub struct EffectiveGearConfig {
+    pub endpoint: String,
+    pub max_reconnect_attempts: u8,
+}
+
+#[derive(Clone)]
+pub struct EffectiveEthereumConfig {
+    pub endpoint: String,
+    pub message_queue_address: String,
+    pub fee_payer: String,
+    pub max_retries: Option<u32>,
+    pub retry_interval_ms: Option<u64>,
+    pub max_fee_per_gas: Option<u128>,
+    pub max_priority_fee_per_gas: Option<u128>,
+}
+
+#[derive(Clone)]
+pub struct EffectiveHttpConfig {
+    pub address: String,
+    pub token: String,
+}
+
+#[derive(Clone)]
+pub struct EffectiveStorageConfig {
+    pub block_storage: PathBuf,
+}
+
+#[derive(Clone)]
+pub enum EffectiveProofStorageConfig {
+    FileSystem {
+        path: PathBuf,
+    },
+    Gear {
+        fee_payer: String,
+        config_dir: PathBuf,
+    },
+}
+
+impl EffectiveConfig {
+    pub fn from_cli(args: &GearEthCoreArgs) -> anyhow::Result<Self> {
+        let ethereum_endpoint = required(
+            args.ethereum_args.ethereum_endpoint.as_deref(),
+            "--ethereum-endpoint/ETH_RPC",
+        )?;
+        let message_queue_address = required(
+            args.ethereum_args.mq_address.as_deref(),
+            "--mq-address/ETH_MESSAGE_QUEUE_ADDRESS",
+        )?;
+        let fee_payer = required(
+            args.ethereum_args.eth_fee_payer.as_deref(),
+            "--eth-fee-payer/ETH_FEE_PAYER",
+        )?;
+        let authority_set_hash = required(
+            args.genesis_config_args.authority_set_hash.as_deref(),
+            "--authority-set-hash/GENESIS_CONFIG_AUTHORITY_SET_HASH",
+        )?;
+        let authority_set_id = args
+            .genesis_config_args
+            .authority_set_id
+            .ok_or_else(|| anyhow!("Missing --authority-set-id/GENESIS_CONFIG_AUTHORITY_SET_ID"))?;
+        let web_server_token = required(
+            args.web_server_token.as_deref(),
+            "--web-server-token/WEB_SERVER_TOKEN",
+        )?;
+        let block_storage = args
+            .block_storage_args
+            .path
+            .clone()
+            .ok_or_else(|| anyhow!("No block storage path provided"))?;
+
+        let proof_storage = match args.proof_storage_args.gear_fee_payer.clone() {
+            Some(fee_payer) => EffectiveProofStorageConfig::Gear {
+                fee_payer,
+                config_dir: DEFAULT_GEAR_PROOF_STORAGE_CONFIG.into(),
+            },
+            None => EffectiveProofStorageConfig::FileSystem {
+                path: DEFAULT_FILE_SYSTEM_PROOF_STORAGE.into(),
+            },
+        };
+
+        let options = build_options(OptionSource {
+            relayer_id: DEFAULT_RELAYER_ID,
+            confirmations_merkle_root: args.confirmations_merkle_root,
+            start_authority_set_id: args.start_authority_set_id,
+            bridging_payment_address: args.bridging_payment_address.as_deref(),
+            thread_count: match args.thread_count {
+                Some(thread_count) => thread_count.into(),
+                None => Some(DEFAULT_COUNT_THREADS),
+            },
+            critical_threshold: args.critical_threshold.clone(),
+            startup_sync_strategy: args.startup_sync_strategy,
+            startup_sync_blocks: args.startup_sync_blocks.clone(),
+            spike_window: args.spike_window,
+            spike_timeout: args.spike_timeout,
+            priority_spike_timeout: args.priority_spike_timeout,
+            spike_threshold: args.spike_threshold,
+            save_interval: args.save_interval,
+            check_interval: args.check_interval,
+            authority_set_hash,
+            authority_set_id,
+        })?;
+
+        let relayer = EffectiveRelayerConfig {
+            id: DEFAULT_RELAYER_ID.to_string(),
+            priority: 0,
+            gear: EffectiveGearConfig {
+                endpoint: args.gear_args.get_endpoint()?,
+                max_reconnect_attempts: args.gear_args.max_reconnect_attempts,
+            },
+            ethereum: EffectiveEthereumConfig {
+                endpoint: ethereum_endpoint.to_string(),
+                message_queue_address: message_queue_address.to_string(),
+                fee_payer: fee_payer.to_string(),
+                max_retries: args.ethereum_args.max_retries,
+                retry_interval_ms: args.ethereum_args.retry_interval_ms,
+                max_fee_per_gas: args.ethereum_args.max_fee_per_gas,
+                max_priority_fee_per_gas: args.ethereum_args.max_priority_fee_per_gas,
+            },
+            http: EffectiveHttpConfig {
+                address: args.web_server_address.clone(),
+                token: web_server_token.to_string(),
+            },
+            storage: EffectiveStorageConfig { block_storage },
+            proof_storage,
+            options,
+        };
+
+        validate_effective_config(EffectiveConfig {
+            prometheus_endpoint: args.prometheus_args.prometheus_endpoint.clone(),
+            relayers: vec![relayer],
+        })
+    }
+
+    pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        let contents = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read config file {}", path.display()))?;
+        Self::from_toml_str(&contents)
+            .with_context(|| format!("Failed to parse config file {}", path.display()))
+    }
+
+    pub fn from_toml_str(contents: &str) -> anyhow::Result<Self> {
+        let raw: RawConfig = toml::from_str(contents)?;
+        raw.into_effective()
+    }
+}
+
+#[derive(Deserialize)]
+struct RawConfig {
+    #[serde(default)]
+    prometheus: RawPrometheusConfig,
+    relayers: BTreeMap<String, RawRelayerConfig>,
+}
+
+#[derive(Default, Deserialize)]
+struct RawPrometheusConfig {
+    endpoint: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct RawRelayerConfig {
+    priority: Option<i64>,
+    gear: RawGearConfig,
+    ethereum: RawEthereumConfig,
+    genesis: RawGenesisConfig,
+    http: RawHttpConfig,
+    storage: RawStorageConfig,
+    proof_storage: RawProofStorageConfig,
+    #[serde(default)]
+    options: RawOptionsConfig,
+}
+
+#[derive(Deserialize)]
+struct RawGearConfig {
+    endpoint: String,
+    #[serde(default = "default_max_reconnect_attempts")]
+    max_reconnect_attempts: u8,
+}
+
+#[derive(Deserialize)]
+struct RawEthereumConfig {
+    endpoint: String,
+    message_queue_address: String,
+    fee_payer: String,
+    max_retries: Option<u32>,
+    retry_interval_ms: Option<u64>,
+    max_fee_per_gas: Option<u128>,
+    max_priority_fee_per_gas: Option<u128>,
+}
+
+#[derive(Deserialize)]
+struct RawGenesisConfig {
+    authority_set_hash: String,
+    authority_set_id: u64,
+}
+
+#[derive(Deserialize)]
+struct RawHttpConfig {
+    address: String,
+    token: String,
+}
+
+#[derive(Deserialize)]
+struct RawStorageConfig {
+    block_storage: PathBuf,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+enum RawProofStorageConfig {
+    #[serde(rename = "filesystem", alias = "file_system")]
+    FileSystem { filesystem_path: PathBuf },
+    #[serde(rename = "gear")]
+    Gear {
+        gear_fee_payer: String,
+        config_dir: PathBuf,
+    },
+}
+
+#[derive(Default, Deserialize)]
+struct RawOptionsConfig {
+    confirmations_merkle_root: Option<u64>,
+    start_authority_set_id: Option<u64>,
+    bridging_payment_address: Option<String>,
+    thread_count: Option<RawThreadCount>,
+    critical_threshold: Option<String>,
+    startup_sync_strategy: Option<String>,
+    #[serde(default)]
+    startup_sync_blocks: Vec<u32>,
+    spike_window: Option<String>,
+    spike_timeout: Option<String>,
+    priority_spike_timeout: Option<String>,
+    spike_threshold: Option<usize>,
+    save_interval: Option<String>,
+    check_interval: Option<String>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(untagged)]
+enum RawThreadCount {
+    Auto(String),
+    Manual(usize),
+}
+
+impl RawConfig {
+    fn into_effective(self) -> anyhow::Result<EffectiveConfig> {
+        if self.relayers.is_empty() {
+            return Err(anyhow!("config must define at least one relayer"));
+        }
+
+        let mut relayers = Vec::with_capacity(self.relayers.len());
+        for (id, relayer) in self.relayers {
+            validate_relayer_id(&id)?;
+            let priority = relayer
+                .priority
+                .ok_or_else(|| anyhow!("relayer {id}: priority is required"))?;
+
+            validate_url(
+                &relayer.gear.endpoint,
+                &format!("relayer {id}: gear.endpoint"),
+            )?;
+            validate_url(
+                &relayer.ethereum.endpoint,
+                &format!("relayer {id}: ethereum.endpoint"),
+            )?;
+            let _ = decode_fixed_hex::<20>(
+                &relayer.ethereum.message_queue_address,
+                &id,
+                "ethereum.message_queue_address",
+            )?;
+            let _ = decode_fixed_hex::<32>(&relayer.ethereum.fee_payer, &id, "ethereum.fee_payer")?;
+            relayer
+                .http
+                .address
+                .parse::<SocketAddr>()
+                .with_context(|| format!("relayer {id}: http.address is invalid"))?;
+            validate_non_empty(&relayer.http.token, &id, "http.token")?;
+            validate_block_storage_path(&relayer.storage.block_storage, &id)?;
+
+            let thread_count = match relayer.options.thread_count {
+                Some(raw) => Some(parse_thread_count(raw, &id)?).flatten(),
+                None => Some(DEFAULT_COUNT_THREADS),
+            };
+            let critical_threshold =
+                parse_critical_threshold(relayer.options.critical_threshold.as_deref(), &id)?;
+            let startup_sync_blocks = relayer.options.startup_sync_blocks.clone();
+            let startup_sync_strategy = parse_startup_sync_strategy(
+                relayer.options.startup_sync_strategy.as_deref(),
+                startup_sync_blocks.clone(),
+                &id,
+            )?;
+            let spike_window = parse_duration(
+                relayer.options.spike_window.as_deref(),
+                "15m",
+                &id,
+                "options.spike_window",
+            )?;
+            let spike_timeout = parse_duration(
+                relayer.options.spike_timeout.as_deref(),
+                "30m",
+                &id,
+                "options.spike_timeout",
+            )?;
+            let priority_spike_timeout = parse_duration(
+                relayer.options.priority_spike_timeout.as_deref(),
+                "10m",
+                &id,
+                "options.priority_spike_timeout",
+            )?;
+            if priority_spike_timeout > spike_timeout {
+                return Err(anyhow!(
+                    "relayer {id}: options.priority_spike_timeout must not exceed options.spike_timeout"
+                ));
+            }
+
+            let save_interval = parse_duration(
+                relayer.options.save_interval.as_deref(),
+                "30m",
+                &id,
+                "options.save_interval",
+            )?;
+            let check_interval = parse_duration(
+                relayer.options.check_interval.as_deref(),
+                "30s",
+                &id,
+                "options.check_interval",
+            )?;
+
+            let proof_storage = match relayer.proof_storage {
+                RawProofStorageConfig::FileSystem { filesystem_path } => {
+                    validate_non_empty_path(
+                        &filesystem_path,
+                        &id,
+                        "proof_storage.filesystem_path",
+                    )?;
+                    EffectiveProofStorageConfig::FileSystem {
+                        path: filesystem_path,
+                    }
+                }
+                RawProofStorageConfig::Gear {
+                    gear_fee_payer,
+                    config_dir,
+                } => EffectiveProofStorageConfig::Gear {
+                    fee_payer: {
+                        validate_non_empty(&gear_fee_payer, &id, "proof_storage.gear_fee_payer")?;
+                        gear_fee_payer
+                    },
+                    config_dir: {
+                        validate_non_empty_path(&config_dir, &id, "proof_storage.config_dir")?;
+                        config_dir
+                    },
+                },
+            };
+
+            let options = build_options(OptionSource {
+                relayer_id: &id,
+                confirmations_merkle_root: relayer.options.confirmations_merkle_root,
+                start_authority_set_id: relayer.options.start_authority_set_id,
+                bridging_payment_address: relayer.options.bridging_payment_address.as_deref(),
+                thread_count,
+                critical_threshold,
+                startup_sync_strategy,
+                startup_sync_blocks,
+                spike_window,
+                spike_timeout,
+                priority_spike_timeout,
+                spike_threshold: relayer.options.spike_threshold.unwrap_or(8),
+                save_interval,
+                check_interval,
+                authority_set_hash: &relayer.genesis.authority_set_hash,
+                authority_set_id: relayer.genesis.authority_set_id,
+            })?;
+
+            relayers.push(EffectiveRelayerConfig {
+                id,
+                priority,
+                gear: EffectiveGearConfig {
+                    endpoint: relayer.gear.endpoint,
+                    max_reconnect_attempts: relayer.gear.max_reconnect_attempts,
+                },
+                ethereum: EffectiveEthereumConfig {
+                    endpoint: relayer.ethereum.endpoint,
+                    message_queue_address: relayer.ethereum.message_queue_address,
+                    fee_payer: relayer.ethereum.fee_payer,
+                    max_retries: relayer.ethereum.max_retries,
+                    retry_interval_ms: relayer.ethereum.retry_interval_ms,
+                    max_fee_per_gas: relayer.ethereum.max_fee_per_gas,
+                    max_priority_fee_per_gas: relayer.ethereum.max_priority_fee_per_gas,
+                },
+                http: EffectiveHttpConfig {
+                    address: relayer.http.address,
+                    token: relayer.http.token,
+                },
+                storage: EffectiveStorageConfig {
+                    block_storage: relayer.storage.block_storage,
+                },
+                proof_storage,
+                options,
+            });
+        }
+
+        validate_effective_config(EffectiveConfig {
+            prometheus_endpoint: self
+                .prometheus
+                .endpoint
+                .unwrap_or_else(|| DEFAULT_PROMETHEUS_ENDPOINT.to_string()),
+            relayers,
+        })
+    }
+}
+
+struct OptionSource<'a> {
+    relayer_id: &'a str,
+    confirmations_merkle_root: Option<u64>,
+    start_authority_set_id: Option<u64>,
+    bridging_payment_address: Option<&'a str>,
+    thread_count: Option<usize>,
+    critical_threshold: cli::CriticalThreshold,
+    startup_sync_strategy: cli::StartupSyncStrategy,
+    startup_sync_blocks: Vec<u32>,
+    spike_window: Duration,
+    spike_timeout: Duration,
+    priority_spike_timeout: Duration,
+    spike_threshold: usize,
+    save_interval: Duration,
+    check_interval: Duration,
+    authority_set_hash: &'a str,
+    authority_set_id: u64,
+}
+
+fn build_options(source: OptionSource<'_>) -> anyhow::Result<MerkleRootRelayerOptions> {
+    let startup_sync_strategy = match source.startup_sync_strategy {
+        cli::StartupSyncStrategy::CriticalThreshold => StartupSyncStrategy::CriticalThreshold,
+        cli::StartupSyncStrategy::SkipCatchUp => StartupSyncStrategy::SkipCatchUp,
+        cli::StartupSyncStrategy::Blocks => {
+            if source.startup_sync_blocks.is_empty() {
+                return Err(anyhow!(
+                    "relayer {}: startup_sync_blocks must be provided when startup_sync_strategy=blocks",
+                    source.relayer_id
+                ));
+            }
+            StartupSyncStrategy::Blocks(source.startup_sync_blocks.clone())
+        }
+    };
+
+    if !matches!(startup_sync_strategy, StartupSyncStrategy::Blocks(_))
+        && !source.startup_sync_blocks.is_empty()
+    {
+        return Err(anyhow!(
+            "relayer {}: startup_sync_blocks can only be used when startup_sync_strategy=blocks",
+            source.relayer_id
+        ));
+    }
+
+    let critical_threshold = match source.critical_threshold {
+        cli::CriticalThreshold::Timeout(duration) => {
+            if duration < Duration::from_secs(3) {
+                return Err(anyhow!(
+                    "relayer {}: critical_threshold duration must be at least 3 seconds",
+                    source.relayer_id
+                ));
+            }
+            CriticalThreshold::Timeout((duration.as_secs() / 3) as u32)
+        }
+        cli::CriticalThreshold::AuthoritySetChange => CriticalThreshold::AuthoritySetChange,
+    };
+
+    let authority_set_hash = decode_fixed_hex::<BLAKE2_DIGEST_SIZE>(
+        source.authority_set_hash,
+        source.relayer_id,
+        "genesis.authority_set_hash",
+    )?;
+
+    let bridging_payment_address = source
+        .bridging_payment_address
+        .map(|value| {
+            decode_fixed_hex::<32>(value, source.relayer_id, "options.bridging_payment_address")
+                .map(H256::from)
+        })
+        .transpose()?;
+
+    Ok(MerkleRootRelayerOptions {
+        spike_config: SpikeConfig {
+            timeout: source.spike_timeout,
+            priority_timeout: source.priority_spike_timeout,
+            window: source.spike_window,
+            threshold: source.spike_threshold,
+        },
+        check_interval: source.check_interval,
+        save_interval: source.save_interval,
+        genesis_config: GenesisConfig {
+            authority_set_hash,
+            authority_set_id: source.authority_set_id,
+        },
+        last_sealed: source.start_authority_set_id,
+        confirmations: source
+            .confirmations_merkle_root
+            .unwrap_or(DEFAULT_COUNT_CONFIRMATIONS),
+        count_thread: source.thread_count,
+        bridging_payment_address,
+        critical_threshold,
+        startup_sync_strategy,
+    })
+}
+
+fn validate_effective_config(config: EffectiveConfig) -> anyhow::Result<EffectiveConfig> {
+    let mut http_addresses = HashSet::new();
+    let mut block_storage_paths = HashSet::new();
+    let mut proof_storage_paths = HashSet::new();
+
+    for relayer in &config.relayers {
+        if !http_addresses.insert(relayer.http.address.clone()) {
+            return Err(anyhow!(
+                "http.address {} is used by more than one relayer",
+                relayer.http.address
+            ));
+        }
+        if !block_storage_paths.insert(relayer.storage.block_storage.clone()) {
+            return Err(anyhow!(
+                "storage.block_storage {} is used by more than one relayer",
+                relayer.storage.block_storage.display()
+            ));
+        }
+        let proof_path = match &relayer.proof_storage {
+            EffectiveProofStorageConfig::FileSystem { path } => path,
+            EffectiveProofStorageConfig::Gear { config_dir, .. } => config_dir,
+        };
+        if !proof_storage_paths.insert(proof_path.clone()) {
+            return Err(anyhow!(
+                "proof storage path {} is used by more than one relayer",
+                proof_path.display()
+            ));
+        }
+    }
+
+    Ok(config)
+}
+
+fn validate_relayer_id(id: &str) -> anyhow::Result<()> {
+    if id.is_empty()
+        || !id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    {
+        return Err(anyhow!(
+            "invalid relayer id {id:?}; expected [A-Za-z0-9_-]+"
+        ));
+    }
+    Ok(())
+}
+
+fn decode_fixed_hex<const LEN: usize>(
+    value: &str,
+    relayer_id: &str,
+    field: &str,
+) -> anyhow::Result<[u8; LEN]> {
+    let value = value.strip_prefix("0x").unwrap_or(value);
+    let bytes = hex::decode(value)
+        .with_context(|| format!("relayer {relayer_id}: {field} is invalid hex"))?;
+    bytes.try_into().map_err(|got: Vec<u8>| {
+        anyhow!(
+            "relayer {relayer_id}: {field} has wrong length. Expected {}, got {}",
+            LEN,
+            got.len()
+        )
+    })
+}
+
+fn validate_url(value: &str, field: &str) -> anyhow::Result<()> {
+    Url::parse(value).with_context(|| format!("{field} must be a valid URL"))?;
+    Ok(())
+}
+
+fn validate_block_storage_path(path: &Path, relayer_id: &str) -> anyhow::Result<()> {
+    if path.as_os_str().is_empty() {
+        return Err(anyhow!(
+            "relayer {relayer_id}: storage.block_storage is empty"
+        ));
+    }
+    if path.exists() && path.is_dir() {
+        return Err(anyhow!(
+            "relayer {relayer_id}: storage.block_storage must be a file path, got directory {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_non_empty(value: &str, relayer_id: &str, field: &str) -> anyhow::Result<()> {
+    if value.trim().is_empty() {
+        return Err(anyhow!("relayer {relayer_id}: {field} must not be empty"));
+    }
+    Ok(())
+}
+
+fn validate_non_empty_path(path: &Path, relayer_id: &str, field: &str) -> anyhow::Result<()> {
+    if path.as_os_str().is_empty() {
+        return Err(anyhow!("relayer {relayer_id}: {field} must not be empty"));
+    }
+    Ok(())
+}
+
+fn parse_thread_count(raw: RawThreadCount, relayer_id: &str) -> anyhow::Result<Option<usize>> {
+    match raw {
+        RawThreadCount::Manual(count) if count > 0 => Ok(Some(count)),
+        RawThreadCount::Manual(_) => Err(anyhow!(
+            "relayer {relayer_id}: options.thread_count must be positive or \"auto\""
+        )),
+        RawThreadCount::Auto(value) if value.eq_ignore_ascii_case("auto") => Ok(None),
+        RawThreadCount::Auto(value) => Err(anyhow!(
+            "relayer {relayer_id}: options.thread_count must be a positive integer or \"auto\", got {value:?}"
+        )),
+    }
+}
+
+fn parse_critical_threshold(
+    value: Option<&str>,
+    relayer_id: &str,
+) -> anyhow::Result<cli::CriticalThreshold> {
+    cli::parse_critical_threshold(value.unwrap_or("4h"))
+        .with_context(|| format!("relayer {relayer_id}: options.critical_threshold is invalid"))
+}
+
+fn parse_startup_sync_strategy(
+    value: Option<&str>,
+    blocks: Vec<u32>,
+    relayer_id: &str,
+) -> anyhow::Result<cli::StartupSyncStrategy> {
+    let strategy = cli::parse_startup_sync_strategy(value.unwrap_or("critical-threshold"))
+        .with_context(|| {
+            format!("relayer {relayer_id}: options.startup_sync_strategy is invalid")
+        })?;
+
+    if strategy == cli::StartupSyncStrategy::Blocks && blocks.is_empty() {
+        return Err(anyhow!(
+            "relayer {relayer_id}: options.startup_sync_blocks must be provided when options.startup_sync_strategy=blocks"
+        ));
+    }
+    if strategy != cli::StartupSyncStrategy::Blocks && !blocks.is_empty() {
+        return Err(anyhow!(
+            "relayer {relayer_id}: options.startup_sync_blocks can only be used when options.startup_sync_strategy=blocks"
+        ));
+    }
+
+    Ok(strategy)
+}
+
+fn parse_duration(
+    value: Option<&str>,
+    default: &str,
+    relayer_id: &str,
+    field: &str,
+) -> anyhow::Result<Duration> {
+    let duration = humantime::parse_duration(value.unwrap_or(default))
+        .with_context(|| format!("relayer {relayer_id}: {field} is invalid"))?;
+    if duration.is_zero() {
+        return Err(anyhow!("relayer {relayer_id}: {field} must be positive"));
+    }
+    Ok(duration)
+}
+
+fn required<'a>(value: Option<&'a str>, field: &str) -> anyhow::Result<&'a str> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("Missing {field}"))
+}
+
+fn default_max_reconnect_attempts() -> u8 {
+    3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_config() -> String {
+        format!(
+            r#"
+[prometheus]
+endpoint = "127.0.0.1:9900"
+
+[relayers.mainnet]
+priority = 100
+
+[relayers.mainnet.gear]
+endpoint = "wss://gear.example"
+max_reconnect_attempts = 4
+
+[relayers.mainnet.ethereum]
+endpoint = "https://eth.example"
+message_queue_address = "0x1111111111111111111111111111111111111111"
+fee_payer = "0x{}"
+max_retries = 5
+retry_interval_ms = 2000
+max_fee_per_gas = 2000000000
+max_priority_fee_per_gas = 500000000
+
+[relayers.mainnet.genesis]
+authority_set_hash = "0x{}"
+authority_set_id = 42
+
+[relayers.mainnet.http]
+address = "127.0.0.1:8443"
+token = "secret"
+
+[relayers.mainnet.storage]
+block_storage = "/tmp/mainnet-blocks.json"
+
+[relayers.mainnet.proof_storage]
+kind = "filesystem"
+filesystem_path = "/tmp/mainnet-proofs"
+
+[relayers.mainnet.options]
+confirmations_merkle_root = 8
+thread_count = "auto"
+critical_threshold = "4h"
+startup_sync_strategy = "critical-threshold"
+spike_window = "15m"
+spike_timeout = "30m"
+priority_spike_timeout = "10m"
+spike_threshold = 8
+save_interval = "30m"
+check_interval = "30s"
+"#,
+            "22".repeat(32),
+            "33".repeat(32),
+        )
+    }
+
+    fn config_error(contents: &str) -> String {
+        match EffectiveConfig::from_toml_str(contents) {
+            Ok(_) => panic!("config unexpectedly parsed successfully"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    fn second_relayer(http: &str, block_storage: &str, proof_storage: &str) -> String {
+        format!(
+            r#"
+[relayers.testnet]
+priority = 50
+
+[relayers.testnet.gear]
+endpoint = "wss://gear2.example"
+
+[relayers.testnet.ethereum]
+endpoint = "https://eth2.example"
+message_queue_address = "0x2222222222222222222222222222222222222222"
+fee_payer = "0x{}"
+
+[relayers.testnet.genesis]
+authority_set_hash = "0x{}"
+authority_set_id = 43
+
+[relayers.testnet.http]
+address = "{http}"
+token = "secret2"
+
+[relayers.testnet.storage]
+block_storage = "{block_storage}"
+
+[relayers.testnet.proof_storage]
+kind = "filesystem"
+filesystem_path = "{proof_storage}"
+"#,
+            "44".repeat(32),
+            "55".repeat(32),
+        )
+    }
+
+    #[test]
+    fn parses_valid_config() {
+        let config = EffectiveConfig::from_toml_str(&valid_config()).unwrap();
+        assert_eq!(config.prometheus_endpoint, "127.0.0.1:9900");
+        assert_eq!(config.relayers.len(), 1);
+        let relayer = &config.relayers[0];
+        assert_eq!(relayer.id, "mainnet");
+        assert_eq!(relayer.priority, 100);
+        assert_eq!(relayer.gear.endpoint, "wss://gear.example");
+        assert_eq!(relayer.gear.max_reconnect_attempts, 4);
+        assert_eq!(relayer.ethereum.max_retries, Some(5));
+        assert_eq!(relayer.options.count_thread, None);
+    }
+
+    #[test]
+    fn parses_multiple_relayers_and_priorities() {
+        let config = valid_config()
+            + &second_relayer(
+                "127.0.0.1:8444",
+                "/tmp/testnet-blocks.json",
+                "/tmp/testnet-proofs",
+            );
+        let config = EffectiveConfig::from_toml_str(&config).unwrap();
+        assert_eq!(config.relayers.len(), 2);
+        assert_eq!(config.relayers[0].id, "mainnet");
+        assert_eq!(config.relayers[0].priority, 100);
+        assert_eq!(config.relayers[1].id, "testnet");
+        assert_eq!(config.relayers[1].priority, 50);
+    }
+
+    #[test]
+    fn example_config_parses() {
+        let config = EffectiveConfig::from_toml_str(include_str!("../config.toml.example"))
+            .expect("example config must stay in sync with the TOML schema");
+        assert_eq!(config.relayers.len(), 2);
+        assert_eq!(config.relayers[0].id, "mainnet");
+        assert_eq!(config.relayers[1].id, "testnet");
+    }
+
+    #[test]
+    fn rejects_empty_relayers() {
+        let err = config_error("[prometheus]\nendpoint = \"127.0.0.1:9900\"\n");
+        assert!(err.contains("relayers"));
+    }
+
+    #[test]
+    fn rejects_missing_priority() {
+        let config = valid_config().replace("priority = 100", "");
+        let err = config_error(&config);
+        assert!(err.contains("priority is required"));
+    }
+
+    #[test]
+    fn rejects_duplicate_http_address() {
+        let config = valid_config()
+            + &second_relayer(
+                "127.0.0.1:8443",
+                "/tmp/testnet-blocks.json",
+                "/tmp/testnet-proofs",
+            );
+        let err = config_error(&config);
+        assert!(err.contains("http.address"));
+    }
+
+    #[test]
+    fn rejects_duplicate_block_storage() {
+        let config = valid_config()
+            + &second_relayer(
+                "127.0.0.1:8444",
+                "/tmp/mainnet-blocks.json",
+                "/tmp/testnet-proofs",
+            );
+        let err = config_error(&config);
+        assert!(err.contains("storage.block_storage"));
+    }
+
+    #[test]
+    fn rejects_duplicate_proof_storage() {
+        let config = valid_config()
+            + &second_relayer(
+                "127.0.0.1:8444",
+                "/tmp/testnet-blocks.json",
+                "/tmp/mainnet-proofs",
+            );
+        let err = config_error(&config);
+        assert!(err.contains("proof storage path"));
+    }
+
+    #[test]
+    fn rejects_invalid_ethereum_fee_payer() {
+        let config = valid_config().replace(
+            &format!("fee_payer = \"0x{}\"", "22".repeat(32)),
+            "fee_payer = \"\"",
+        );
+        let err = config_error(&config);
+        assert!(err.contains("ethereum.fee_payer"));
+    }
+
+    #[test]
+    fn rejects_empty_http_token() {
+        let config = valid_config().replace("token = \"secret\"", "token = \"\"");
+        let err = config_error(&config);
+        assert!(err.contains("http.token"));
+    }
+
+    #[test]
+    fn rejects_empty_filesystem_proof_storage_path() {
+        let config = valid_config().replace(
+            "filesystem_path = \"/tmp/mainnet-proofs\"",
+            "filesystem_path = \"\"",
+        );
+        let err = config_error(&config);
+        assert!(err.contains("proof_storage.filesystem_path"));
+    }
+
+    #[test]
+    fn rejects_invalid_relayer_id() {
+        let config = valid_config().replace("[relayers.mainnet", "[relayers.\"bad.id\"");
+        let err = config_error(&config);
+        assert!(err.contains("invalid relayer id"));
+    }
+
+    #[test]
+    fn rejects_startup_blocks_without_blocks_strategy() {
+        let config = valid_config()
+            + r#"
+startup_sync_blocks = [1, 2]
+"#;
+        let err = config_error(&config);
+        assert!(err.contains("startup_sync_blocks"));
+    }
+
+    #[test]
+    fn rejects_tiny_critical_threshold() {
+        let config =
+            valid_config().replace("critical_threshold = \"4h\"", "critical_threshold = \"2s\"");
+        let err = config_error(&config);
+        assert!(err.contains("at least 3 seconds"));
+    }
+
+    #[test]
+    fn rejects_zero_duration() {
+        let config = valid_config().replace("check_interval = \"30s\"", "check_interval = \"0s\"");
+        let err = config_error(&config);
+        assert!(err.contains("options.check_interval"));
+        assert!(err.contains("positive"));
+    }
+
+    #[test]
+    fn rejects_zero_thread_count() {
+        let config = valid_config().replace("thread_count = \"auto\"", "thread_count = 0");
+        let err = config_error(&config);
+        assert!(err.contains("options.thread_count"));
+        assert!(err.contains("positive"));
+    }
+
+    #[test]
+    fn rejects_priority_timeout_greater_than_regular_timeout() {
+        let config = valid_config().replace(
+            "priority_spike_timeout = \"10m\"",
+            "priority_spike_timeout = \"40m\"",
+        );
+        let err = config_error(&config);
+        assert!(err.contains("priority_spike_timeout"));
+    }
+}

--- a/relayer/src/kill_switch.rs
+++ b/relayer/src/kill_switch.rs
@@ -177,12 +177,6 @@ impl KillSwitchRelayer {
                 Err(err) => {
                     loop_delay = ERROR_REPEAT_DELAY;
 
-                    let eth_api = if let State::SubmitMerkleRoot { .. } = self.state {
-                        self.eth_admin_api.as_ref().expect("bad state")
-                    } else {
-                        &self.eth_observer_api
-                    };
-
                     match err {
                         Error::ScanForEvents(ScanForEventsError::EthApi(
                             ethereum_client::Error::ErrorInHTTPTransport(err),
@@ -198,8 +192,17 @@ impl KillSwitchRelayer {
                                 log::error!(
                                     "Recoverable Ethereum transport error: {err}, reconnecting..."
                                 );
-                                if let Err(e) = eth_api.reconnect().await {
-                                    log::error!("Ethereum API reconnect failed: {e}");
+                                if let State::SubmitMerkleRoot { .. } = self.state {
+                                    let eth_api = self.eth_admin_api.as_mut().expect("bad state");
+                                    match eth_api.reconnect().await {
+                                        Ok(reconnected) => *eth_api = reconnected,
+                                        Err(e) => log::error!("Ethereum API reconnect failed: {e}"),
+                                    }
+                                } else {
+                                    match self.eth_observer_api.reconnect().await {
+                                        Ok(reconnected) => self.eth_observer_api = reconnected,
+                                        Err(e) => log::error!("Ethereum API reconnect failed: {e}"),
+                                    }
                                 }
                             }
                         }

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod common;
+pub mod config;
 pub mod ethereum_checkpoints;
 pub mod hex_utils;
 pub mod kill_switch;

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -8,4 +8,5 @@ pub mod message_relayer;
 pub mod proof_storage;
 pub mod prover_interface;
 pub mod queue_cleaner;
+pub mod rpc;
 pub mod server;

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -1,3 +1,4 @@
+use actix_web::dev::ServerHandle;
 use anyhow::{anyhow, Context, Result as AnyResult};
 use clap::Parser;
 use eth_events_electra_client::traits::EthereumEventClient;
@@ -13,13 +14,17 @@ use relayer::{
     cli::{
         BeaconRpcArgs, Cli, CliCommands, EthGearManualArgs, EthGearTokensArgs,
         EthGearTokensCommands, EthereumArgs, EthereumKillSwitchArgs, EthereumSignerArgs, FeePayers,
-        FetchMerkleRootsArgs, GearArgs, GearEthTokensCommands, GearSignerArgs, ProofStorageArgs,
+        FetchMerkleRootsArgs, GearEthCoreArgs, GearEthTokensCommands, GearSignerArgs,
         DEFAULT_COUNT_CONFIRMATIONS, DEFAULT_COUNT_THREADS,
     },
-    common, ethereum_checkpoints, hex_utils,
+    common,
+    config::{
+        EffectiveConfig, EffectiveEthereumConfig, EffectiveGearConfig, EffectiveProofStorageConfig,
+        EffectiveRelayerConfig,
+    },
+    ethereum_checkpoints, hex_utils,
     kill_switch::KillSwitchRelayer,
-    merkle_roots,
-    merkle_roots::MerkleRootRelayerOptions,
+    merkle_roots::{self, prover::SharedFinalityProver},
     message_relayer::{self, eth_to_gear, gear_to_eth},
     proof_storage::{FileSystemProofStorage, GearProofStorage, ProofStorage},
     prover_interface, server,
@@ -29,6 +34,7 @@ use std::{
     collections::HashSet,
     env,
     fs::{self, File},
+    future::Future,
     io::Read as _,
     net::TcpListener,
     path::Path,
@@ -38,7 +44,7 @@ use std::{
 };
 
 use tokio::{sync::mpsc, task, time};
-use utils_prometheus::MetricsBuilder;
+use utils_prometheus::{MeteredService, MetricsBuilder};
 use vft_manager_client::traits::VftManager;
 use zeroize::Zeroizing;
 
@@ -185,70 +191,8 @@ async fn run() -> AnyResult<()> {
             log::info!("merkle_root = '{}'", hex::encode(proof.merkle_root));
         }
 
-        CliCommands::GearEthCore(mut args) => {
-            let rust_min_stack = env::var("RUST_MIN_STACK").context("RUST_MIN_STACK")?;
-            let rust_min_stack = rust_min_stack.parse::<usize>().context("RUST_MIN_STACK")?;
-            if rust_min_stack < SIZE_THREAD_STACK_MIN {
-                return Err(anyhow!("RUST_MIN_STACK={rust_min_stack} is less than the required minimum ({SIZE_THREAD_STACK_MIN}). Re-run the program with the corresponding environment variable set.\n\nAt the moment we cannot control how the external libraries spawn threads so base on the environment variable from standard library. For details - https://doc.rust-lang.org/std/thread/index.html#stack-size"));
-            }
-
-            let api_provider = ApiProvider::new(
-                args.gear_args.get_endpoint()?,
-                args.gear_args.max_reconnect_attempts,
-            )
-            .await
-            .expect("Failed to connect to Gear API");
-
-            let Some(path) = args.block_storage_args.path.take() else {
-                return Err(anyhow!("No block storage path provided"));
-            };
-
-            let eth_api = create_eth_signer_client(&args.ethereum_args).await;
-
-            let metrics = MetricsBuilder::new();
-
-            let (proof_storage, metrics) =
-                create_proof_storage(&args.proof_storage_args, &args.gear_args, metrics).await;
-            let storage =
-                relayer::merkle_roots::storage::MerkleRootStorage::new(proof_storage, path);
-
-            let options = MerkleRootRelayerOptions::from_cli(&args)?;
-
-            let tcp_listener = TcpListener::bind(&args.web_server_address)?;
-
-            let (sender, receiver) = mpsc::unbounded_channel();
-            let web_server =
-                server::create(tcp_listener, args.web_server_token, None, Some(sender))
-                    .context("Failed to create web server")?;
-            let handle_server = web_server.handle();
-            tokio::spawn(web_server);
-
-            let relayer = merkle_roots::Relayer::new(
-                api_provider.connection(),
-                eth_api,
-                receiver,
-                storage,
-                options,
-            )
-            .await;
-
-            metrics
-                .register_service(&relayer)
-                .build()
-                .run(args.prometheus_args.prometheus_endpoint)
-                .await;
-            api_provider.spawn();
-
-            let res = relayer.run().await;
-
-            if tokio::time::timeout(Duration::from_secs(5 * 60), handle_server.stop(true))
-                .await
-                .is_err()
-            {
-                log::error!("Failed to stop web server within timeout");
-                std::process::exit(1);
-            }
-            return res;
+        CliCommands::GearEthCore(args) => {
+            return run_gear_eth_core(args).await;
         }
 
         CliCommands::KillSwitch(args) => {
@@ -420,9 +364,14 @@ async fn run() -> AnyResult<()> {
                     // spawn web-server
                     let tcp_listener = TcpListener::bind(web_server_address)?;
                     let (sender, receiver) = mpsc::unbounded_channel();
-                    let web_server =
-                        server::create(tcp_listener, web_server_token, Some(sender), None)
-                            .context("Failed to create web server")?;
+                    let web_server = server::create(
+                        tcp_listener,
+                        web_server_token,
+                        "gear-eth-token-paid-transfers".to_string(),
+                        Some(sender),
+                        None,
+                    )
+                    .context("Failed to create web server")?;
                     let handle_server = web_server.handle();
                     task::spawn(web_server);
 
@@ -739,6 +688,277 @@ async fn run() -> AnyResult<()> {
     Ok(())
 }
 
+async fn run_gear_eth_core(args: GearEthCoreArgs) -> AnyResult<()> {
+    let rust_min_stack = env::var("RUST_MIN_STACK").context("RUST_MIN_STACK")?;
+    let rust_min_stack = rust_min_stack.parse::<usize>().context("RUST_MIN_STACK")?;
+    if rust_min_stack < SIZE_THREAD_STACK_MIN {
+        return Err(anyhow!("RUST_MIN_STACK={rust_min_stack} is less than the required minimum ({SIZE_THREAD_STACK_MIN}). Re-run the program with the corresponding environment variable set.\n\nAt the moment we cannot control how the external libraries spawn threads so base on the environment variable from standard library. For details - https://doc.rust-lang.org/std/thread/index.html#stack-size"));
+    }
+
+    let EffectiveConfig {
+        prometheus_endpoint,
+        relayers,
+    } = match args.config.as_ref() {
+        Some(path) => EffectiveConfig::from_path(path)?,
+        None => EffectiveConfig::from_cli(&args)?,
+    };
+
+    if relayers.len() == 1 {
+        let relayer = relayers
+            .into_iter()
+            .next()
+            .expect("relayers length is checked immediately above");
+        let running =
+            start_gear_eth_core_relayer(relayer, Some(prometheus_endpoint), None, false).await?;
+        return wait_single_relayer(running).await;
+    }
+
+    run_gear_eth_core_relayers(relayers, prometheus_endpoint).await
+}
+
+struct RunningGearEthCoreRelayer {
+    id: String,
+    task: task::JoinHandle<AnyResult<()>>,
+    server_handle: ServerHandle,
+    metrics: Option<MetricsBuilder>,
+}
+
+async fn run_gear_eth_core_relayers(
+    relayers: Vec<EffectiveRelayerConfig>,
+    prometheus_endpoint: String,
+) -> AnyResult<()> {
+    log::info!(
+        "Starting {} merkle-root relayers in one process. Prometheus endpoint {prometheus_endpoint} uses relayer labels for per-relayer collectors",
+        relayers.len()
+    );
+
+    let shared_prover = SharedFinalityProver::new();
+    let mut metrics = MetricsBuilder::new();
+    metrics.register_service_mut(&shared_prover);
+
+    let mut running = start_required_gear_eth_core_relayers(relayers, |relayer| {
+        start_gear_eth_core_relayer(relayer, None, Some(&shared_prover), true)
+    })
+    .await?;
+
+    for relayer in &mut running {
+        if let Some(relayer_metrics) = relayer.metrics.take() {
+            metrics.append(relayer_metrics);
+        }
+    }
+    metrics.build().run(prometheus_endpoint).await;
+
+    supervise_running_gear_eth_core_relayers(running).await
+}
+
+async fn start_required_gear_eth_core_relayers<I, F, Fut>(
+    relayers: impl IntoIterator<Item = I>,
+    mut start: F,
+) -> AnyResult<Vec<RunningGearEthCoreRelayer>>
+where
+    F: FnMut(I) -> Fut,
+    Fut: Future<Output = AnyResult<RunningGearEthCoreRelayer>>,
+{
+    let mut running = Vec::new();
+    for relayer in relayers {
+        match start(relayer).await {
+            Ok(relayer) => running.push(relayer),
+            Err(err) => {
+                stop_running_gear_eth_core_relayers(running).await;
+                return Err(err);
+            }
+        }
+    }
+    Ok(running)
+}
+
+async fn stop_running_gear_eth_core_relayers(running: Vec<RunningGearEthCoreRelayer>) {
+    let mut tasks = Vec::with_capacity(running.len());
+    for relayer in running {
+        stop_web_server(relayer.server_handle).await;
+        relayer.task.abort();
+        tasks.push(relayer.task);
+    }
+
+    for task in tasks {
+        let _ = task.await;
+    }
+}
+
+async fn supervise_running_gear_eth_core_relayers(
+    running: Vec<RunningGearEthCoreRelayer>,
+) -> AnyResult<()> {
+    if running.is_empty() {
+        return Err(anyhow!("no merkle-root relayers started"));
+    }
+
+    let mut tasks = Vec::with_capacity(running.len());
+    let mut ids = Vec::with_capacity(running.len());
+    let mut server_handles = Vec::with_capacity(running.len());
+
+    for relayer in running {
+        ids.push(relayer.id);
+        server_handles.push(relayer.server_handle);
+        tasks.push(relayer.task);
+    }
+
+    let (result, index, remaining_tasks) = futures::future::select_all(tasks).await;
+    for server_handle in server_handles {
+        stop_web_server(server_handle).await;
+    }
+    for task in remaining_tasks {
+        task.abort();
+    }
+
+    let id = ids
+        .get(index)
+        .cloned()
+        .unwrap_or_else(|| "<unknown>".to_string());
+
+    match result {
+        Ok(Ok(())) => Err(anyhow!("merkle-root relayer {id} exited unexpectedly")),
+        Ok(Err(err)) => Err(err).with_context(|| format!("merkle-root relayer {id} failed")),
+        Err(err) => Err(anyhow!("merkle-root relayer {id} task failed: {err}")),
+    }
+}
+
+async fn wait_single_relayer(running: RunningGearEthCoreRelayer) -> AnyResult<()> {
+    let RunningGearEthCoreRelayer {
+        id,
+        task,
+        server_handle,
+        ..
+    } = running;
+    match task.await {
+        Ok(result) => result,
+        Err(err) => {
+            stop_web_server(server_handle).await;
+            Err(anyhow!("merkle-root relayer {id} task failed: {err}"))
+        }
+    }
+}
+
+async fn start_gear_eth_core_relayer(
+    config: EffectiveRelayerConfig,
+    prometheus_endpoint: Option<String>,
+    shared_prover: Option<&SharedFinalityProver>,
+    label_metrics: bool,
+) -> AnyResult<RunningGearEthCoreRelayer> {
+    let id = config.id.clone();
+    let api_provider = ApiProvider::new(
+        config.gear.endpoint.clone(),
+        config.gear.max_reconnect_attempts,
+    )
+    .await
+    .context("Failed to connect to Gear API")?;
+
+    let eth_api = create_eth_signer_client_from_config(&config.ethereum).await?;
+
+    let mut metrics = MetricsBuilder::new();
+
+    let metric_relayer_id = label_metrics.then_some(id.as_str());
+    let proof_storage = create_proof_storage_from_config(
+        &config.proof_storage,
+        &config.gear,
+        &mut metrics,
+        metric_relayer_id,
+    )
+    .await?;
+    let storage = relayer::merkle_roots::storage::MerkleRootStorage::new(
+        proof_storage,
+        config.storage.block_storage.clone(),
+    );
+
+    let tcp_listener = TcpListener::bind(&config.http.address)?;
+
+    let (sender, receiver) = mpsc::unbounded_channel();
+    let web_server = server::create(
+        tcp_listener,
+        config.http.token.clone(),
+        format!("merkle-root relayer {}", config.id),
+        None,
+        Some(sender),
+    )
+    .context("Failed to create web server")?;
+    let handle_server = web_server.handle();
+    let task_handle_server = handle_server.clone();
+    tokio::spawn(web_server);
+
+    let relayer = if let Some(shared_prover) = shared_prover {
+        let prover = shared_prover.register(
+            id.clone(),
+            config.priority,
+            api_provider.connection(),
+            config.options.genesis_config,
+            config.options.count_thread,
+        );
+        merkle_roots::Relayer::new_with_prover_io(
+            api_provider.connection(),
+            eth_api,
+            receiver,
+            storage,
+            config.options,
+            prover,
+        )
+        .await
+    } else {
+        merkle_roots::Relayer::new(
+            api_provider.connection(),
+            eth_api,
+            receiver,
+            storage,
+            config.options,
+        )
+        .await
+    };
+
+    register_gear_eth_core_metrics(&mut metrics, metric_relayer_id, &relayer);
+
+    let metrics = if let Some(prometheus_endpoint) = prometheus_endpoint {
+        metrics.build().run(prometheus_endpoint).await;
+        None
+    } else {
+        Some(metrics)
+    };
+    api_provider.spawn();
+
+    let task_id = id.clone();
+    let task = tokio::spawn(async move {
+        let result = relayer.run().await;
+        stop_web_server(task_handle_server).await;
+        result
+    });
+
+    Ok(RunningGearEthCoreRelayer {
+        id: task_id,
+        task,
+        server_handle: handle_server,
+        metrics,
+    })
+}
+
+fn register_gear_eth_core_metrics(
+    metrics: &mut MetricsBuilder,
+    relayer_id: Option<&str>,
+    service: &impl MeteredService,
+) {
+    if let Some(relayer_id) = relayer_id {
+        metrics.register_labeled_service_mut(service, [("relayer", relayer_id)]);
+    } else {
+        metrics.register_service_mut(service);
+    }
+}
+
+async fn stop_web_server(handle: ServerHandle) {
+    if tokio::time::timeout(Duration::from_secs(5 * 60), handle.stop(true))
+        .await
+        .is_err()
+    {
+        log::error!("Failed to stop web server within timeout");
+        std::process::exit(1);
+    }
+}
+
 async fn create_gclient_client(args: &GearSignerArgs) -> gclient::GearApi {
     let endpoint = args.connection.get_endpoint().expect("Invalid gear args");
     gclient::GearApi::builder()
@@ -767,6 +987,20 @@ async fn create_eth_signer_client(args: &EthereumSignerArgs) -> EthApi {
     )
     .await
     .expect("Error while creating ethereum client")
+}
+
+async fn create_eth_signer_client_from_config(args: &EffectiveEthereumConfig) -> AnyResult<EthApi> {
+    EthApi::new_with_retries(
+        &args.endpoint,
+        &args.message_queue_address,
+        Some(&args.fee_payer),
+        args.max_retries,
+        args.retry_interval_ms.map(Duration::from_millis),
+        args.max_fee_per_gas,
+        args.max_priority_fee_per_gas,
+    )
+    .await
+    .context("Error while creating ethereum client")
 }
 
 async fn create_eth_killswitch_client(
@@ -839,31 +1073,37 @@ async fn create_beacon_client(args: &BeaconRpcArgs) -> BeaconClient {
         .expect("Failed to create beacon client")
 }
 
-async fn create_proof_storage(
-    proof_storage_args: &ProofStorageArgs,
-    gear_args: &GearArgs,
-    mut metrics: MetricsBuilder,
-) -> (Arc<dyn ProofStorage>, MetricsBuilder) {
-    let proof_storage: Arc<dyn ProofStorage> =
-        if let Some(fee_payer) = proof_storage_args.gear_fee_payer.as_ref() {
+async fn create_proof_storage_from_config(
+    proof_storage_config: &EffectiveProofStorageConfig,
+    gear_config: &EffectiveGearConfig,
+    metrics: &mut MetricsBuilder,
+    relayer_id: Option<&str>,
+) -> AnyResult<Arc<dyn ProofStorage>> {
+    let proof_storage: Arc<dyn ProofStorage> = match proof_storage_config {
+        EffectiveProofStorageConfig::Gear {
+            fee_payer,
+            config_dir,
+        } => {
             let proof_storage = GearProofStorage::new(
-                &gear_args.get_endpoint().expect("Invalid endpoint"),
-                gear_args.max_reconnect_attempts,
+                &gear_config.endpoint,
+                gear_config.max_reconnect_attempts,
                 fee_payer,
-                "./onchain_proof_storage_data".into(),
+                config_dir.clone(),
             )
             .await
-            .expect("Failed to initialize proof storage");
+            .context("Failed to initialize proof storage")?;
 
-            metrics = metrics.register_service(&proof_storage);
+            register_gear_eth_core_metrics(metrics, relayer_id, &proof_storage);
 
             Arc::new(proof_storage)
-        } else {
+        }
+        EffectiveProofStorageConfig::FileSystem { path } => {
             log::warn!("Fee payer not present, falling back to FileSystemProofStorage");
-            Arc::new(FileSystemProofStorage::new("./proof_storage".into()).await)
-        };
+            Arc::new(FileSystemProofStorage::new(path.clone()).await)
+        }
+    };
 
-    (proof_storage, metrics)
+    Ok(proof_storage)
 }
 
 async fn fetch_merkle_roots(args: FetchMerkleRootsArgs) -> AnyResult<()> {
@@ -934,4 +1174,187 @@ async fn fetch_historical_proxy_and_checkpoints(
     log::info!("Checkpoint light client address is {checkpoints_address:#?} for slot #{slot}");
 
     Ok((historical_proxy_address, checkpoints_address))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{web, App, HttpResponse, HttpServer};
+    use std::{
+        net::SocketAddr,
+        sync::{Arc, Mutex},
+    };
+
+    #[tokio::test]
+    async fn supervisor_reports_unexpected_relayer_exit_with_id() {
+        let (running, _addr) = dummy_running_relayer("mainnet", Ok(()));
+
+        let err = supervise_running_gear_eth_core_relayers(vec![running])
+            .await
+            .expect_err("supervisor must reject unexpected relayer exit");
+
+        assert!(err.to_string().contains("mainnet"));
+        assert!(err.to_string().contains("exited unexpectedly"));
+    }
+
+    #[tokio::test]
+    async fn supervisor_reports_relayer_error_with_id() {
+        let (running, _addr) = dummy_running_relayer("testnet", Err(anyhow!("boom")));
+
+        let err = supervise_running_gear_eth_core_relayers(vec![running])
+            .await
+            .expect_err("supervisor must report relayer task error");
+
+        assert!(err.to_string().contains("testnet"));
+        assert!(err.to_string().contains("failed"));
+    }
+
+    #[tokio::test]
+    async fn supervisor_stops_http_server_on_relayer_exit() {
+        let (running, addr) = dummy_running_relayer("mainnet", Ok(()));
+        wait_until_server_accepts(addr).await;
+
+        let _ = supervise_running_gear_eth_core_relayers(vec![running])
+            .await
+            .expect_err("unexpected relayer exit should still stop the HTTP server");
+
+        wait_until_server_stops(addr).await;
+    }
+
+    #[tokio::test]
+    async fn startup_failure_stops_already_started_relayers() {
+        let started_addr = Arc::new(Mutex::new(None));
+        let started_addr_for_start = started_addr.clone();
+
+        let err = match start_required_gear_eth_core_relayers(["first", "second"], |id| {
+            let id = id.to_string();
+            let started_addr = started_addr_for_start.clone();
+            async move {
+                if id == "first" {
+                    let (running, addr) = dummy_pending_relayer(&id);
+                    *started_addr.lock().unwrap() = Some(addr);
+                    wait_until_server_accepts(addr).await;
+                    Ok(running)
+                } else {
+                    Err(anyhow!("failed to start {id}"))
+                }
+            }
+        })
+        .await
+        {
+            Ok(_) => panic!("startup failure must be returned"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("second"));
+        let addr = started_addr
+            .lock()
+            .unwrap()
+            .expect("first relayer must have started");
+        wait_until_server_stops(addr).await;
+    }
+
+    #[tokio::test]
+    async fn startup_starts_all_requested_relayers() {
+        let mut addresses = Vec::new();
+        let running = start_required_gear_eth_core_relayers(["first", "second", "third"], |id| {
+            let (running, addr) = dummy_pending_relayer(id);
+            addresses.push(addr);
+            async move { Ok(running) }
+        })
+        .await
+        .expect("all relayers should start");
+
+        assert_eq!(running.len(), 3);
+        for addr in &addresses {
+            wait_until_server_accepts(*addr).await;
+        }
+
+        stop_running_gear_eth_core_relayers(running).await;
+
+        for addr in addresses {
+            wait_until_server_stops(addr).await;
+        }
+    }
+
+    fn dummy_running_relayer(
+        id: &str,
+        result: AnyResult<()>,
+    ) -> (RunningGearEthCoreRelayer, SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = HttpServer::new(|| {
+            App::new().route("/", web::get().to(|| async { HttpResponse::Ok().finish() }))
+        })
+        .listen(listener)
+        .unwrap()
+        .disable_signals()
+        .run();
+        let server_handle = server.handle();
+        tokio::spawn(server);
+
+        (
+            RunningGearEthCoreRelayer {
+                id: id.to_string(),
+                task: tokio::spawn(async move { result }),
+                server_handle,
+                metrics: None,
+            },
+            addr,
+        )
+    }
+
+    fn dummy_pending_relayer(id: &str) -> (RunningGearEthCoreRelayer, SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = HttpServer::new(|| {
+            App::new().route("/", web::get().to(|| async { HttpResponse::Ok().finish() }))
+        })
+        .listen(listener)
+        .unwrap()
+        .disable_signals()
+        .run();
+        let server_handle = server.handle();
+        tokio::spawn(server);
+
+        (
+            RunningGearEthCoreRelayer {
+                id: id.to_string(),
+                task: tokio::spawn(async { futures::future::pending::<AnyResult<()>>().await }),
+                server_handle,
+                metrics: None,
+            },
+            addr,
+        )
+    }
+
+    async fn wait_until_server_accepts(addr: SocketAddr) {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let url = format!("http://{addr}/");
+        for _ in 0..50 {
+            if client.get(&url).send().await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("dummy HTTP server did not start");
+    }
+
+    async fn wait_until_server_stops(addr: SocketAddr) {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+        let url = format!("http://{addr}/");
+        for _ in 0..50 {
+            if client.get(&url).send().await.is_err() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("dummy HTTP server did not stop");
+    }
 }

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -37,7 +37,7 @@ use std::{
     future::Future,
     io::Read as _,
     net::TcpListener,
-    path::Path,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -182,6 +182,7 @@ async fn run() -> AnyResult<()> {
                 genesis_config,
                 block_hash,
                 count_thread,
+                PathBuf::from("data"),
                 Some(gear_api.produce_finality_proof(&justification).await?),
             )
             .await?;
@@ -891,6 +892,7 @@ async fn start_gear_eth_core_relayer(
             api_provider.connection(),
             config.options.genesis_config,
             config.options.count_thread,
+            config.options.gnark_data_path.clone(),
         );
         merkle_roots::Relayer::new_with_prover_io(
             api_provider.connection(),

--- a/relayer/src/merkle_roots/authority_set_sync.rs
+++ b/relayer/src/merkle_roots/authority_set_sync.rs
@@ -2,6 +2,7 @@ use crate::{
     common::{sync_authority_set_id, SyncStepCount},
     message_relayer::common::GearBlock,
     proof_storage::ProofStorage,
+    rpc,
 };
 use futures::executor::block_on;
 use gear_common::api_provider::ApiProviderConnection;
@@ -152,15 +153,24 @@ impl AuthoritySetSync {
                             };
                         }
                         Some(Request::Initialize) => {
-                            let client = self.api_provider.client();
                             log::info!("Initializing authority set sync");
                             let latest_proven_authority_set_id = self.proof_storage.get_latest_authority_set_id().await;
                             if latest_proven_authority_set_id.is_none() {
                                 log::info!("No authority set found in proof storage, syncing from genesis");
                                 let genesis_authority_set_id = self.genesis_config.authority_set_id;
-                                let genesis_block_hash = client.find_era_first_block(genesis_authority_set_id + 1).await?;
-                                let genesis_block = client.get_block_at(genesis_block_hash).await?;
-                                let block = GearBlock::from_subxt_block(&client, genesis_block).await?;
+                                let block = rpc::retry_gear(
+                                    &mut self.api_provider,
+                                    "authority set sync initialize",
+                                    move |client| async move {
+                                        let genesis_block_hash = client
+                                            .find_era_first_block(genesis_authority_set_id + 1)
+                                            .await?;
+                                        let genesis_block =
+                                            client.get_block_at(genesis_block_hash).await?;
+                                        GearBlock::from_subxt_block(&client, genesis_block).await
+                                    },
+                                )
+                                .await?;
                                 let Some(_) = self.sync_authority_set_completely(&block, blocks, responses).await? else {
                                     return Ok(());
                                 };
@@ -265,32 +275,51 @@ impl AuthoritySetSync {
         block: &GearBlock,
         responses: &UnboundedSender<Response>,
     ) -> anyhow::Result<(SyncStepCount, u64)> {
-        let gear_api = self.api_provider.client();
-
         let finalized_head = block.hash();
-        let latest_authority_set_id = gear_api.authority_set_id(finalized_head).await?;
+        let proof_storage = self.proof_storage.clone();
+        let genesis_config = self.genesis_config;
+        let responses = responses.clone();
+        let count_thread = self.count_thread;
+
+        let (sync_steps, latest_authority_set_id, latest_proven_authority_set_id) =
+            rpc::retry_gear(
+                &mut self.api_provider,
+                "authority set sync",
+                move |gear_api| {
+                    let proof_storage = proof_storage.clone();
+                    let responses = responses.clone();
+                    async move {
+                        let latest_authority_set_id =
+                            gear_api.authority_set_id(finalized_head).await?;
+                        let latest_proven_authority_set_id =
+                            proof_storage.get_latest_authority_set_id().await;
+                        let sync_steps = sync_authority_set_id(
+                            &gear_api,
+                            &proof_storage,
+                            genesis_config,
+                            latest_authority_set_id,
+                            latest_proven_authority_set_id,
+                            &responses,
+                            count_thread,
+                        )
+                        .await?;
+                        Ok::<_, anyhow::Error>((
+                            sync_steps,
+                            latest_authority_set_id,
+                            latest_proven_authority_set_id,
+                        ))
+                    }
+                },
+            )
+            .await?;
 
         self.metrics
             .latest_observed_gear_era
             .set(latest_authority_set_id as i64);
-        let latest_proven_authority_set_id = self.proof_storage.get_latest_authority_set_id().await;
-
-        if let Some(&latest_proven) = latest_proven_authority_set_id.as_ref() {
+        if let Some(latest_proven) = latest_proven_authority_set_id {
             self.metrics.latest_proven_era.set(latest_proven as i64);
         }
 
-        Ok((
-            sync_authority_set_id(
-                &gear_api,
-                &self.proof_storage,
-                self.genesis_config,
-                latest_authority_set_id,
-                latest_proven_authority_set_id,
-                responses,
-                self.count_thread,
-            )
-            .await?,
-            latest_authority_set_id,
-        ))
+        Ok((sync_steps, latest_authority_set_id))
     }
 }

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -1,6 +1,5 @@
 use crate::{
-    cli::{self, GearEthCoreArgs, DEFAULT_COUNT_CONFIRMATIONS, DEFAULT_COUNT_THREADS},
-    hex_utils,
+    cli::GearEthCoreArgs,
     merkle_roots::{authority_set_sync::AuthoritySetSyncIo, prover::FinalityProverIo},
     message_relayer::common::{
         gear::block_listener::BlockListener,
@@ -11,10 +10,7 @@ use crate::{
     prover_interface::FinalProof,
     rpc,
 };
-use ::prover::{
-    consts::BLAKE2_DIGEST_SIZE,
-    proving::{GenesisConfig, ProofWithCircuitData},
-};
+use ::prover::proving::{GenesisConfig, ProofWithCircuitData};
 use anyhow::Context;
 use ethereum_client::EthApi;
 use gear_common::api_provider::ApiProviderConnection;
@@ -46,7 +42,7 @@ pub mod submitter;
 pub struct Relayer {
     merkle_roots: MerkleRootRelayer,
     authority_set_sync: authority_set_sync::AuthoritySetSync,
-    prover: prover::FinalityProver,
+    prover: ProverSource,
     submitter: submitter::MerkleRootSubmitter,
     block_listener: BlockListener,
 
@@ -54,14 +50,22 @@ pub struct Relayer {
     http: UnboundedReceiver<MerkleRootsRequest>,
 }
 
+enum ProverSource {
+    Owned(prover::FinalityProver),
+    External(FinalityProverIo),
+}
+
 impl MeteredService for Relayer {
     fn get_sources(&self) -> impl IntoIterator<Item = Box<dyn prometheus::core::Collector>> {
-        self.authority_set_sync
-            .get_sources()
-            .into_iter()
-            .chain(self.merkle_roots.get_sources())
-            .chain(self.submitter.get_sources())
-            .chain(self.prover.get_sources())
+        let mut sources: Vec<Box<dyn prometheus::core::Collector>> = Vec::new();
+        sources.extend(self.authority_set_sync.get_sources());
+        sources.extend(self.block_listener.get_sources());
+        sources.extend(self.merkle_roots.get_sources());
+        sources.extend(self.submitter.get_sources());
+        if let ProverSource::Owned(prover) = &self.prover {
+            sources.extend(prover.get_sources());
+        }
+        sources
     }
 }
 
@@ -84,11 +88,11 @@ impl Relayer {
         )
         .await;
 
-        let prover = prover::FinalityProver::new(
+        let prover = ProverSource::Owned(prover::FinalityProver::new(
             api_provider.clone(),
             options.genesis_config,
             options.count_thread,
-        );
+        ));
 
         let submitter = submitter::MerkleRootSubmitter::new(
             eth_api.clone(),
@@ -101,6 +105,44 @@ impl Relayer {
             merkle_roots,
             authority_set_sync,
             prover,
+            submitter,
+            block_listener,
+
+            eth_api,
+            http,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_with_prover_io(
+        api_provider: ApiProviderConnection,
+        eth_api: EthApi,
+        http: UnboundedReceiver<MerkleRootsRequest>,
+        storage: Arc<MerkleRootStorage>,
+        options: MerkleRootRelayerOptions,
+        prover: FinalityProverIo,
+    ) -> Self {
+        let block_listener = BlockListener::new(api_provider.clone(), storage.clone());
+
+        let authority_set_sync = authority_set_sync::AuthoritySetSync::new(
+            api_provider.clone(),
+            storage.proofs.clone(),
+            options.genesis_config,
+            options.count_thread,
+        )
+        .await;
+
+        let submitter = submitter::MerkleRootSubmitter::new(
+            eth_api.clone(),
+            storage.clone(),
+            options.confirmations,
+        );
+        let merkle_roots = MerkleRootRelayer::new(api_provider, storage, options).await;
+
+        Self {
+            merkle_roots,
+            authority_set_sync,
+            prover: ProverSource::External(prover),
             submitter,
             block_listener,
 
@@ -124,7 +166,10 @@ impl Relayer {
         let [blocks0, blocks1] = block_listener.run().await;
 
         let authority_set_sync = authority_set_sync.run(blocks1);
-        let prover = prover.run();
+        let prover = match prover {
+            ProverSource::Owned(prover) => prover.run(),
+            ProverSource::External(prover) => prover,
+        };
         let submitter = submitter.run();
 
         merkle_roots
@@ -1370,69 +1415,12 @@ pub struct MerkleRootRelayerOptions {
 
 impl MerkleRootRelayerOptions {
     pub fn from_cli(config: &GearEthCoreArgs) -> anyhow::Result<Self> {
-        if config.startup_sync_strategy != cli::StartupSyncStrategy::Blocks
-            && !config.startup_sync_blocks.is_empty()
-        {
-            return Err(anyhow::anyhow!(
-                "startup-sync-blocks can only be used when startup-sync-strategy=blocks"
-            ));
-        }
-
-        let startup_sync_strategy = match config.startup_sync_strategy {
-            cli::StartupSyncStrategy::CriticalThreshold => StartupSyncStrategy::CriticalThreshold,
-            cli::StartupSyncStrategy::SkipCatchUp => StartupSyncStrategy::SkipCatchUp,
-            cli::StartupSyncStrategy::Blocks => {
-                if config.startup_sync_blocks.is_empty() {
-                    return Err(anyhow::anyhow!(
-                        "startup-sync-blocks must be provided when startup-sync-strategy=blocks"
-                    ));
-                }
-                StartupSyncStrategy::Blocks(config.startup_sync_blocks.clone())
-            }
-        };
-
-        Ok(Self {
-            critical_threshold: match config.critical_threshold {
-                cli::CriticalThreshold::Timeout(duration) => {
-                    CriticalThreshold::Timeout((duration.as_secs() / 3) as u32)
-                },
-                cli::CriticalThreshold::AuthoritySetChange => {
-                    CriticalThreshold::AuthoritySetChange
-                },
-            },
-            startup_sync_strategy,
-            spike_config: SpikeConfig {
-                timeout: config.spike_timeout,
-                priority_timeout: config.priority_spike_timeout,
-                window: config.spike_window,
-                threshold: config.spike_threshold,
-            },
-            check_interval: config.check_interval,
-            save_interval: config.save_interval,
-            genesis_config: GenesisConfig {
-                authority_set_hash: hex::decode(&config.genesis_config_args.authority_set_hash)
-                    .context(
-                        "Incorrect format for authority set hash: hex encoded hash is expected",
-                    )?
-                    .try_into()
-                    .map_err(|got: Vec<u8>| {
-                        anyhow::anyhow!("Incorrect format for authority set hash: wrong length. Expected {}, got {}", BLAKE2_DIGEST_SIZE, got.len())
-                    })?,
-                authority_set_id: config.genesis_config_args.authority_set_id,
-            },
-            last_sealed: config.start_authority_set_id,
-            confirmations: config.confirmations_merkle_root.unwrap_or(DEFAULT_COUNT_CONFIRMATIONS),
-            count_thread: match config.thread_count {
-                None => Some(DEFAULT_COUNT_THREADS),
-                Some(thread_count) => thread_count.into(),
-            },
-            bridging_payment_address: config
-                .bridging_payment_address
-                .as_ref()
-                .map(|x| hex_utils::decode_h256(x))
-                .transpose()
-                .context("Failed to parse bridging payment address")?,
-        })
+        crate::config::EffectiveConfig::from_cli(config)?
+            .relayers
+            .into_iter()
+            .next()
+            .map(|relayer| relayer.options)
+            .ok_or_else(|| anyhow::anyhow!("No relayer config found"))
     }
 }
 

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -20,6 +20,7 @@ use prometheus::IntGauge;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap, VecDeque},
+    path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -92,6 +93,7 @@ impl Relayer {
             api_provider.clone(),
             options.genesis_config,
             options.count_thread,
+            options.gnark_data_path.clone(),
         ));
 
         let submitter = submitter::MerkleRootSubmitter::new(
@@ -1411,6 +1413,7 @@ pub struct MerkleRootRelayerOptions {
     pub critical_threshold: CriticalThreshold,
     /// Startup sync strategy for initial catch-up.
     pub startup_sync_strategy: StartupSyncStrategy,
+    pub gnark_data_path: PathBuf,
 }
 
 impl MerkleRootRelayerOptions {

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     proof_storage::ProofStorageError,
     prover_interface::FinalProof,
+    rpc,
 };
 use ::prover::{
     consts::BLAKE2_DIGEST_SIZE,
@@ -1136,13 +1137,6 @@ impl MerkleRootRelayer {
 
         let nonces = storage::message_queued_events_of(&block).collect::<Vec<_>>();
 
-        // mark root processed so that we don't process the entire block again.
-        self.storage.merkle_root_processed(block.number()).await;
-
-        if let Err(err) = self.storage.save(&self.roots).await {
-            log::error!("Failed to save block storage state: {err:?}");
-        }
-
         if self
             .storage
             .is_merkle_root_submitted(block.number(), merkle_root)
@@ -1154,14 +1148,23 @@ impl MerkleRootRelayer {
                 merkle_root,
                 block.number()
             );
+            self.storage.merkle_root_processed(block.number()).await;
+            if let Err(err) = self.storage.save(&self.roots).await {
+                log::error!("Failed to save block storage state: {err:?}");
+            }
             return Ok(None);
         }
 
-        let signed_by_authority_set_id = self
-            .api_provider
-            .client()
-            .signed_by_authority_set_id(block.hash())
-            .await?;
+        let block_hash_for_authority = block.hash();
+        let signed_by_authority_set_id = rpc::retry_gear(
+            &mut self.api_provider,
+            "merkle root signed authority set id",
+            move |api| async move {
+                api.signed_by_authority_set_id(block_hash_for_authority)
+                    .await
+            },
+        )
+        .await?;
 
         let block_number = block.number();
 
@@ -1293,8 +1296,18 @@ impl MerkleRootRelayer {
                 log::error!(
                     "Failed to get proof for authority set id {signed_by_authority_set_id}: {err}"
                 );
+                self.storage.merkle_root_processed(block_number).await;
+                if let Err(save_err) = self.storage.save(&self.roots).await {
+                    log::error!("Failed to save block storage state: {save_err:?}");
+                }
                 return Err(err.into());
             }
+        }
+
+        // Mark root processed only after durable root state exists or the work is queued.
+        self.storage.merkle_root_processed(block_number).await;
+        if let Err(err) = self.storage.save(&self.roots).await {
+            log::error!("Failed to save block storage state: {err:?}");
         }
 
         Ok(Some((queue_id, merkle_root)))

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -6,13 +6,17 @@ use futures::executor::block_on;
 use gear_common::api_provider::ApiProviderConnection;
 use gear_rpc_client::dto::RawBlockInclusionProof;
 use primitive_types::H256;
-use prometheus::IntGauge;
+use prometheus::{IntCounter, IntGauge, IntGaugeVec, Opts};
 use prover::proving::{GenesisConfig, ProofWithCircuitData};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{error::TryRecvError, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 #[derive(Clone)]
@@ -46,15 +50,59 @@ pub enum Response {
     },
 }
 
+#[derive(Clone)]
+struct ProverContext {
+    api_provider: ApiProviderConnection,
+    genesis_config: GenesisConfig,
+    count_thread: Option<usize>,
+}
+
+enum RequestSender {
+    Direct(UnboundedSender<Request>),
+    Shared {
+        relayer_id: String,
+        priority: i64,
+        context: ProverContext,
+        requests: UnboundedSender<SharedRequest>,
+        responses: UnboundedSender<Response>,
+        sequence: Arc<AtomicU64>,
+    },
+}
+
 pub struct FinalityProverIo {
-    requests: UnboundedSender<Request>,
+    requests: RequestSender,
     responses: UnboundedReceiver<Response>,
 }
 
 impl FinalityProverIo {
-    pub fn new(requests: UnboundedSender<Request>, responses: UnboundedReceiver<Response>) -> Self {
+    pub fn new_direct(
+        requests: UnboundedSender<Request>,
+        responses: UnboundedReceiver<Response>,
+    ) -> Self {
         Self {
-            requests,
+            requests: RequestSender::Direct(requests),
+            responses,
+        }
+    }
+
+    fn new_shared(
+        relayer_id: String,
+        priority: i64,
+        context: ProverContext,
+        requests: UnboundedSender<SharedRequest>,
+        responses: UnboundedReceiver<Response>,
+        response_tx: UnboundedSender<Response>,
+        sequence: Arc<AtomicU64>,
+    ) -> Self {
+        Self {
+            requests: RequestSender::Shared {
+                relayer_id,
+                priority,
+                context,
+                requests,
+                responses: response_tx,
+                sequence,
+            },
             responses,
         }
     }
@@ -70,17 +118,36 @@ impl FinalityProverIo {
         batch: bool,
         block_inclusion_proof: RawBlockInclusionProof,
     ) -> bool {
-        self.requests
-            .send(Request {
-                block_number,
-                block_hash,
-                merkle_root,
-                inner_proof,
-                queue_id,
-                batch,
-                block_inclusion_proof,
-            })
-            .is_ok()
+        let request = Request {
+            block_number,
+            block_hash,
+            merkle_root,
+            inner_proof,
+            queue_id,
+            batch,
+            block_inclusion_proof,
+        };
+
+        match &self.requests {
+            RequestSender::Direct(requests) => requests.send(request).is_ok(),
+            RequestSender::Shared {
+                relayer_id,
+                priority,
+                context,
+                requests,
+                responses,
+                sequence,
+            } => requests
+                .send(SharedRequest {
+                    relayer_id: relayer_id.clone(),
+                    priority: *priority,
+                    sequence: sequence.fetch_add(1, Ordering::Relaxed),
+                    context: context.clone(),
+                    request,
+                    responses: responses.clone(),
+                })
+                .is_ok(),
+        }
     }
 
     pub async fn recv(&mut self) -> Option<Response> {
@@ -102,6 +169,42 @@ impl_metered_service!(
             "merkle_root_relayer_current_root_block",
             "Block number of the current merkle root being processed"
         ),
+        pending_requests_by_relayer: IntGaugeVec = IntGaugeVec::new(
+            Opts::new(
+                "merkle_root_relayer_pending_requests_by_relayer",
+                "Number of pending shared prover requests by relayer"
+            ),
+            &["relayer"],
+        ),
+        currently_processing_by_relayer: IntGaugeVec = IntGaugeVec::new(
+            Opts::new(
+                "merkle_root_relayer_currently_processing_by_relayer",
+                "Number of shared prover requests currently being processed by relayer"
+            ),
+            &["relayer"],
+        ),
+        current_relayer_priority: IntGaugeVec = IntGaugeVec::new(
+            Opts::new(
+                "merkle_root_relayer_current_relayer_priority",
+                "Priority of the relayer currently selected by the shared prover"
+            ),
+            &["relayer"],
+        ),
+        current_root_block_by_relayer: IntGaugeVec = IntGaugeVec::new(
+            Opts::new(
+                "merkle_root_relayer_current_root_block_by_relayer",
+                "Block number currently being processed by the shared prover for each relayer"
+            ),
+            &["relayer"],
+        ),
+        dropped_responses: IntCounter = IntCounter::new(
+            "merkle_root_relayer_dropped_prover_responses",
+            "Number of shared prover responses dropped because the receiving relayer channel was closed"
+        ),
+        failed_requests: IntCounter = IntCounter::new(
+            "merkle_root_relayer_failed_prover_requests",
+            "Number of shared prover requests that failed during proof generation"
+        ),
         max_proof_time: IntGauge = IntGauge::new(
             "merkle_root_relayer_max_proof_time_seconds",
             "Maximum time taken to generate a proof (in seconds)"
@@ -119,10 +222,7 @@ impl_metered_service!(
 
 /// A separate thread responsible for running block finality prover.
 pub struct FinalityProver {
-    api_provider: ApiProviderConnection,
-    genesis_config: GenesisConfig,
-
-    count_thread: Option<usize>,
+    context: ProverContext,
 
     metrics: Metrics,
 }
@@ -140,11 +240,11 @@ impl FinalityProver {
         count_thread: Option<usize>,
     ) -> Self {
         Self {
-            api_provider,
-
-            genesis_config,
-
-            count_thread,
+            context: ProverContext {
+                api_provider,
+                genesis_config,
+                count_thread,
+            },
 
             metrics: Metrics::new(),
         }
@@ -154,7 +254,7 @@ impl FinalityProver {
         let (req_tx, mut req_rx) = tokio::sync::mpsc::unbounded_channel();
         let (res_tx, res_rx) = tokio::sync::mpsc::unbounded_channel();
 
-        let io = FinalityProverIo::new(req_tx, res_rx);
+        let io = FinalityProverIo::new_direct(req_tx, res_rx);
 
         tokio::task::spawn_blocking(move || {
             block_on(async move {
@@ -254,7 +354,7 @@ impl FinalityProver {
 
                 let block_hash = request.block_hash;
                 let authority_set_id = rpc::retry_gear(
-                    &mut self.api_provider,
+                    &mut self.context.api_provider,
                     "prover authority set id",
                     move |gear_api| async move { gear_api.authority_set_id(block_hash).await },
                 )
@@ -379,49 +479,633 @@ impl FinalityProver {
         inner_proof: ProofWithCircuitData,
         block_inclusion_proof: RawBlockInclusionProof,
     ) -> anyhow::Result<FinalProof> {
-        log::info!("Generating merkle root proof for block #{block_number}");
+        generate_proof(
+            &self.metrics,
+            &mut self.context,
+            block_number,
+            block_hash,
+            merkle_root,
+            inner_proof,
+            block_inclusion_proof,
+        )
+        .await
+    }
+}
 
-        log::info!("Proving merkle root({merkle_root}) presence in block #{block_number}");
+async fn generate_proof(
+    metrics: &Metrics,
+    context: &mut ProverContext,
+    block_number: u32,
+    block_hash: H256,
+    merkle_root: H256,
+    inner_proof: ProofWithCircuitData,
+    block_inclusion_proof: RawBlockInclusionProof,
+) -> anyhow::Result<FinalProof> {
+    log::info!("Generating merkle root proof for block #{block_number}");
 
-        let start = Instant::now();
-        let genesis_config = self.genesis_config;
-        let count_thread = self.count_thread;
-        let proof = rpc::retry_gear(
-            &mut self.api_provider,
-            "prover finality proof",
-            move |gear_api| {
-                let inner_proof = inner_proof.clone();
-                let block_inclusion_proof = block_inclusion_proof.clone();
-                async move {
-                    prover_interface::prove_final(
-                        &gear_api,
-                        inner_proof,
-                        genesis_config,
-                        block_hash,
-                        count_thread,
-                        Some(block_inclusion_proof),
-                    )
-                    .await
+    log::info!("Proving merkle root({merkle_root}) presence in block #{block_number}");
+
+    let start = Instant::now();
+    let genesis_config = context.genesis_config;
+    let count_thread = context.count_thread;
+    let proof = rpc::retry_gear(
+        &mut context.api_provider,
+        "prover finality proof",
+        move |gear_api| {
+            let inner_proof = inner_proof.clone();
+            let block_inclusion_proof = block_inclusion_proof.clone();
+            async move {
+                prover_interface::prove_final(
+                    &gear_api,
+                    inner_proof,
+                    genesis_config,
+                    block_hash,
+                    count_thread,
+                    Some(block_inclusion_proof),
+                )
+                .await
+            }
+        },
+    )
+    .await?;
+    let elapsed = start.elapsed().as_secs_f64();
+    log::info!("Proof for {merkle_root} generated (block #{block_number}) in {elapsed:.3} seconds",);
+
+    metrics.last_proof_time.set(elapsed.ceil() as i64);
+    if metrics.min_proof_time.get() == 0 || elapsed < metrics.min_proof_time.get() as f64 {
+        metrics.min_proof_time.set(elapsed.ceil() as i64);
+    }
+    if elapsed > metrics.max_proof_time.get() as f64 {
+        metrics.max_proof_time.set(elapsed.ceil() as i64);
+    }
+
+    Ok(proof)
+}
+
+struct SharedRequest {
+    relayer_id: String,
+    priority: i64,
+    sequence: u64,
+    context: ProverContext,
+    request: Request,
+    responses: UnboundedSender<Response>,
+}
+
+pub struct SharedFinalityProver {
+    requests: UnboundedSender<SharedRequest>,
+    sequence: Arc<AtomicU64>,
+    metrics: Metrics,
+}
+
+impl MeteredService for SharedFinalityProver {
+    fn get_sources(&self) -> impl IntoIterator<Item = Box<dyn prometheus::core::Collector>> {
+        self.metrics.get_sources()
+    }
+}
+
+impl SharedFinalityProver {
+    pub fn new() -> Self {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let metrics = Metrics::new();
+        let worker_metrics = metrics.clone();
+
+        tokio::task::spawn_blocking(move || {
+            block_on(async move {
+                if let Err(err) = process_shared_requests(&mut rx, &worker_metrics).await {
+                    log::error!("Error processing shared finality prover requests: {err}");
+                } else {
+                    log::info!("Shared prover exiting");
                 }
+            })
+        });
+
+        Self {
+            requests: tx,
+            sequence: Arc::new(AtomicU64::new(0)),
+            metrics,
+        }
+    }
+
+    pub fn register(
+        &self,
+        relayer_id: String,
+        priority: i64,
+        api_provider: ApiProviderConnection,
+        genesis_config: GenesisConfig,
+        count_thread: Option<usize>,
+    ) -> FinalityProverIo {
+        let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel();
+        FinalityProverIo::new_shared(
+            relayer_id,
+            priority,
+            ProverContext {
+                api_provider,
+                genesis_config,
+                count_thread,
             },
+            self.requests.clone(),
+            response_rx,
+            response_tx,
+            self.sequence.clone(),
+        )
+    }
+}
+
+impl Default for SharedFinalityProver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+async fn process_shared_requests(
+    requests: &mut UnboundedReceiver<SharedRequest>,
+    metrics: &Metrics,
+) -> anyhow::Result<()> {
+    const BATCH_SIZE: usize = 4096;
+
+    let mut pending = Vec::with_capacity(BATCH_SIZE);
+
+    loop {
+        if pending.is_empty() {
+            let Some(request) = requests.recv().await else {
+                log::info!("Shared prover request channel closed, exiting");
+                return Ok(());
+            };
+            pending.push(request);
+        }
+
+        while pending.len() < BATCH_SIZE {
+            match requests.try_recv() {
+                Ok(request) => pending.push(request),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break,
+            }
+        }
+
+        record_pending_requests(metrics, &pending);
+
+        let Some(work) = take_next_shared_proof_work(&mut pending).await? else {
+            continue;
+        };
+
+        let relayer_id = work.relayer_id().to_string();
+        log::info!("Shared prover selected relayer {relayer_id} for the next proof job");
+        match work {
+            SelectedSharedProofWork::Single(request) => {
+                process_shared_single_request(request, &relayer_id, metrics).await?;
+            }
+            SelectedSharedProofWork::Batch {
+                authority_set_id,
+                queue_id,
+                latest,
+                batch_roots,
+            } => {
+                process_shared_batch_request(
+                    latest,
+                    batch_roots,
+                    authority_set_id,
+                    queue_id,
+                    &relayer_id,
+                    metrics,
+                )
+                .await?;
+            }
+        }
+    }
+}
+
+fn record_pending_requests(metrics: &Metrics, pending: &[SharedRequest]) {
+    let mut counts = BTreeMap::<&str, usize>::new();
+    for request in pending {
+        *counts.entry(request.relayer_id.as_str()).or_default() += 1;
+    }
+    record_pending_request_counts(metrics, counts);
+}
+
+fn record_pending_request_counts<'a>(
+    metrics: &Metrics,
+    counts: impl IntoIterator<Item = (&'a str, usize)>,
+) {
+    let mut total = 0;
+    metrics.pending_requests_by_relayer.reset();
+    for (relayer_id, count) in counts {
+        total += count;
+        metrics
+            .pending_requests_by_relayer
+            .with_label_values(&[relayer_id])
+            .set(count as i64);
+    }
+    metrics.pending_requests.set(total as i64);
+}
+
+fn record_current_shared_request(
+    metrics: &Metrics,
+    relayer_id: &str,
+    priority: i64,
+    block_number: u32,
+    currently_processing: usize,
+) {
+    metrics
+        .currently_processing
+        .set(currently_processing as i64);
+    metrics.current_root_block.set(block_number as i64);
+    metrics.currently_processing_by_relayer.reset();
+    metrics.current_relayer_priority.reset();
+    metrics.current_root_block_by_relayer.reset();
+    metrics
+        .currently_processing_by_relayer
+        .with_label_values(&[relayer_id])
+        .set(currently_processing as i64);
+    metrics
+        .current_relayer_priority
+        .with_label_values(&[relayer_id])
+        .set(priority);
+    metrics
+        .current_root_block_by_relayer
+        .with_label_values(&[relayer_id])
+        .set(block_number as i64);
+}
+
+fn clear_current_shared_request(metrics: &Metrics) {
+    metrics.currently_processing.set(0);
+    metrics.current_root_block.set(0);
+    metrics.currently_processing_by_relayer.reset();
+    metrics.current_relayer_priority.reset();
+    metrics.current_root_block_by_relayer.reset();
+}
+
+enum SelectedSharedProofWork {
+    Single(SharedRequest),
+    Batch {
+        authority_set_id: u64,
+        queue_id: u64,
+        latest: SharedRequest,
+        batch_roots: Vec<(u32, H256)>,
+    },
+}
+
+impl SelectedSharedProofWork {
+    fn relayer_id(&self) -> &str {
+        match self {
+            SelectedSharedProofWork::Single(request) => &request.relayer_id,
+            SelectedSharedProofWork::Batch { latest, .. } => &latest.relayer_id,
+        }
+    }
+}
+
+async fn take_next_shared_proof_work(
+    pending: &mut Vec<SharedRequest>,
+) -> anyhow::Result<Option<SelectedSharedProofWork>> {
+    let Some(relayer_id) = select_next_relayer_id(pending.iter().map(|request| {
+        (
+            request.relayer_id.as_str(),
+            request.priority,
+            request.sequence,
+        )
+    })) else {
+        return Ok(None);
+    };
+
+    if let Some((index, _)) = pending
+        .iter()
+        .enumerate()
+        .filter(|(_, request)| request.relayer_id == relayer_id && !request.request.batch)
+        .min_by_key(|(_, request)| (request.request.block_number, request.sequence))
+    {
+        return Ok(Some(SelectedSharedProofWork::Single(pending.remove(index))));
+    }
+
+    let mut selected_relayer_requests = Vec::new();
+    let mut index = 0;
+    while index < pending.len() {
+        if pending[index].relayer_id == relayer_id {
+            selected_relayer_requests.push(pending.remove(index));
+        } else {
+            index += 1;
+        }
+    }
+
+    let mut request_groups = BTreeMap::<(u64, u64), Vec<SharedRequestWithAuthoritySet>>::new();
+    for mut request in selected_relayer_requests {
+        let block_hash = request.request.block_hash;
+        let authority_set_id = rpc::retry_gear(
+            &mut request.context.api_provider,
+            "shared prover authority set id",
+            move |gear_api| async move { gear_api.authority_set_id(block_hash).await },
         )
         .await?;
-        let elapsed = start.elapsed().as_secs_f64();
-        log::info!(
-            "Proof for {merkle_root} generated (block #{block_number}) in {elapsed:.3} seconds",
-        );
+        let queue_id = request.request.queue_id;
+        request_groups
+            .entry((authority_set_id, queue_id))
+            .or_default()
+            .push(SharedRequestWithAuthoritySet {
+                request,
+                authority_set_id: Some(authority_set_id),
+            });
+    }
 
-        self.metrics.last_proof_time.set(elapsed.ceil() as i64);
-        if self.metrics.min_proof_time.get() == 0
-            || elapsed < self.metrics.min_proof_time.get() as f64
-        {
-            self.metrics.min_proof_time.set(elapsed.ceil() as i64);
+    let Some(((authority_set_id, queue_id), selected_group)) = request_groups.pop_first() else {
+        return Ok(None);
+    };
+
+    for (_, group) in request_groups {
+        pending.extend(group.into_iter().map(|request| request.request));
+    }
+
+    let mut work = plan_shared_relayer_requests(selected_group);
+    match work.pop() {
+        Some(SharedProofWork::Batch {
+            authority_set_id: work_authority_set_id,
+            queue_id: work_queue_id,
+            latest,
+            batch_roots,
+        }) => {
+            debug_assert_eq!(authority_set_id, work_authority_set_id);
+            debug_assert_eq!(queue_id, work_queue_id);
+            Ok(Some(SelectedSharedProofWork::Batch {
+                authority_set_id,
+                queue_id,
+                latest: latest.request,
+                batch_roots,
+            }))
         }
-        if elapsed > self.metrics.max_proof_time.get() as f64 {
-            self.metrics.max_proof_time.set(elapsed.ceil() as i64);
+        Some(SharedProofWork::Single(request)) => {
+            Ok(Some(SelectedSharedProofWork::Single(request.request)))
+        }
+        None => Ok(None),
+    }
+}
+
+fn select_next_relayer_id<'a>(
+    pending: impl IntoIterator<Item = (&'a str, i64, u64)>,
+) -> Option<String> {
+    pending
+        .into_iter()
+        .max_by(
+            |(_, left_priority, left_sequence), (_, right_priority, right_sequence)| {
+                left_priority
+                    .cmp(right_priority)
+                    .then_with(|| right_sequence.cmp(left_sequence))
+            },
+        )
+        .map(|(relayer_id, _, _)| relayer_id.to_string())
+}
+
+async fn process_shared_single_request(
+    request: SharedRequest,
+    relayer_id: &str,
+    metrics: &Metrics,
+) -> anyhow::Result<()> {
+    let priority = request.priority;
+    let Request {
+        block_number,
+        block_hash,
+        merkle_root,
+        inner_proof,
+        block_inclusion_proof,
+        ..
+    } = request.request;
+    log::info!(
+        "Shared prover proving relayer {relayer_id} block #{block_number} with merkle-root {merkle_root} (non-batched)",
+    );
+    record_current_shared_request(metrics, relayer_id, priority, block_number, 1);
+    metrics
+        .pending_requests
+        .set((metrics.pending_requests.get() - 1).max(0));
+
+    let mut context = request.context;
+    let proof = match generate_proof(
+        metrics,
+        &mut context,
+        block_number,
+        block_hash,
+        merkle_root,
+        inner_proof,
+        block_inclusion_proof,
+    )
+    .await
+    {
+        Ok(proof) => proof,
+        Err(err) => {
+            metrics.failed_requests.inc();
+            clear_current_shared_request(metrics);
+            return Err(err);
+        }
+    };
+
+    clear_current_shared_request(metrics);
+
+    send_shared_response(
+        &request.responses,
+        Response::Single {
+            block_number,
+            merkle_root,
+            proof,
+        },
+        metrics,
+        relayer_id,
+    );
+
+    Ok(())
+}
+
+async fn process_shared_batch_request(
+    request: SharedRequest,
+    batch_roots: Vec<(u32, H256)>,
+    authority_set_id: u64,
+    queue_id: u64,
+    relayer_id: &str,
+    metrics: &Metrics,
+) -> anyhow::Result<()> {
+    let priority = request.priority;
+    let responses = request.responses;
+    let Request {
+        block_number,
+        block_hash,
+        merkle_root,
+        inner_proof,
+        block_inclusion_proof,
+        ..
+    } = request.request;
+    log::info!(
+        "Shared prover proving relayer {relayer_id} latest block #{block_number} with authority set #{authority_set_id}, merkle-root {merkle_root} and queue #{queue_id} (will apply to {} blocks)",
+        batch_roots.len()
+    );
+    let currently_processing = batch_roots.len() + 1;
+    record_current_shared_request(
+        metrics,
+        relayer_id,
+        priority,
+        block_number,
+        currently_processing,
+    );
+    metrics
+        .pending_requests
+        .set((metrics.pending_requests.get() - currently_processing as i64).max(0));
+
+    let mut context = request.context;
+    let proof = match generate_proof(
+        metrics,
+        &mut context,
+        block_number,
+        block_hash,
+        merkle_root,
+        inner_proof,
+        block_inclusion_proof,
+    )
+    .await
+    {
+        Ok(proof) => proof,
+        Err(err) => {
+            metrics.failed_requests.inc();
+            clear_current_shared_request(metrics);
+            return Err(err);
+        }
+    };
+
+    clear_current_shared_request(metrics);
+
+    send_shared_response(
+        &responses,
+        Response::Batched {
+            block_number,
+            merkle_root,
+            proof,
+            batch_roots,
+        },
+        metrics,
+        relayer_id,
+    );
+
+    Ok(())
+}
+
+fn send_shared_response(
+    responses: &UnboundedSender<Response>,
+    response: Response,
+    metrics: &Metrics,
+    relayer_id: &str,
+) {
+    if responses.send(response).is_err() {
+        metrics.dropped_responses.inc();
+        log::warn!("Shared prover response channel for relayer {relayer_id} closed");
+    }
+}
+
+struct SharedRequestWithAuthoritySet {
+    request: SharedRequest,
+    authority_set_id: Option<u64>,
+}
+
+trait SharedProofRequestInfo {
+    fn is_batch(&self) -> bool;
+    fn block_number(&self) -> u32;
+    fn merkle_root(&self) -> H256;
+    fn queue_id(&self) -> u64;
+    fn authority_set_id(&self) -> Option<u64>;
+}
+
+impl SharedProofRequestInfo for SharedRequestWithAuthoritySet {
+    fn is_batch(&self) -> bool {
+        self.request.request.batch
+    }
+
+    fn block_number(&self) -> u32 {
+        self.request.request.block_number
+    }
+
+    fn merkle_root(&self) -> H256 {
+        self.request.request.merkle_root
+    }
+
+    fn queue_id(&self) -> u64 {
+        self.request.request.queue_id
+    }
+
+    fn authority_set_id(&self) -> Option<u64> {
+        self.authority_set_id
+    }
+}
+
+enum SharedProofWork<T> {
+    Single(T),
+    Batch {
+        authority_set_id: u64,
+        queue_id: u64,
+        latest: T,
+        batch_roots: Vec<(u32, H256)>,
+    },
+}
+
+fn plan_shared_relayer_requests<T: SharedProofRequestInfo>(
+    requests: Vec<T>,
+) -> Vec<SharedProofWork<T>> {
+    let mut non_batch_requests = Vec::new();
+    let mut request_groups: BTreeMap<(u64, u64), SharedBatchProofWork<T>> = BTreeMap::new();
+
+    for request in requests {
+        if !request.is_batch() {
+            non_batch_requests.push(request);
+            continue;
         }
 
-        Ok(proof)
+        let authority_set_id = request
+            .authority_set_id()
+            .expect("batch requests must have authority set id");
+        let queue_id = request.queue_id();
+        match request_groups.entry((authority_set_id, queue_id)) {
+            Entry::Occupied(mut entry) => entry.get_mut().add_request(request),
+            Entry::Vacant(entry) => {
+                entry.insert(SharedBatchProofWork::new(request));
+            }
+        }
+    }
+
+    non_batch_requests.sort_by_key(|request| request.block_number());
+
+    let mut work = non_batch_requests
+        .into_iter()
+        .map(SharedProofWork::Single)
+        .collect::<Vec<_>>();
+    work.extend(
+        request_groups
+            .into_iter()
+            .map(
+                |((authority_set_id, queue_id), batch)| SharedProofWork::Batch {
+                    authority_set_id,
+                    queue_id,
+                    latest: batch.latest,
+                    batch_roots: batch.batch_roots,
+                },
+            ),
+    );
+    work
+}
+
+struct SharedBatchProofWork<T> {
+    latest: T,
+    batch_roots: Vec<(u32, H256)>,
+}
+
+impl<T: SharedProofRequestInfo> SharedBatchProofWork<T> {
+    fn new(init: T) -> Self {
+        Self {
+            latest: init,
+            batch_roots: Vec::new(),
+        }
+    }
+
+    fn add_request(&mut self, request: T) {
+        if request.block_number() > self.latest.block_number() {
+            let previous_latest = std::mem::replace(&mut self.latest, request);
+            self.batch_roots.push((
+                previous_latest.block_number(),
+                previous_latest.merkle_root(),
+            ));
+        } else {
+            self.batch_roots
+                .push((request.block_number(), request.merkle_root()));
+        }
     }
 }
 
@@ -464,5 +1148,288 @@ impl BatchProofRequest {
             self.batch_roots
                 .push((request.block_number, request.merkle_root));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        clear_current_shared_request, plan_shared_relayer_requests, record_current_shared_request,
+        record_pending_request_counts, select_next_relayer_id, send_shared_response, Metrics,
+        Response, SharedProofRequestInfo, SharedProofWork,
+    };
+    use crate::prover_interface::FinalProof;
+    use primitive_types::H256;
+    use prometheus::Registry;
+    use tokio::sync::mpsc;
+    use utils_prometheus::MeteredService;
+
+    #[test]
+    fn shared_scheduler_selects_highest_priority_relayer() {
+        let selected =
+            select_next_relayer_id([("testnet", 10, 0), ("mainnet", 100, 1), ("devnet", 50, 2)]);
+        assert_eq!(selected.as_deref(), Some("mainnet"));
+    }
+
+    #[test]
+    fn shared_scheduler_uses_fifo_for_equal_priority() {
+        let selected =
+            select_next_relayer_id([("second", 100, 2), ("first", 100, 1), ("third", 100, 3)]);
+        assert_eq!(selected.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn shared_metrics_expose_queue_and_current_work_by_relayer() {
+        let metrics = Metrics::new();
+        let registry = Registry::new();
+        for source in metrics.get_sources() {
+            registry.register(source).unwrap();
+        }
+
+        record_pending_request_counts(&metrics, [("mainnet", 2), ("testnet", 1)]);
+        record_current_shared_request(&metrics, "mainnet", 100, 42, 1);
+
+        let families = registry.gather();
+        assert_eq!(
+            gauge_value(
+                &families,
+                "merkle_root_relayer_pending_requests_by_relayer",
+                "relayer",
+                "mainnet",
+            ),
+            Some(2)
+        );
+        assert_eq!(
+            gauge_value(
+                &families,
+                "merkle_root_relayer_pending_requests_by_relayer",
+                "relayer",
+                "testnet",
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            gauge_value(
+                &families,
+                "merkle_root_relayer_currently_processing_by_relayer",
+                "relayer",
+                "mainnet",
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            gauge_value(
+                &families,
+                "merkle_root_relayer_current_relayer_priority",
+                "relayer",
+                "mainnet",
+            ),
+            Some(100)
+        );
+        assert_eq!(
+            gauge_value(
+                &families,
+                "merkle_root_relayer_current_root_block_by_relayer",
+                "relayer",
+                "mainnet",
+            ),
+            Some(42)
+        );
+
+        clear_current_shared_request(&metrics);
+        let families = registry.gather();
+        assert_eq!(
+            gauge_value(
+                &families,
+                "merkle_root_relayer_currently_processing_by_relayer",
+                "relayer",
+                "mainnet",
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn shared_planner_processes_non_batched_requests_before_batches() {
+        let work = plan_shared_relayer_requests(vec![
+            test_request("batch-old", true, 20, 10, Some(1)),
+            test_request("single-new", false, 30, 99, None),
+            test_request("single-old", false, 10, 99, None),
+            test_request("batch-new", true, 25, 10, Some(1)),
+        ]);
+
+        assert_eq!(work.len(), 3);
+        assert_single(&work[0], "single-old", 10);
+        assert_single(&work[1], "single-new", 30);
+        assert_batch(&work[2], 1, 10, "batch-new", 25, &[(20, root(20))]);
+    }
+
+    #[test]
+    fn shared_planner_batches_only_same_authority_set_and_queue() {
+        let work = plan_shared_relayer_requests(vec![
+            test_request("authority-one-old", true, 10, 7, Some(1)),
+            test_request("authority-two", true, 40, 7, Some(2)),
+            test_request("queue-eight", true, 30, 8, Some(1)),
+            test_request("authority-one-new", true, 50, 7, Some(1)),
+        ]);
+
+        assert_eq!(work.len(), 3);
+        assert_batch(&work[0], 1, 7, "authority-one-new", 50, &[(10, root(10))]);
+        assert_batch(&work[1], 1, 8, "queue-eight", 30, &[]);
+        assert_batch(&work[2], 2, 7, "authority-two", 40, &[]);
+    }
+
+    #[test]
+    fn shared_batch_response_routes_only_to_originating_relayer() {
+        let metrics = Metrics::new();
+        let (origin_tx, mut origin_rx) = mpsc::unbounded_channel();
+        let (_other_tx, mut other_rx) = mpsc::unbounded_channel::<Response>();
+
+        send_shared_response(
+            &origin_tx,
+            Response::Batched {
+                block_number: 42,
+                merkle_root: root(42),
+                proof: final_proof(42),
+                batch_roots: vec![(41, root(41))],
+            },
+            &metrics,
+            "mainnet",
+        );
+
+        match origin_rx
+            .try_recv()
+            .expect("originating relayer receives response")
+        {
+            Response::Batched {
+                block_number,
+                merkle_root,
+                batch_roots,
+                ..
+            } => {
+                assert_eq!(block_number, 42);
+                assert_eq!(merkle_root, root(42));
+                assert_eq!(batch_roots, vec![(41, root(41))]);
+            }
+            Response::Single { .. } => panic!("expected batched response"),
+        }
+        assert!(other_rx.try_recv().is_err());
+        assert_eq!(metrics.dropped_responses.get(), 0);
+    }
+
+    #[derive(Debug)]
+    struct TestRequest {
+        name: &'static str,
+        batch: bool,
+        block_number: u32,
+        merkle_root: H256,
+        queue_id: u64,
+        authority_set_id: Option<u64>,
+    }
+
+    impl SharedProofRequestInfo for TestRequest {
+        fn is_batch(&self) -> bool {
+            self.batch
+        }
+
+        fn block_number(&self) -> u32 {
+            self.block_number
+        }
+
+        fn merkle_root(&self) -> H256 {
+            self.merkle_root
+        }
+
+        fn queue_id(&self) -> u64 {
+            self.queue_id
+        }
+
+        fn authority_set_id(&self) -> Option<u64> {
+            self.authority_set_id
+        }
+    }
+
+    fn test_request(
+        name: &'static str,
+        batch: bool,
+        block_number: u32,
+        queue_id: u64,
+        authority_set_id: Option<u64>,
+    ) -> TestRequest {
+        TestRequest {
+            name,
+            batch,
+            block_number,
+            merkle_root: root(block_number),
+            queue_id,
+            authority_set_id,
+        }
+    }
+
+    fn root(value: u32) -> H256 {
+        H256::from_low_u64_be(value.into())
+    }
+
+    fn final_proof(block_number: u32) -> FinalProof {
+        FinalProof {
+            proof: vec![block_number as u8],
+            block_number,
+            merkle_root: [block_number as u8; 32],
+        }
+    }
+
+    fn assert_single(work: &SharedProofWork<TestRequest>, name: &str, block_number: u32) {
+        match work {
+            SharedProofWork::Single(request) => {
+                assert_eq!(request.name, name);
+                assert_eq!(request.block_number, block_number);
+            }
+            SharedProofWork::Batch { .. } => panic!("expected single proof work"),
+        }
+    }
+
+    fn assert_batch(
+        work: &SharedProofWork<TestRequest>,
+        authority_set_id: u64,
+        queue_id: u64,
+        latest_name: &str,
+        latest_block: u32,
+        batch_roots: &[(u32, H256)],
+    ) {
+        match work {
+            SharedProofWork::Batch {
+                authority_set_id: actual_authority_set_id,
+                queue_id: actual_queue_id,
+                latest,
+                batch_roots: actual_batch_roots,
+            } => {
+                assert_eq!(*actual_authority_set_id, authority_set_id);
+                assert_eq!(*actual_queue_id, queue_id);
+                assert_eq!(latest.name, latest_name);
+                assert_eq!(latest.block_number, latest_block);
+                assert_eq!(actual_batch_roots, batch_roots);
+            }
+            SharedProofWork::Single(_) => panic!("expected batched proof work"),
+        }
+    }
+
+    fn gauge_value(
+        families: &[prometheus::proto::MetricFamily],
+        name: &str,
+        label_name: &str,
+        label_value: &str,
+    ) -> Option<i64> {
+        families
+            .iter()
+            .find(|family| family.get_name() == name)?
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.get_name() == label_name && label.get_value() == label_value)
+            })
+            .map(|metric| metric.get_gauge().get_value() as i64)
     }
 }

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -10,6 +10,7 @@ use prometheus::{IntCounter, IntGauge, IntGaugeVec, Opts};
 use prover::proving::{GenesisConfig, ProofWithCircuitData};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
+    path::PathBuf,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -55,6 +56,7 @@ struct ProverContext {
     api_provider: ApiProviderConnection,
     genesis_config: GenesisConfig,
     count_thread: Option<usize>,
+    gnark_data_path: PathBuf,
 }
 
 enum RequestSender {
@@ -238,12 +240,14 @@ impl FinalityProver {
         api_provider: ApiProviderConnection,
         genesis_config: GenesisConfig,
         count_thread: Option<usize>,
+        gnark_data_path: PathBuf,
     ) -> Self {
         Self {
             context: ProverContext {
                 api_provider,
                 genesis_config,
                 count_thread,
+                gnark_data_path,
             },
 
             metrics: Metrics::new(),
@@ -508,12 +512,14 @@ async fn generate_proof(
     let start = Instant::now();
     let genesis_config = context.genesis_config;
     let count_thread = context.count_thread;
+    let gnark_data_path = context.gnark_data_path.clone();
     let proof = rpc::retry_gear(
         &mut context.api_provider,
         "prover finality proof",
         move |gear_api| {
             let inner_proof = inner_proof.clone();
             let block_inclusion_proof = block_inclusion_proof.clone();
+            let gnark_data_path = gnark_data_path.clone();
             async move {
                 prover_interface::prove_final(
                     &gear_api,
@@ -521,6 +527,7 @@ async fn generate_proof(
                     genesis_config,
                     block_hash,
                     count_thread,
+                    gnark_data_path,
                     Some(block_inclusion_proof),
                 )
                 .await
@@ -593,6 +600,7 @@ impl SharedFinalityProver {
         api_provider: ApiProviderConnection,
         genesis_config: GenesisConfig,
         count_thread: Option<usize>,
+        gnark_data_path: PathBuf,
     ) -> FinalityProverIo {
         let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel();
         FinalityProverIo::new_shared(
@@ -602,6 +610,7 @@ impl SharedFinalityProver {
                 api_provider,
                 genesis_config,
                 count_thread,
+                gnark_data_path,
             },
             self.requests.clone(),
             response_rx,

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -1,7 +1,10 @@
-use crate::prover_interface::{self, FinalProof};
+use crate::{
+    prover_interface::{self, FinalProof},
+    rpc,
+};
 use futures::executor::block_on;
 use gear_common::api_provider::ApiProviderConnection;
-use gear_rpc_client::{dto::RawBlockInclusionProof, GearApi};
+use gear_rpc_client::dto::RawBlockInclusionProof;
 use primitive_types::H256;
 use prometheus::IntGauge;
 use prover::proving::{GenesisConfig, ProofWithCircuitData};
@@ -171,8 +174,6 @@ impl FinalityProver {
         requests: &mut UnboundedReceiver<Request>,
         responses: &UnboundedSender<Response>,
     ) -> anyhow::Result<()> {
-        let gear_api = self.api_provider.client();
-
         // Batch size which is equal approximately to 2 full queues.
         const BATCH_SIZE: usize = 4096;
 
@@ -213,7 +214,6 @@ impl FinalityProver {
 
                         let proof = self
                             .generate_proof(
-                                &gear_api,
                                 request.block_number,
                                 request.block_hash,
                                 request.merkle_root,
@@ -252,7 +252,13 @@ impl FinalityProver {
                     continue;
                 }
 
-                let authority_set_id = gear_api.authority_set_id(request.block_hash).await?;
+                let block_hash = request.block_hash;
+                let authority_set_id = rpc::retry_gear(
+                    &mut self.api_provider,
+                    "prover authority set id",
+                    move |gear_api| async move { gear_api.authority_set_id(block_hash).await },
+                )
+                .await?;
                 match request_groups.entry((authority_set_id, request.queue_id)) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().add_request(request);
@@ -291,7 +297,6 @@ impl FinalityProver {
                     .set(self.metrics.pending_requests.get() - 1);
                 let proof = self
                     .generate_proof(
-                        &gear_api,
                         request.block_number,
                         request.block_hash,
                         request.merkle_root,
@@ -338,7 +343,6 @@ impl FinalityProver {
 
                 let proof = self
                     .generate_proof(
-                        &gear_api,
                         block_number,
                         block_hash,
                         merkle_root,
@@ -369,7 +373,6 @@ impl FinalityProver {
 
     async fn generate_proof(
         &mut self,
-        gear_api: &GearApi,
         block_number: u32,
         block_hash: H256,
         merkle_root: H256,
@@ -381,13 +384,26 @@ impl FinalityProver {
         log::info!("Proving merkle root({merkle_root}) presence in block #{block_number}");
 
         let start = Instant::now();
-        let proof = prover_interface::prove_final(
-            gear_api,
-            inner_proof,
-            self.genesis_config,
-            block_hash,
-            self.count_thread,
-            Some(block_inclusion_proof),
+        let genesis_config = self.genesis_config;
+        let count_thread = self.count_thread;
+        let proof = rpc::retry_gear(
+            &mut self.api_provider,
+            "prover finality proof",
+            move |gear_api| {
+                let inner_proof = inner_proof.clone();
+                let block_inclusion_proof = block_inclusion_proof.clone();
+                async move {
+                    prover_interface::prove_final(
+                        &gear_api,
+                        inner_proof,
+                        genesis_config,
+                        block_hash,
+                        count_thread,
+                        Some(block_inclusion_proof),
+                    )
+                    .await
+                }
+            },
         )
         .await?;
         let elapsed = start.elapsed().as_secs_f64();

--- a/relayer/src/merkle_roots/storage.rs
+++ b/relayer/src/merkle_roots/storage.rs
@@ -203,11 +203,12 @@ impl MerkleRootStorage {
         let blocks = self.blocks.read().await;
         let submitted_merkle_roots = self.submitted_roots.read().await;
 
+        let tmp_path = self.path.with_extension("tmp");
         let mut file = tokio::fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&self.path)
+            .open(&tmp_path)
             .await?;
 
         let storage = SerializedStorage {
@@ -220,6 +221,8 @@ impl MerkleRootStorage {
 
         file.write_all(serialized.as_bytes()).await?;
         file.flush().await?;
+        drop(file);
+        tokio::fs::rename(&tmp_path, &self.path).await?;
 
         Ok(())
     }

--- a/relayer/src/merkle_roots/submitter.rs
+++ b/relayer/src/merkle_roots/submitter.rs
@@ -17,6 +17,7 @@ use utils_prometheus::{impl_metered_service, MeteredService};
 use crate::{
     common::{submit_merkle_root_to_ethereum, BASE_RETRY_DELAY, MAX_RETRIES},
     prover_interface::FinalProof,
+    rpc,
 };
 
 use super::storage::MerkleRootStorage;
@@ -238,11 +239,11 @@ impl MerkleRootSubmitter {
                         continue;
                     }
 
-                    self.storage.submitted_merkle_root(request.merkle_root_block, H256::from(request.proof.merkle_root)).await;
-
+                    loop {
                     match submit_merkle_root_to_ethereum(&self.eth_api, request.proof.clone()).await {
                         Ok(pending_tx) => {
                             log::info!("Submitted merkle root to Ethereum, tx hash: {}", pending_tx.tx_hash());
+                            self.storage.submitted_merkle_root(request.merkle_root_block, H256::from(request.proof.merkle_root)).await;
                             self.metrics.total_submissions.inc();
                             pending_transactions.push(SubmittedMerkleRoot::new(
                                 pending_tx,
@@ -252,6 +253,7 @@ impl MerkleRootSubmitter {
                                 request.proof,
                                 self.confirmations,
                             ));
+                            break;
                         }
                         // How do we get here?
                         // - Relayer crashed and already submitted the merkle root but not yet confirmed it
@@ -269,10 +271,11 @@ impl MerkleRootSubmitter {
                                     merkle_root_block: request.merkle_root_block,
                                     merkle_root: request.merkle_root,
                                     status: ResponseStatus::Submitted,
-                                    proof: request.proof,
+                                    proof: request.proof.clone(),
                                 }).is_err() {
                                     return Ok(());
                                 };
+                                break;
                             } else {
                                 log::error!("Failed to submit merkle root {}: Error during contract execution: {err:?}", H256::from(request.proof.merkle_root));
                                 self.metrics.failed_submissions.inc();
@@ -282,13 +285,24 @@ impl MerkleRootSubmitter {
                                     merkle_root_block: request.merkle_root_block,
                                     merkle_root: request.merkle_root,
                                     status: ResponseStatus::Failed("Error during contract execution".to_string()),
-                                    proof: request.proof,
+                                    proof: request.proof.clone(),
                                 }).is_err() {
                                     return Ok(());
                                 };
+                                break;
                             }
                         }
 
+
+                        Err(err) if is_recoverable_eth_error(&err) => {
+                            log::warn!(
+                                "Recoverable error while submitting merkle root {}: {err}. Reconnecting and retrying",
+                                H256::from(request.proof.merkle_root)
+                            );
+                            tokio::time::sleep(BASE_RETRY_DELAY).await;
+                            self.eth_api = self.eth_api.reconnect().await?;
+                            continue;
+                        }
 
                         Err(err) => {
 
@@ -300,11 +314,13 @@ impl MerkleRootSubmitter {
                                 merkle_root_block: request.merkle_root_block,
                                 merkle_root: request.merkle_root,
                                 status: ResponseStatus::Failed(err.to_string()),
-                                proof: request.proof,
+                                proof: request.proof.clone(),
                             }).is_err() {
                                 return Ok(());
                             };
+                            break;
                         }
+                    }
                     }
                 },
 
@@ -420,6 +436,15 @@ impl MerkleRootSubmitter {
         tokio::task::spawn(task(self, rx, response_tx));
 
         SubmitterIo::new(tx, response_rx)
+    }
+}
+
+fn is_recoverable_eth_error(err: &ethereum_client::Error) -> bool {
+    match err {
+        ethereum_client::Error::ErrorInHTTPTransport(err) => {
+            crate::common::is_rpc_transport_error_recoverable(err)
+        }
+        _ => rpc::is_recoverable_error_text(err),
     }
 }
 

--- a/relayer/src/message_relayer/common/ethereum/block_listener.rs
+++ b/relayer/src/message_relayer/common/ethereum/block_listener.rs
@@ -58,10 +58,11 @@ impl BlockListener {
         receiver
     }
 
-    async fn run_inner(&self, sender: &UnboundedSender<EthereumBlockNumber>) -> anyhow::Result<()> {
-        let mut current_block = self.from_block;
-
-        self.metrics.latest_block.set(current_block as i64);
+    async fn run_inner(
+        &mut self,
+        sender: &UnboundedSender<EthereumBlockNumber>,
+    ) -> anyhow::Result<()> {
+        self.metrics.latest_block.set(self.from_block as i64);
 
         // Fetch unprocessed blocks in background
         let storage = self.storage.clone();
@@ -84,15 +85,14 @@ impl BlockListener {
 
         loop {
             let latest = self.eth_api.finalized_block().await?.header.number;
-            if latest >= current_block {
-                for block in current_block..=latest {
+            if latest >= self.from_block {
+                for block in self.from_block..=latest {
                     if let Err(e) = self.storage.add_block(block).await {
                         log::error!("Failed to add block {block} to storage: {e}");
                     }
                     sender.send(EthereumBlockNumber(block))?;
+                    self.from_block = block.saturating_add(1);
                 }
-
-                current_block = latest + 1;
 
                 self.metrics.latest_block.set(latest as i64);
             } else {
@@ -117,11 +117,16 @@ async fn task(mut this: BlockListener, sender: UnboundedSender<EthereumBlockNumb
 
         tokio::time::sleep(Duration::from_secs(30)).await;
 
-        this.eth_api = match this.eth_api.reconnect().await {
-            Ok(api) => api,
-            Err(e) => {
-                log::error!("Failed to reconnect to Ethereum API: {e}");
-                return;
+        loop {
+            match this.eth_api.reconnect().await {
+                Ok(api) => {
+                    this.eth_api = api;
+                    break;
+                }
+                Err(e) => {
+                    log::error!("Failed to reconnect to Ethereum API: {e}. Retrying...");
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                }
             }
         }
     }

--- a/relayer/src/message_relayer/common/ethereum/deposit_event_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/deposit_event_extractor.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 use crate::{
-    common::{self, BASE_RETRY_DELAY, MAX_RETRIES},
+    common::{self, BASE_RETRY_DELAY},
     message_relayer::{
         common::{
             ethereum::block_listener::ETHEREUM_BLOCK_TIME_APPROX, EthereumBlockNumber,
@@ -70,7 +70,7 @@ impl DepositEventExtractor {
         let (sender, receiver) = unbounded_channel();
 
         tokio::task::spawn(async move {
-            let mut attempts = 0;
+            let mut attempts: u32 = 0;
             let UnprocessedBlocks {
                 last_block,
                 mut unprocessed,
@@ -94,22 +94,27 @@ impl DepositEventExtractor {
                 let res = self.run_inner(&sender, &mut blocks, &mut unprocessed).await;
                 if let Err(err) = res {
                     attempts += 1;
-                    let delay = BASE_RETRY_DELAY * 2u32.pow(attempts - 1);
-
-                    log::error!(
-                        "Deposit event extractor failed (attempt {attempts}/{MAX_RETRIES}): {err}. Retrying in {delay:?}"
-                    );
-                    if attempts >= MAX_RETRIES {
-                        log::error!("Maximum attempts reached, exiting...");
+                    if !common::is_transport_error_recoverable(&err) {
+                        log::error!(
+                            "Non recoverable deposit event extractor error, exiting: {err}"
+                        );
                         return;
                     }
+                    let delay = BASE_RETRY_DELAY * 2u32.pow(attempts.saturating_sub(1).min(6));
+
+                    log::error!(
+                        "Deposit event extractor failed with recoverable error (attempt {attempts}): {err}. Retrying in {delay:?}"
+                    );
                     tokio::time::sleep(delay).await;
-                    if common::is_transport_error_recoverable(&err) {
-                        self.eth_api = match self.eth_api.reconnect().await {
-                            Ok(api) => api,
+                    loop {
+                        match self.eth_api.reconnect().await {
+                            Ok(api) => {
+                                self.eth_api = api;
+                                break;
+                            }
                             Err(err) => {
-                                log::error!("Failed to reconnect to Ethereum: {err}");
-                                return;
+                                log::error!("Failed to reconnect to Ethereum: {err}. Retrying...");
+                                tokio::time::sleep(BASE_RETRY_DELAY).await;
                             }
                         }
                     }

--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -117,13 +117,18 @@ async fn task(mut this: MerkleRootExtractor) {
 
         log::error!(r#"Merkle root extractor failed: "{err:?}""#);
 
-        this.eth_api = match this.eth_api.reconnect().await {
-            Ok(eth_api) => eth_api,
-            Err(err) => {
-                log::error!(r#"Failed to reconnect to Ethereum: "{err}""#);
-                break;
+        loop {
+            match this.eth_api.reconnect().await {
+                Ok(eth_api) => {
+                    this.eth_api = eth_api;
+                    break;
+                }
+                Err(err) => {
+                    log::error!(r#"Failed to reconnect to Ethereum: "{err}". Retrying..."#);
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                }
             }
-        };
+        }
     }
 }
 
@@ -138,8 +143,7 @@ async fn task_inner(this: &mut MerkleRootExtractor) -> anyhow::Result<()> {
         tokio::select! {
             _ = interval.tick() => {
                 if !this.api_provider.is_alive() {
-                    log::error!("ApiProvider connection is dead, exiting Merkle root extractor task");
-                    return Ok(());
+                    return Err(anyhow::anyhow!("ApiProvider connection is dead"));
                 }
             }
 
@@ -150,8 +154,7 @@ async fn task_inner(this: &mut MerkleRootExtractor) -> anyhow::Result<()> {
                         return Err(anyhow::anyhow!("Failed to get first log from stream: {e:?}"));
                     }
                     None => {
-                        log::info!("Log stream closed");
-                        return Ok(());
+                        return Err(anyhow::anyhow!("Log stream closed"));
                     }
                 };
 

--- a/relayer/src/message_relayer/common/ethereum/message_paid_event_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_paid_event_extractor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{self, BASE_RETRY_DELAY, MAX_RETRIES},
+    common::{self, BASE_RETRY_DELAY},
     message_relayer::{
         common::{EthereumBlockNumber, EthereumSlotNumber, TxHashWithSlot},
         eth_to_gear::storage::{Storage, UnprocessedBlocks},
@@ -147,7 +147,7 @@ async fn task(
         }
     }
 
-    let mut attempts = 0;
+    let mut attempts: u32 = 0;
     loop {
         let result = this.run_inner(&sender, &mut blocks, &mut unprocessed).await;
         let Err(err) = result else {
@@ -155,32 +155,30 @@ async fn task(
             return;
         };
 
-        attempts += 1;
-        log::error!("Paid event extractor failed (attempt {attempts}/{MAX_RETRIES}): {err}");
-
-        if attempts >= MAX_RETRIES {
-            log::error!("Max attempts reached, exiting...");
-            return;
-        }
-
-        tokio::time::sleep(BASE_RETRY_DELAY * 2u32.pow(attempts - 1)).await;
-
         if !common::is_transport_error_recoverable(&err) {
-            log::error!("Non recoverable error, exiting.");
+            log::error!("Non recoverable paid event extractor error, exiting: {err}");
             return;
         }
 
-        this.eth_api = match this.eth_api.reconnect().await {
-            Ok(eth_api) => {
-                attempts = 0;
+        attempts += 1;
+        log::error!(
+            "Paid event extractor failed with recoverable error (attempt {attempts}): {err}"
+        );
 
-                eth_api
-            }
+        tokio::time::sleep(BASE_RETRY_DELAY * 2u32.pow(attempts.saturating_sub(1).min(6))).await;
 
-            Err(err) => {
-                log::error!("Failed to reconnect to Ethereum API: {err}");
-                return;
+        loop {
+            match this.eth_api.reconnect().await {
+                Ok(eth_api) => {
+                    attempts = 0;
+                    this.eth_api = eth_api;
+                    break;
+                }
+                Err(err) => {
+                    log::error!("Failed to reconnect to Ethereum API: {err}. Retrying...");
+                    tokio::time::sleep(BASE_RETRY_DELAY).await;
+                }
             }
-        };
+        }
     }
 }

--- a/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
+++ b/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
@@ -1,7 +1,12 @@
-use crate::common::{self, BASE_RETRY_DELAY, MAX_RETRIES};
-use alloy::providers::{PendingTransactionBuilder, PendingTransactionError, Provider};
+use crate::{
+    common::{self, BASE_RETRY_DELAY, MAX_RETRIES},
+    rpc,
+};
+use alloy::providers::{
+    PendingTransactionBuilder, PendingTransactionError, Provider, RootProvider,
+};
 use ethereum_client::{EthApi, TxHash};
-use futures::{stream::FuturesUnordered, StreamExt};
+use futures::{future::BoxFuture, stream::FuturesUnordered, StreamExt};
 use prometheus::{
     core::{AtomicU64, GenericCounter, GenericGauge},
     IntCounter, IntGauge,
@@ -26,6 +31,10 @@ pub enum Response {
     Success(Uuid, TxHash),
     Failed(Uuid, PendingTransactionError),
 }
+
+type TxWatchResult =
+    Result<(Uuid, alloy::rpc::types::TransactionReceipt), (Uuid, TxHash, PendingTransactionError)>;
+type TxWatch = BoxFuture<'static, TxWatchResult>;
 
 pub struct StatusFetcherIo {
     requests: UnboundedSender<Request>,
@@ -144,7 +153,7 @@ async fn task_inner(
     channel: &mut UnboundedReceiver<Request>,
     responses: &UnboundedSender<Response>,
 ) -> anyhow::Result<()> {
-    let mut txs = FuturesUnordered::new();
+    let mut txs: FuturesUnordered<TxWatch> = FuturesUnordered::new();
     loop {
         tokio::select! {
             message = channel.recv() => {
@@ -157,15 +166,12 @@ async fn task_inner(
 
                 this.metrics.pending_tx_count.inc();
 
-                let pending = PendingTransactionBuilder::new(
+                txs.push(watch_tx(
                     this.eth_api.raw_provider().root().clone(),
+                    tx_uuid,
                     tx_hash,
-                );
-
-                let confirmations = this.confirmations;
-                txs.push(async move {
-                    Ok((tx_uuid, pending.with_required_confirmations(confirmations).get_receipt().await.map_err(|e| (tx_uuid, e))?))
-                });
+                    this.confirmations,
+                ));
             }
 
             Some(tx) = txs.next(), if !txs.is_empty() => {
@@ -189,7 +195,17 @@ async fn task_inner(
                         this.metrics.pending_tx_count.dec();
                         responses.send(Response::Success(uuid, tx_hash))?;
                     }
-                    Err((uuid, e)) => {
+                    Err((uuid, tx_hash, e)) if rpc::is_recoverable_error_text(&e) => {
+                        log::warn!("Recoverable error while polling transaction {tx_hash}: {e}. Reconnecting and continuing to watch");
+                        this.eth_api = this.eth_api.reconnect().await?;
+                        txs.push(watch_tx(
+                            this.eth_api.raw_provider().root().clone(),
+                            uuid,
+                            tx_hash,
+                            this.confirmations,
+                        ));
+                    }
+                    Err((uuid, _tx_hash, e)) => {
                         this.metrics.total_failed_txs.inc();
                         log::error!("Failed to get transaction {uuid} status: {e}");
                         responses.send(Response::Failed(uuid, e))?;
@@ -198,4 +214,18 @@ async fn task_inner(
             }
         }
     }
+}
+
+fn watch_tx(provider: RootProvider, tx_uuid: Uuid, tx_hash: TxHash, confirmations: u64) -> TxWatch {
+    Box::pin(async move {
+        let pending = PendingTransactionBuilder::new(provider, tx_hash);
+        Ok((
+            tx_uuid,
+            pending
+                .with_required_confirmations(confirmations)
+                .get_receipt()
+                .await
+                .map_err(|e| (tx_uuid, tx_hash, e))?,
+        ))
+    })
 }

--- a/relayer/src/message_relayer/common/gear/block_listener.rs
+++ b/relayer/src/message_relayer/common/gear/block_listener.rs
@@ -1,6 +1,9 @@
-use crate::message_relayer::common::{
-    gear::block_storage::{UnprocessedBlocks, UnprocessedBlocksStorage},
-    GearBlock,
+use crate::{
+    message_relayer::common::{
+        gear::block_storage::{UnprocessedBlocks, UnprocessedBlocksStorage},
+        GearBlock,
+    },
+    rpc,
 };
 use futures::StreamExt;
 use gear_common::api_provider::ApiProviderConnection;
@@ -60,62 +63,21 @@ impl BlockListener {
                 first_block,
                 blocks: _,
             } = self.block_storage.unprocessed_blocks().await;
-
-            let api_back = self.api_provider.client();
-            let tx_back = tx2.clone();
-            let storage_back = self.block_storage.clone();
-
-            tokio::spawn(async move {
-                if let Some(from_block) = last_block.or(first_block) {
-                    log::info!("Gear block listener: unprocessed blocks found, fetching them.");
-                    let latest_finalized_block = match api_back.latest_finalized_block().await {
-                        Ok(block) => block,
-                        Err(err) => {
-                            log::error!("Failed to get latest finalized block: {err}");
-                            return Err(anyhow::anyhow!("Failed to get latest finalized block"));
-                        }
-                    };
-                    let Ok(latest_finalized_block_number) =
-                        api_back.block_hash_to_number(latest_finalized_block).await
-                    else {
-                        log::error!("Failed to convert latest finalized block hash to number");
-                        return Err(anyhow::anyhow!(
-                            "Failed to convert latest finalized block hash to number"
-                        ));
-                    };
-
-                    for block in from_block.1..=latest_finalized_block_number {
-                        let hash = if block == latest_finalized_block_number {
-                            latest_finalized_block
-                        } else {
-                            match api_back.block_number_to_hash(block).await {
-                                Ok(hash) => hash,
-                                Err(err) => {
-                                    log::error!(
-                                        "Failed to get block hash for number {block}: {err}"
-                                    );
-                                    continue;
-                                }
-                            }
-                        };
-                        let missing_block_data = api_back.api.blocks().at(hash).await?;
-                        let gear_block =
-                            GearBlock::from_subxt_block(&api_back, missing_block_data).await?;
-                        storage_back.add_block(&api_back, &gear_block).await?;
-                        match tx_back.send(gear_block) {
-                            Ok(_) => {}
-                            Err(err) => {
-                                log::error!("Failed to send Gear block: {err}");
-                                return Err(anyhow::anyhow!("Failed to send Gear block"));
-                            }
-                        }
-                    }
-                }
-
-                Ok(())
-            });
-
             let mut last_finalized_block_number = None;
+            if let Some(from_block) = first_block.or(last_block) {
+                log::info!(
+                    "Gear block listener: unprocessed blocks found, replaying from #{} in background",
+                    from_block.1
+                );
+                self.spawn_replay_to_latest(
+                    tx2.clone(),
+                    from_block.1,
+                    &mut last_finalized_block_number,
+                    "startup catch-up",
+                )
+                .await;
+            }
+
             loop {
                 let res = self.run_inner(&tx2, &mut last_finalized_block_number).await;
                 let e = match res {
@@ -136,10 +98,20 @@ impl BlockListener {
 
                 if let Err(e) = self.api_provider.reconnect().await {
                     log::error!(r#"API provider unable to reconnect: "{e}""#);
-                    return;
+                    continue;
                 }
 
                 log::debug!("API provider reconnected");
+                let from_block = last_finalized_block_number
+                    .map(|block| block.saturating_add(1))
+                    .unwrap_or_default();
+                self.spawn_replay_to_latest(
+                    tx2.clone(),
+                    from_block,
+                    &mut last_finalized_block_number,
+                    "reconnect replay",
+                )
+                .await;
             }
         });
 
@@ -151,7 +123,7 @@ impl BlockListener {
     }
 
     async fn run_inner(
-        &self,
+        &mut self,
         tx: &broadcast::Sender<GearBlock>,
         last_finalized_block_number: &mut Option<u32>,
     ) -> anyhow::Result<bool> {
@@ -169,50 +141,21 @@ impl BlockListener {
                 if last_finalized + 1 != block_number {
                     log::info!("Detected gap: last finalized block was #{last_finalized}, current block is #{block_number}");
 
-                    // Fetch missing blocks
-                    for missing_block in (last_finalized + 1)..block_number {
-                        log::trace!("Fetching missing block #{missing_block}");
-
-                        let missing_block_hash = match gear_api
-                            .block_number_to_hash(missing_block)
-                            .await
-                        {
-                            Ok(hash) => hash,
-                            Err(err) => {
-                                log::error!("Failed to get block hash for missing block #{missing_block}: {err}");
-                                continue;
-                            }
-                        };
-
-                        let missing_block_data =
-                            gear_api.api.blocks().at(missing_block_hash).await?;
-                        let gear_block =
-                            GearBlock::from_subxt_block(&gear_api, missing_block_data).await?;
-                        self.block_storage.add_block(&gear_api, &gear_block).await?;
-                        match tx.send(gear_block) {
-                            Ok(_) => {}
-                            Err(broadcast::error::SendError(_)) => {
-                                log::error!(
-                                    "No active receivers for Gear block listener, stopping"
-                                );
-                                return Ok(false);
-                            }
-                        }
-                    }
+                    self.spawn_replay_range(
+                        tx.clone(),
+                        last_finalized + 1,
+                        block_number.saturating_sub(1),
+                        "live gap replay",
+                    );
                 }
             }
 
             // Process the current block
-            let block_hash: primitive_types::H256 = block_hash.0.into();
-            let block = gear_api.api.blocks().at(block_hash).await?;
-            let gear_block = GearBlock::from_subxt_block(&gear_api, block).await?;
-            self.block_storage.add_block(&gear_api, &gear_block).await?;
-            match tx.send(gear_block) {
-                Ok(_) => {}
-                Err(broadcast::error::SendError(_)) => {
-                    log::error!("No active receivers for Gear block listener, stopping");
-                    return Ok(false);
-                }
+            if !self
+                .fetch_store_send(tx, block_number, Some(block_hash.0.into()))
+                .await?
+            {
+                return Ok(false);
             }
 
             // Update the last finalized block number
@@ -222,4 +165,193 @@ impl BlockListener {
 
         Ok(true)
     }
+
+    async fn spawn_replay_to_latest(
+        &mut self,
+        tx: broadcast::Sender<GearBlock>,
+        from_block: u32,
+        last_finalized_block_number: &mut Option<u32>,
+        reason: &'static str,
+    ) {
+        let latest = {
+            let client = self.api_provider.client();
+            match client.latest_finalized_block().await {
+                Ok(hash) => match client.block_hash_to_number(hash).await {
+                    Ok(number) => Some(number),
+                    Err(err) => {
+                        log::warn!(
+                            "Gear block listener failed to inspect latest finalized block number for {reason}: {err}. Background replay will retry latest lookup"
+                        );
+                        None
+                    }
+                },
+                Err(err) => {
+                    log::warn!(
+                    "Gear block listener failed to inspect latest finalized block for {reason}: {err}. Background replay will retry latest lookup"
+                );
+                    None
+                }
+            }
+        };
+
+        if let Some(latest) = latest {
+            if from_block > latest {
+                return;
+            }
+            *last_finalized_block_number = Some(
+                last_finalized_block_number
+                    .map(|current| current.max(latest))
+                    .unwrap_or(latest),
+            );
+            self.spawn_replay_range(tx, from_block, latest, reason);
+        } else {
+            spawn_replay_to_latest(
+                self.api_provider.clone(),
+                self.block_storage.clone(),
+                tx,
+                from_block,
+                reason,
+            );
+        }
+    }
+
+    fn spawn_replay_range(
+        &self,
+        tx: broadcast::Sender<GearBlock>,
+        from_block: u32,
+        to_block: u32,
+        reason: &'static str,
+    ) {
+        if from_block > to_block {
+            return;
+        }
+
+        spawn_replay_range(
+            self.api_provider.clone(),
+            self.block_storage.clone(),
+            tx,
+            from_block,
+            to_block,
+            reason,
+        );
+    }
+
+    async fn fetch_store_send(
+        &mut self,
+        tx: &broadcast::Sender<GearBlock>,
+        block_number: u32,
+        known_hash: Option<primitive_types::H256>,
+    ) -> anyhow::Result<bool> {
+        let storage = self.block_storage.clone();
+        let gear_block = rpc::retry_gear(
+            &mut self.api_provider,
+            "gear finalized block replay",
+            move |api| {
+                let storage = storage.clone();
+                async move {
+                    let block_hash = match known_hash {
+                        Some(hash) => hash,
+                        None => api.block_number_to_hash(block_number).await?,
+                    };
+                    let block = api.api.blocks().at(block_hash).await?;
+                    let gear_block = GearBlock::from_subxt_block(&api, block).await?;
+                    storage.add_block(&api, &gear_block).await?;
+                    Ok(gear_block)
+                }
+            },
+        )
+        .await?;
+        if tx.send(gear_block).is_err() {
+            log::error!("No active receivers for Gear block listener, stopping");
+            return Ok(false);
+        }
+        Ok(true)
+    }
+}
+
+fn spawn_replay_to_latest(
+    mut api_provider: ApiProviderConnection,
+    storage: Arc<dyn UnprocessedBlocksStorage>,
+    tx: broadcast::Sender<GearBlock>,
+    from_block: u32,
+    reason: &'static str,
+) {
+    tokio::spawn(async move {
+        let latest = match rpc::retry_gear(
+            &mut api_provider,
+            "gear background latest finalized block",
+            |api| async move {
+                let hash = api.latest_finalized_block().await?;
+                api.block_hash_to_number(hash).await
+            },
+        )
+        .await
+        {
+            Ok(latest) => latest,
+            Err(err) => {
+                log::error!("Gear block listener {reason} failed to fetch latest block: {err}");
+                return;
+            }
+        };
+
+        replay_range(api_provider, storage, tx, from_block, latest, reason).await;
+    });
+}
+
+fn spawn_replay_range(
+    api_provider: ApiProviderConnection,
+    storage: Arc<dyn UnprocessedBlocksStorage>,
+    tx: broadcast::Sender<GearBlock>,
+    from_block: u32,
+    to_block: u32,
+    reason: &'static str,
+) {
+    tokio::spawn(async move {
+        replay_range(api_provider, storage, tx, from_block, to_block, reason).await;
+    });
+}
+
+async fn replay_range(
+    mut api_provider: ApiProviderConnection,
+    storage: Arc<dyn UnprocessedBlocksStorage>,
+    tx: broadcast::Sender<GearBlock>,
+    from_block: u32,
+    to_block: u32,
+    reason: &'static str,
+) {
+    log::info!("Gear block listener {reason}: replaying blocks #{from_block}..=#{to_block}");
+    for block_number in from_block..=to_block {
+        log::trace!("Gear block listener {reason}: replaying finalized block #{block_number}");
+        let storage = storage.clone();
+        let gear_block = match rpc::retry_gear(
+            &mut api_provider,
+            "gear background finalized block replay",
+            move |api| {
+                let storage = storage.clone();
+                async move {
+                    let block_hash = api.block_number_to_hash(block_number).await?;
+                    let block = api.api.blocks().at(block_hash).await?;
+                    let gear_block = GearBlock::from_subxt_block(&api, block).await?;
+                    storage.add_block(&api, &gear_block).await?;
+                    Ok::<_, anyhow::Error>(gear_block)
+                }
+            },
+        )
+        .await
+        {
+            Ok(block) => block,
+            Err(err) => {
+                log::error!(
+                    "Gear block listener {reason}: failed to replay block #{block_number}: {err}"
+                );
+                return;
+            }
+        };
+
+        if tx.send(gear_block).is_err() {
+            log::info!("Gear block listener {reason}: no active receivers, stopping replay");
+            return;
+        }
+    }
+    log::info!("Gear block listener {reason}: replay finished");
 }

--- a/relayer/src/message_relayer/common/gear/merkle_proof_fetcher.rs
+++ b/relayer/src/message_relayer/common/gear/merkle_proof_fetcher.rs
@@ -1,4 +1,4 @@
-use crate::message_relayer::common::RelayedMerkleRoot;
+use crate::{message_relayer::common::RelayedMerkleRoot, rpc};
 use gear_common::api_provider::ApiProviderConnection;
 use gear_rpc_client::dto::MerkleProof;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -101,7 +101,6 @@ async fn task_inner(
     requests: &mut UnboundedReceiver<Request>,
     responses: &UnboundedSender<Response>,
 ) -> anyhow::Result<()> {
-    let gear_api = this.api_provider.client();
     while let Some(request) = requests.recv().await {
         let message_hash = request.message_hash;
         log::info!(
@@ -114,12 +113,20 @@ async fn task_inner(
             request.merkle_root.block_hash,
         );
 
-        let proof = gear_api
-            .fetch_message_inclusion_merkle_proof(
-                request.merkle_root.block_hash,
-                message_hash.into(),
-            )
-            .await?;
+        let merkle_root_block_hash = request.merkle_root.block_hash;
+        let proof = rpc::retry_gear(
+            &mut this.api_provider,
+            "message inclusion merkle proof",
+            move |gear_api| async move {
+                gear_api
+                    .fetch_message_inclusion_merkle_proof(
+                        merkle_root_block_hash,
+                        message_hash.into(),
+                    )
+                    .await
+            },
+        )
+        .await?;
 
         responses.send(Response {
             proof,

--- a/relayer/src/message_relayer/common/gear/message_data_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_data_extractor.rs
@@ -1,5 +1,8 @@
-use crate::message_relayer::common::{
-    self, web_request::Message, AuthoritySetId, GearBlock, GearBlockNumber, MessageInBlock,
+use crate::{
+    message_relayer::common::{
+        self, web_request::Message, AuthoritySetId, GearBlock, GearBlockNumber, MessageInBlock,
+    },
+    rpc,
 };
 use anyhow::Result as AnyResult;
 use ethereum_common::U256;
@@ -46,16 +49,26 @@ impl MessageDataExtractor {
     }
 
     async fn retreive_block_data(&mut self, block_number: u32) -> AnyResult<BlockData> {
-        let gear_api = self.api_provider.client();
-
-        let block_hash = gear_api.block_number_to_hash(block_number).await?;
-        let block = gear_api.get_block_at(block_hash).await?;
-        let authority_set_id = gear_api.signed_by_authority_set_id(block_hash).await?;
-
-        let header = block.header().clone();
-        let events = gear_api.get_events_at(Some(block_hash)).await?;
-
-        let justification = gear_api.get_justification(block_hash).await?;
+        let (header, events, justification, _block_hash, authority_set_id) = rpc::retry_gear(
+            &mut self.api_provider,
+            "message data block fetch",
+            move |gear_api| async move {
+                let block_hash = gear_api.block_number_to_hash(block_number).await?;
+                let block = gear_api.get_block_at(block_hash).await?;
+                let authority_set_id = gear_api.signed_by_authority_set_id(block_hash).await?;
+                let header = block.header().clone();
+                let events = gear_api.get_events_at(Some(block_hash)).await?;
+                let justification = gear_api.get_justification(block_hash).await?;
+                Ok::<_, anyhow::Error>((
+                    header,
+                    events,
+                    justification,
+                    block_hash,
+                    authority_set_id,
+                ))
+            },
+        )
+        .await?;
 
         let block_data = (
             GearBlock::new(header, events, justification),

--- a/relayer/src/message_relayer/common/gear/message_queued_event_extractor.rs
+++ b/relayer/src/message_relayer/common/gear/message_queued_event_extractor.rs
@@ -1,6 +1,9 @@
-use crate::message_relayer::{
-    common::{self, AuthoritySetId, GearBlock, GearBlockNumber, MessageInBlock},
-    gear_to_eth::storage::Storage,
+use crate::{
+    message_relayer::{
+        common::{self, AuthoritySetId, GearBlock, GearBlockNumber, MessageInBlock},
+        gear_to_eth::storage::Storage,
+    },
+    rpc,
 };
 use gear_common::api_provider::ApiProviderConnection;
 use prometheus::IntCounter;
@@ -76,15 +79,21 @@ impl MessageQueuedEventExtractor {
         });
     }
 
-    async fn run_inner(&self, blocks: &mut Receiver<GearBlock>) -> anyhow::Result<()> {
-        let gear_api = self.api_provider.client();
+    async fn run_inner(&mut self, blocks: &mut Receiver<GearBlock>) -> anyhow::Result<()> {
         loop {
             match blocks.recv().await {
                 Ok(block) => {
                     let block_hash = block.hash();
-                    let authority_set_id = gear_api
-                        .signed_by_authority_set_id(block_hash.0.into())
-                        .await?;
+                    let authority_set_id = rpc::retry_gear(
+                        &mut self.api_provider,
+                        "message queued authority set id",
+                        move |gear_api| async move {
+                            gear_api
+                                .signed_by_authority_set_id(block_hash.0.into())
+                                .await
+                        },
+                    )
+                    .await?;
 
                     self.process_block_events(block, authority_set_id).await?;
                 }

--- a/relayer/src/message_relayer/common/mod.rs
+++ b/relayer/src/message_relayer/common/mod.rs
@@ -91,7 +91,7 @@ pub struct PaidMessage {
     pub nonce: [u8; 32],
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RelayedMerkleRoot {
     pub block: GearBlockNumber,
     pub block_hash: H256,
@@ -260,7 +260,7 @@ pub mod web_request {
         },
     }
 
-    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     pub enum MerkleRootsResponse {
         MerkleRootProof {
             proof: Vec<u8>,

--- a/relayer/src/proof_storage/file_system.rs
+++ b/relayer/src/proof_storage/file_system.rs
@@ -76,24 +76,31 @@ impl FileSystemProofStorage {
     async fn save_state(&self) -> Result<(), ProofStorageError> {
         let circuit_data = self.cache.get_circuit_data().await?;
 
-        fs::write(
-            self.save_to.join("circuit_data.bin"),
-            circuit_data.clone().into_bytes(),
-        )
-        .await
-        .map_err(|_| ProofStorageError::NotInitialized)?;
+        self.atomic_write("circuit_data.bin", circuit_data.clone().into_bytes())
+            .await?;
 
         let inner = self.cache.inner().read().await;
 
         for (validator_set_id, proof) in &inner.proofs {
-            fs::write(
-                self.save_to.join(format!("proof_{validator_set_id}.bin")),
+            self.atomic_write(
+                &format!("proof_{validator_set_id}.bin"),
                 proof.clone().into_bytes(),
             )
-            .await
-            .map_err(|_| ProofStorageError::NotInitialized)?;
+            .await?;
         }
 
+        Ok(())
+    }
+
+    async fn atomic_write(&self, name: &str, bytes: Vec<u8>) -> Result<(), ProofStorageError> {
+        let path = self.save_to.join(name);
+        let tmp_path = self.save_to.join(format!("{name}.tmp"));
+        fs::write(&tmp_path, bytes)
+            .await
+            .map_err(|_| ProofStorageError::NotInitialized)?;
+        fs::rename(&tmp_path, &path)
+            .await
+            .map_err(|_| ProofStorageError::NotInitialized)?;
         Ok(())
     }
 

--- a/relayer/src/prover_interface.rs
+++ b/relayer/src/prover_interface.rs
@@ -12,7 +12,7 @@ use prover::{
 };
 use serde::{Deserialize, Serialize};
 use sp_consensus_grandpa::GrandpaJustification;
-use std::{str::FromStr, thread, time::Instant};
+use std::{path::PathBuf, str::FromStr, thread, time::Instant};
 use subxt::utils::H256;
 use utils_prometheus::MeteredService;
 pub struct Metrics;
@@ -228,6 +228,7 @@ pub async fn prove_final(
     genesis_config: GenesisConfig,
     at_block: H256,
     count_thread: Option<usize>,
+    gnark_data_path: PathBuf,
     inclusion_proof: Option<RawBlockInclusionProof>,
 ) -> anyhow::Result<FinalProof> {
     let (headers, proof) = if let Some(proof) = inclusion_proof {
@@ -276,6 +277,7 @@ pub async fn prove_final(
         genesis_config,
         (proof, headers),
         count_thread,
+        gnark_data_path,
     )
     .await
 }
@@ -286,6 +288,7 @@ pub async fn prove_final_with_block_finality(
     genesis_config: GenesisConfig,
     (block_finality_proof, headers): (RawBlockInclusionProof, Vec<GearHeader>),
     count_thread: Option<usize>,
+    gnark_data_path: PathBuf,
 ) -> anyhow::Result<FinalProof> {
     let Some(header_first) = headers.first() else {
         return Err(anyhow!(
@@ -323,7 +326,7 @@ pub async fn prove_final_with_block_finality(
             message_contents,
         );
 
-        gnark::prove_circuit(&proof)
+        gnark::prove_circuit(&proof, &gnark_data_path)
     });
 
     let proof = handler
@@ -394,7 +397,10 @@ fn parse_rpc_block_finality_proof(
 
 pub mod gnark {
     use core::ffi::c_char;
-    use std::ffi::{CStr, CString};
+    use std::{
+        ffi::{CStr, CString},
+        path::Path,
+    };
 
     use prover::proving::ExportedProofWithCircuitData;
     use serde::{Deserialize, Serialize};
@@ -406,14 +412,18 @@ pub mod gnark {
     }
 
     extern "C" {
-        fn prove(circuit_data: *const c_char) -> *const c_char;
+        fn prove(circuit_data: *const c_char, data_path: *const c_char) -> *const c_char;
     }
 
-    pub fn prove_circuit(s: &ExportedProofWithCircuitData) -> ProveResult {
+    pub fn prove_circuit(s: &ExportedProofWithCircuitData, data_path: &Path) -> ProveResult {
         let serialized = serde_json::to_string(s).expect("Failed to serialize data");
         let c_string = CString::new(serialized).expect("CString::new failed");
+        let data_path = data_path
+            .to_str()
+            .expect("Gnark data path should be valid UTF-8");
+        let data_path = CString::new(data_path).expect("CString::new failed");
         let result = unsafe {
-            let result_ptr = prove(c_string.as_ptr());
+            let result_ptr = prove(c_string.as_ptr(), data_path.as_ptr());
             if result_ptr.is_null() {
                 panic!("prove returned null pointer");
             }

--- a/relayer/src/rpc.rs
+++ b/relayer/src/rpc.rs
@@ -1,0 +1,224 @@
+use std::{
+    future::Future,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use alloy::transports::{RpcError, TransportErrorKind};
+use gear_common::api_provider::ApiProviderConnection;
+use gear_rpc_client::GearApi;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RpcFailureKind {
+    Recoverable,
+    Permanent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDecision {
+    Retry,
+    Fail,
+}
+
+#[derive(Debug, Error)]
+#[error("{operation} failed with {kind:?} RPC error: {message}")]
+pub struct RpcFailure {
+    pub operation: &'static str,
+    pub kind: RpcFailureKind,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub base_delay: Duration,
+    pub max_delay: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            base_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(60),
+        }
+    }
+}
+
+impl RetryPolicy {
+    fn delay(&self, attempt: u32) -> Duration {
+        let multiplier = 1u32.checked_shl(attempt.min(6)).unwrap_or(64);
+        let delay = self
+            .base_delay
+            .saturating_mul(multiplier)
+            .min(self.max_delay);
+        let jitter_bound = delay.as_millis().min(1_000) as u64 + 1;
+        let jitter_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.subsec_nanos() as u64 % jitter_bound)
+            .unwrap_or_default();
+        delay + Duration::from_millis(jitter_ms)
+    }
+}
+
+pub fn classify_anyhow(err: &anyhow::Error) -> RetryDecision {
+    if err.chain().any(is_recoverable_error_text) {
+        return RetryDecision::Retry;
+    }
+
+    if let Some(ethereum_client::Error::ErrorInHTTPTransport(err)) =
+        err.downcast_ref::<ethereum_client::Error>()
+    {
+        return classify_alloy_rpc(err);
+    }
+
+    if let Some(err) = err.downcast_ref::<RpcError<TransportErrorKind>>() {
+        return classify_alloy_rpc(err);
+    }
+
+    if let Some(gclient::Error::GearSDK(gsdk::Error::Subxt(err))) =
+        err.downcast_ref::<gclient::Error>()
+    {
+        if is_recoverable_subxt(err) {
+            return RetryDecision::Retry;
+        }
+    }
+
+    if let Some(gsdk::Error::Subxt(err)) = err.downcast_ref::<gsdk::Error>() {
+        if is_recoverable_subxt(err) {
+            return RetryDecision::Retry;
+        }
+    }
+
+    if let Some(err) = err.downcast_ref::<subxt::Error>() {
+        if is_recoverable_subxt(err) {
+            return RetryDecision::Retry;
+        }
+    }
+
+    RetryDecision::Fail
+}
+
+pub fn classify_alloy_rpc(err: &RpcError<TransportErrorKind>) -> RetryDecision {
+    match err {
+        RpcError::Transport(transport) => match transport {
+            TransportErrorKind::MissingBatchResponse(_)
+            | TransportErrorKind::BackendGone
+            | TransportErrorKind::PubsubUnavailable
+            | TransportErrorKind::HttpError(_) => RetryDecision::Retry,
+            TransportErrorKind::Custom(message) if is_recoverable_error_text(message) => {
+                RetryDecision::Retry
+            }
+            _ => RetryDecision::Fail,
+        },
+        RpcError::ErrorResp(_) => RetryDecision::Fail,
+        RpcError::NullResp => RetryDecision::Retry,
+        _ => RetryDecision::Fail,
+    }
+}
+
+pub fn is_recoverable_error_text(message: impl std::fmt::Display) -> bool {
+    let message = message.to_string().to_ascii_lowercase();
+    message.contains("background task closed")
+        || message.contains("connection closed")
+        || message.contains("disconnectedwillreconnect")
+        || message.contains("disconnected will reconnect")
+        || message.contains("restart required")
+        || message.contains("backend gone")
+        || message.contains("transport error")
+        || message.contains("subscription dropped")
+        || message.contains("connection refused")
+        || message.contains("connection reset")
+        || message.contains("broken pipe")
+        || message.contains("timed out")
+        || message.contains("timeout")
+}
+
+pub async fn retry_gear<T, F, Fut>(
+    connection: &mut ApiProviderConnection,
+    operation: &'static str,
+    mut f: F,
+) -> anyhow::Result<T>
+where
+    F: FnMut(GearApi) -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    let mut attempt = 0;
+    let policy = RetryPolicy::default();
+
+    loop {
+        let client = connection.client();
+        match f(client).await {
+            Ok(value) => return Ok(value),
+            Err(err) if classify_anyhow(&err) == RetryDecision::Retry => {
+                let delay = policy.delay(attempt);
+                log::warn!(
+                    "{operation} failed with recoverable Gear RPC error: {err}. Reconnecting in {delay:?}"
+                );
+                tokio::time::sleep(delay).await;
+                connection.reconnect().await.map_err(|reconnect_err| {
+                    anyhow::anyhow!(
+                        "{} failed to reconnect after recoverable RPC error: {reconnect_err}",
+                        operation
+                    )
+                })?;
+                attempt = attempt.saturating_add(1);
+            }
+            Err(err) => {
+                return Err(RpcFailure {
+                    operation,
+                    kind: RpcFailureKind::Permanent,
+                    message: err.to_string(),
+                }
+                .into());
+            }
+        }
+    }
+}
+
+fn is_recoverable_subxt(err: &subxt::Error) -> bool {
+    if err.is_disconnected_will_reconnect() {
+        return true;
+    }
+
+    matches!(
+        err,
+        subxt::Error::Rpc(subxt::error::RpcError::SubscriptionDropped)
+            | subxt::Error::Rpc(subxt::error::RpcError::ClientError(
+                gsdk::ext::subxt_rpcs::Error::DisconnectedWillReconnect(_)
+            ))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_known_disconnect_text_as_recoverable() {
+        let err = anyhow::anyhow!(
+            "RPC error: client error: The background task closed connection closed; restart required"
+        );
+
+        assert_eq!(classify_anyhow(&err), RetryDecision::Retry);
+    }
+
+    #[test]
+    fn does_not_treat_plain_channel_closure_as_rpc_recoverable() {
+        let err = anyhow::anyhow!("No active receivers for Gear block listener");
+
+        assert_eq!(classify_anyhow(&err), RetryDecision::Fail);
+    }
+
+    #[test]
+    fn classifies_backend_gone_as_recoverable() {
+        let err = RpcError::Transport(TransportErrorKind::BackendGone);
+
+        assert_eq!(classify_alloy_rpc(&err), RetryDecision::Retry);
+    }
+
+    #[test]
+    fn classifies_real_socket_failures_as_recoverable() {
+        let err = anyhow::anyhow!("transport error: connection refused");
+
+        assert_eq!(classify_anyhow(&err), RetryDecision::Retry);
+    }
+}

--- a/relayer/src/server.rs
+++ b/relayer/src/server.rs
@@ -8,17 +8,22 @@ use tokio::sync::mpsc::UnboundedSender;
 
 const HEADER_TOKEN: &str = "X-Token";
 
+struct Secret(String);
+
+struct LogContext(String);
+
 async fn relay_messages(
     request: HttpRequest,
     messages: web::Json<Messages>,
-    secret: web::Data<String>,
+    secret: web::Data<Secret>,
+    log_context: web::Data<LogContext>,
     channel: web::Data<UnboundedSender<Message>>,
 ) -> HttpResponse {
     if !request
         .headers()
         .get(HEADER_TOKEN)
         .and_then(|h| h.to_str().ok())
-        .map(|t| t == secret.get_ref())
+        .map(|t| t == secret.0.as_str())
         .unwrap_or(false)
     {
         return HttpResponse::Unauthorized().finish();
@@ -41,7 +46,10 @@ async fn relay_messages(
             Ok(_) => to_process -= 1,
 
             Err(e) => {
-                log::error!(r#"Unable to send message "{message:?}": {e:?}"#);
+                log::error!(
+                    r#"[{}] Unable to send message "{message:?}": {e:?}"#,
+                    log_context.0.as_str()
+                );
             }
         }
     }
@@ -58,22 +66,25 @@ async fn relay_messages(
 async fn get_merkle_root_proof(
     request: HttpRequest,
     blocks: web::Json<MerkleRootBlocks>,
-    secret: web::Data<String>,
+    secret: web::Data<Secret>,
+    log_context: web::Data<LogContext>,
     channel: web::Data<UnboundedSender<MerkleRootsRequest>>,
 ) -> HttpResponse {
     if !request
         .headers()
         .get(HEADER_TOKEN)
         .and_then(|h| h.to_str().ok())
-        .map(|t| t == secret.get_ref())
+        .map(|t| t == secret.0.as_str())
         .unwrap_or(false)
     {
         return HttpResponse::Unauthorized().finish();
     }
 
     let blocks = blocks.into_inner().blocks;
+    let len = blocks.len();
 
     let mut futures = FuturesUnordered::new();
+    let mut failed_sends = 0;
 
     for block in blocks {
         let (sender, receiver) = tokio::sync::oneshot::channel();
@@ -83,14 +94,17 @@ async fn get_merkle_root_proof(
         };
 
         if channel.send(request).is_err() {
-            log::error!("Unable to send merkle root proof request for block {block}");
+            log::error!(
+                "[{}] Unable to send merkle root proof request for block {block}",
+                log_context.0.as_str()
+            );
+            failed_sends += 1;
             continue;
         }
 
         futures.push(receiver);
     }
-    let len = futures.len();
-    let mut to_process = len;
+    let mut to_process = failed_sends + futures.len();
 
     let mut merkle_roots = Vec::new();
 
@@ -101,7 +115,10 @@ async fn get_merkle_root_proof(
                 to_process -= 1;
             }
             Err(e) => {
-                log::error!("Unable to receive merkle root proof response: {e:?}");
+                log::error!(
+                    "[{}] Unable to receive merkle root proof response: {e:?}",
+                    log_context.0.as_str()
+                );
             }
         }
     }
@@ -118,17 +135,20 @@ async fn get_merkle_root_proof(
 pub fn create(
     tcp_listener: TcpListener,
     secret: String,
+    log_context: String,
     messages_channel: Option<UnboundedSender<Message>>,
     merkle_roots_channel: Option<UnboundedSender<MerkleRootsRequest>>,
 ) -> std::io::Result<actix_web::dev::Server> {
     let messages_channel = messages_channel.map(web::Data::new);
     let merkle_roots_channel = merkle_roots_channel.map(web::Data::new);
 
-    let secret = web::Data::new(secret);
+    let secret = web::Data::new(Secret(secret));
+    let log_context = web::Data::new(LogContext(log_context));
 
     let server = HttpServer::new(move || {
         let mut app = App::new()
             .app_data(secret.clone())
+            .app_data(log_context.clone())
             // enable logger
             .wrap(middleware::Logger::default())
             .app_data(
@@ -174,6 +194,7 @@ pub fn create(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message_relayer::common::web_request::MerkleRootsResponse;
     use ethereum_common::U256;
     use reqwest::{
         header::{HeaderValue, CONTENT_TYPE},
@@ -197,7 +218,14 @@ mod tests {
         const SECRET: &str = "SECRET123";
         let (channel, mut receiver) = mpsc::unbounded_channel();
 
-        let server = super::create(listener, SECRET.to_string(), Some(channel), None).unwrap();
+        let server = super::create(
+            listener,
+            SECRET.to_string(),
+            "test".to_string(),
+            Some(channel),
+            None,
+        )
+        .unwrap();
 
         task::spawn(server);
 
@@ -290,5 +318,260 @@ mod tests {
             response.status(),
             reqwest::StatusCode::INTERNAL_SERVER_ERROR
         );
+    }
+
+    #[tokio::test]
+    async fn test_merkle_root_proof_server() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        const SECRET: &str = "SECRET123";
+        let (channel, mut receiver) = mpsc::unbounded_channel();
+
+        let server = super::create(
+            listener,
+            SECRET.to_string(),
+            "test".to_string(),
+            None,
+            Some(channel),
+        )
+        .unwrap();
+
+        task::spawn(server);
+
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let url = format!("http://127.0.0.1:{port}/get_merkle_root_proof");
+        let body = MerkleRootBlocks { blocks: vec![123] };
+
+        let response = client.post(&url).json(&body).send().await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+        let client_for_request = client.clone();
+        let url_for_request = url.clone();
+        let request = task::spawn(async move {
+            client_for_request
+                .post(&url_for_request)
+                .json(&body)
+                .header(HEADER_TOKEN, SECRET)
+                .send()
+                .await
+                .unwrap()
+        });
+
+        let request_received = receiver.recv().await.unwrap();
+        match request_received {
+            MerkleRootsRequest::GetMerkleRootProof {
+                block_number,
+                response,
+            } => {
+                assert_eq!(block_number, 123);
+                response
+                    .send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number })
+                    .unwrap();
+            }
+        }
+
+        let response = request.await.unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let body = response.json::<Vec<MerkleRootsResponse>>().await.unwrap();
+        assert_eq!(
+            body,
+            vec![MerkleRootsResponse::NoMerkleRootOnBlock { block_number: 123 }]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merkle_root_proof_separate_listeners_route_independently() {
+        const SECRET_A: &str = "SECRET_A";
+        const SECRET_B: &str = "SECRET_B";
+
+        let (url_a, mut receiver_a) = spawn_merkle_root_server(SECRET_A, "relayer-a");
+        let (url_b, mut receiver_b) = spawn_merkle_root_server(SECRET_B, "relayer-b");
+
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let request_a = {
+            let client = client.clone();
+            let url = url_a.clone();
+            task::spawn(async move {
+                client
+                    .post(&url)
+                    .json(&MerkleRootBlocks { blocks: vec![111] })
+                    .header(HEADER_TOKEN, SECRET_A)
+                    .send()
+                    .await
+                    .unwrap()
+            })
+        };
+
+        let request_received = receiver_a.recv().await.unwrap();
+        match request_received {
+            MerkleRootsRequest::GetMerkleRootProof {
+                block_number,
+                response,
+            } => {
+                assert_eq!(block_number, 111);
+                response
+                    .send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number })
+                    .unwrap();
+            }
+        }
+        assert!(receiver_b.try_recv().is_err());
+        assert_eq!(request_a.await.unwrap().status(), reqwest::StatusCode::OK);
+
+        let request_b = {
+            let client = client.clone();
+            let url = url_b.clone();
+            task::spawn(async move {
+                client
+                    .post(&url)
+                    .json(&MerkleRootBlocks { blocks: vec![222] })
+                    .header(HEADER_TOKEN, SECRET_B)
+                    .send()
+                    .await
+                    .unwrap()
+            })
+        };
+
+        let request_received = receiver_b.recv().await.unwrap();
+        match request_received {
+            MerkleRootsRequest::GetMerkleRootProof {
+                block_number,
+                response,
+            } => {
+                assert_eq!(block_number, 222);
+                response
+                    .send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number })
+                    .unwrap();
+            }
+        }
+        assert!(receiver_a.try_recv().is_err());
+        assert_eq!(request_b.await.unwrap().status(), reqwest::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_merkle_root_proof_closed_channel_is_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        const SECRET: &str = "SECRET123";
+        let (channel, receiver) = mpsc::unbounded_channel();
+        drop(receiver);
+
+        let server = super::create(
+            listener,
+            SECRET.to_string(),
+            "test".to_string(),
+            None,
+            Some(channel),
+        )
+        .unwrap();
+
+        task::spawn(server);
+
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let url = format!("http://127.0.0.1:{port}/get_merkle_root_proof");
+        let response = client
+            .post(&url)
+            .json(&MerkleRootBlocks { blocks: vec![123] })
+            .header(HEADER_TOKEN, SECRET)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merkle_root_proof_dropped_response_is_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        const SECRET: &str = "SECRET123";
+        let (channel, mut receiver) = mpsc::unbounded_channel();
+
+        let server = super::create(
+            listener,
+            SECRET.to_string(),
+            "test".to_string(),
+            None,
+            Some(channel),
+        )
+        .unwrap();
+
+        task::spawn(server);
+
+        let client = ClientBuilder::new()
+            .timeout(Duration::from_secs(60))
+            .build()
+            .unwrap();
+
+        let url = format!("http://127.0.0.1:{port}/get_merkle_root_proof");
+        let body = MerkleRootBlocks { blocks: vec![123] };
+
+        let request = task::spawn(async move {
+            client
+                .post(&url)
+                .json(&body)
+                .header(HEADER_TOKEN, SECRET)
+                .send()
+                .await
+                .unwrap()
+        });
+
+        let request_received = receiver.recv().await.unwrap();
+        match request_received {
+            MerkleRootsRequest::GetMerkleRootProof {
+                block_number,
+                response,
+            } => {
+                assert_eq!(block_number, 123);
+                drop(response);
+            }
+        }
+
+        let response = request.await.unwrap();
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    fn spawn_merkle_root_server(
+        secret: &str,
+        log_context: &str,
+    ) -> (String, mpsc::UnboundedReceiver<MerkleRootsRequest>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (channel, receiver) = mpsc::unbounded_channel();
+
+        let server = super::create(
+            listener,
+            secret.to_string(),
+            log_context.to_string(),
+            None,
+            Some(channel),
+        )
+        .unwrap();
+        task::spawn(server);
+
+        (
+            format!("http://127.0.0.1:{port}/get_merkle_root_proof"),
+            receiver,
+        )
     }
 }

--- a/relayer/tests/live_rpc_reconnect.rs
+++ b/relayer/tests/live_rpc_reconnect.rs
@@ -1,0 +1,470 @@
+use std::{
+    env,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use alloy::pubsub::Subscription;
+use ethereum_client::{EthApi, PollingEthApi};
+use futures::StreamExt;
+use gear_common::api_provider::ApiProvider;
+use relayer::{
+    message_relayer::common::{
+        gear::{
+            block_listener::BlockListener,
+            block_storage::{UnprocessedBlocks, UnprocessedBlocksStorage},
+        },
+        GearBlock,
+    },
+    rpc,
+};
+
+const DEFAULT_GEAR_ENDPOINT: &str = "wss://testnet-archive.vara.network";
+const DEFAULT_GEAR_RPC_RETRIES: u8 = 3;
+const DEFAULT_ETH_ENDPOINT: &str = "wss://hoodi-reth-rpc.gear-tech.io/ws";
+const DEFAULT_ETH_MESSAGE_QUEUE_ADDRESS: &str = "0xAb8F315Cc80cf2368750fE5A33E259d6241b3dEB";
+
+fn gear_endpoint() -> String {
+    env::var("GEAR_ENDPOINT")
+        .or_else(|_| env::var("GEAR_DOMAIN"))
+        .unwrap_or_else(|_| DEFAULT_GEAR_ENDPOINT.to_string())
+}
+
+fn gear_retries() -> u8 {
+    env::var("GEAR_RPC_RETRIES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_GEAR_RPC_RETRIES)
+}
+
+fn eth_endpoint() -> String {
+    env::var("ETHEREUM_RPC")
+        .or_else(|_| env::var("ETHEREUM_ENDPOINT"))
+        .or_else(|_| env::var("ETH_RPC"))
+        .unwrap_or_else(|_| DEFAULT_ETH_ENDPOINT.to_string())
+}
+
+fn eth_message_queue_address() -> String {
+    env::var("ETH_MESSAGE_QUEUE_ADDRESS")
+        .unwrap_or_else(|_| DEFAULT_ETH_MESSAGE_QUEUE_ADDRESS.to_string())
+}
+
+async fn gear_latest_number(
+    connection: &mut gear_common::api_provider::ApiProviderConnection,
+) -> anyhow::Result<u32> {
+    rpc::retry_gear(
+        connection,
+        "live test gear latest finalized",
+        |api| async move {
+            let hash = api.latest_finalized_block().await?;
+            api.block_hash_to_number(hash).await
+        },
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Vara testnet RPC"]
+async fn live_gear_retry_helper_survives_explicit_reconnect() -> anyhow::Result<()> {
+    let provider = ApiProvider::new(gear_endpoint(), gear_retries()).await?;
+    let mut connection = provider.connection();
+    provider.spawn();
+
+    let before = gear_latest_number(&mut connection).await?;
+    connection.reconnect().await?;
+    let after = gear_latest_number(&mut connection).await?;
+
+    assert!(
+        after >= before,
+        "latest finalized block regressed across reconnect: before={before}, after={after}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Vara testnet RPC"]
+async fn live_gear_provider_reconnects_multiple_connections() -> anyhow::Result<()> {
+    let provider = ApiProvider::new(gear_endpoint(), gear_retries()).await?;
+    let mut first = provider.connection();
+    let mut second = provider.connection();
+    provider.spawn();
+
+    let baseline = gear_latest_number(&mut first).await?;
+    first.reconnect().await?;
+    let after_first_reconnect = gear_latest_number(&mut first).await?;
+    second.reconnect().await?;
+    let after_second_reconnect = gear_latest_number(&mut second).await?;
+
+    assert!(
+        after_first_reconnect >= baseline,
+        "first connection regressed across reconnect: baseline={baseline}, after={after_first_reconnect}"
+    );
+    assert!(
+        after_second_reconnect >= baseline,
+        "second connection regressed after provider session refresh: baseline={baseline}, after={after_second_reconnect}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires live Vara testnet RPC"]
+async fn live_gear_worker_continues_while_sibling_triggers_reconnects() -> anyhow::Result<()> {
+    let provider = ApiProvider::new(gear_endpoint(), gear_retries()).await?;
+    let mut worker_connection = provider.connection();
+    let mut reconnect_connection = provider.connection();
+    provider.spawn();
+
+    let worker = tokio::spawn(async move {
+        let mut observed = Vec::new();
+        for _ in 0..8 {
+            let block = gear_latest_number(&mut worker_connection).await?;
+            observed.push(block);
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        anyhow::Ok(observed)
+    });
+
+    let reconnector = tokio::spawn(async move {
+        for _ in 0..4 {
+            tokio::time::sleep(Duration::from_millis(125)).await;
+            reconnect_connection.reconnect().await?;
+            let _ = gear_latest_number(&mut reconnect_connection).await?;
+        }
+        anyhow::Ok(())
+    });
+
+    reconnector.await??;
+    let observed = worker.await??;
+
+    assert_eq!(
+        observed.len(),
+        8,
+        "worker did not complete all RPC calls while sibling reconnected"
+    );
+    for pair in observed.windows(2) {
+        assert!(
+            pair[1] >= pair[0],
+            "worker observed finalized block regression while sibling reconnected: {observed:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Vara testnet RPC"]
+async fn live_gear_subscription_can_be_recreated_after_reconnect() -> anyhow::Result<()> {
+    let provider = ApiProvider::new(gear_endpoint(), gear_retries()).await?;
+    let mut connection = provider.connection();
+    provider.spawn();
+
+    let subscription = connection
+        .client()
+        .subscribe_grandpa_justifications()
+        .await?;
+    drop(subscription);
+
+    connection.reconnect().await?;
+
+    let mut subscription = connection
+        .client()
+        .subscribe_grandpa_justifications()
+        .await?;
+    let justification = tokio::time::timeout(Duration::from_secs(45), subscription.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("GRANDPA justification stream ended after reconnect"))??;
+
+    assert!(
+        justification.commit.target_number > 0,
+        "recreated GRANDPA subscription yielded an invalid block number"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Vara testnet RPC"]
+async fn live_gear_block_listener_background_catchup_still_emits_blocks() -> anyhow::Result<()> {
+    let provider = ApiProvider::new(gear_endpoint(), gear_retries()).await?;
+    let mut setup_connection = provider.connection();
+    let listener_connection = provider.connection();
+    provider.spawn();
+
+    let latest = gear_latest_number(&mut setup_connection).await?;
+    let from_block = latest.saturating_sub(8);
+    let storage = Arc::new(CountingStorage {
+        from_block,
+        added: AtomicUsize::new(0),
+    });
+
+    let listener = BlockListener::new(listener_connection, storage.clone());
+    let [mut blocks] = listener.run::<1>().await;
+
+    let received = tokio::time::timeout(Duration::from_secs(90), blocks.recv()).await??;
+    assert!(
+        received.number() >= from_block,
+        "received block {} before requested catch-up start {from_block}",
+        received.number()
+    );
+    assert!(
+        storage.added.load(Ordering::SeqCst) > 0,
+        "listener emitted a block without recording it in replay storage"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Vara testnet RPC"]
+async fn live_gear_background_catchup_replays_multiple_blocks() -> anyhow::Result<()> {
+    let provider = ApiProvider::new(gear_endpoint(), gear_retries()).await?;
+    let mut setup_connection = provider.connection();
+    let listener_connection = provider.connection();
+    provider.spawn();
+
+    let latest = gear_latest_number(&mut setup_connection).await?;
+    let from_block = latest.saturating_sub(12);
+    let storage = Arc::new(CountingStorage {
+        from_block,
+        added: AtomicUsize::new(0),
+    });
+
+    let listener = BlockListener::new(listener_connection, storage.clone());
+    let [_blocks] = listener.run::<1>().await;
+
+    let added = storage.wait_for_added(4, Duration::from_secs(90)).await;
+    assert!(
+        added >= 4,
+        "background catch-up did not replay enough blocks: added={added}, from_block={from_block}, latest={latest}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Hoodi Ethereum RPC"]
+async fn live_ethereum_polling_reconnect_keeps_finalized_queries() -> anyhow::Result<()> {
+    let api =
+        PollingEthApi::new_with_retries(&eth_endpoint(), Some(3), Some(Duration::from_secs(2)))
+            .await?;
+
+    let before = api.finalized_block().await?.header.number;
+    let api = api.reconnect().await?;
+    let after = api.finalized_block().await?.header.number;
+    let _block = api.get_block(after).await?;
+
+    assert!(
+        after >= before,
+        "Ethereum finalized block regressed across reconnect: before={before}, after={after}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Hoodi Ethereum RPC"]
+async fn live_ethereum_polling_survives_repeated_reconnects() -> anyhow::Result<()> {
+    let mut api =
+        PollingEthApi::new_with_retries(&eth_endpoint(), Some(3), Some(Duration::from_secs(2)))
+            .await?;
+
+    let baseline = api.finalized_block().await?.header.number;
+    for attempt in 0..3 {
+        api = api.reconnect().await?;
+        let finalized = api.finalized_block().await?.header.number;
+        let _block = api.get_block(finalized).await?;
+        assert!(
+            finalized >= baseline,
+            "finalized block regressed on reconnect attempt {attempt}: baseline={baseline}, finalized={finalized}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires live Hoodi Ethereum RPC"]
+async fn live_ethereum_worker_queries_while_sibling_reconnects() -> anyhow::Result<()> {
+    let worker_api =
+        PollingEthApi::new_with_retries(&eth_endpoint(), Some(3), Some(Duration::from_secs(2)))
+            .await?;
+    let mut reconnect_api = worker_api.clone();
+
+    let worker = tokio::spawn(async move {
+        let mut observed = Vec::new();
+        for _ in 0..8 {
+            let finalized = worker_api.finalized_block().await?.header.number;
+            let _ = worker_api.get_block(finalized).await?;
+            observed.push(finalized);
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        anyhow::Ok(observed)
+    });
+
+    let reconnector = tokio::spawn(async move {
+        for _ in 0..4 {
+            tokio::time::sleep(Duration::from_millis(125)).await;
+            reconnect_api = reconnect_api.reconnect().await?;
+            let _ = reconnect_api.finalized_block().await?;
+        }
+        anyhow::Ok(())
+    });
+
+    reconnector.await??;
+    let observed = worker.await??;
+
+    assert_eq!(
+        observed.len(),
+        8,
+        "Ethereum worker did not complete all RPC calls while sibling reconnected"
+    );
+    for pair in observed.windows(2) {
+        assert!(
+            pair[1] >= pair[0],
+            "Ethereum worker observed finalized block regression while sibling reconnected: {observed:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Hoodi Ethereum RPC and MessageQueue contract"]
+async fn live_ethereum_contract_reconnect_keeps_queries_and_subscriptions() -> anyhow::Result<()> {
+    let api = EthApi::new_with_retries(
+        &eth_endpoint(),
+        &eth_message_queue_address(),
+        None,
+        Some(3),
+        Some(Duration::from_secs(2)),
+        None,
+        None,
+    )
+    .await?;
+
+    let max_block_number = api.max_block_number().await?;
+    let finalized = api.finalized_block_number().await?;
+    let from = finalized.saturating_sub(128);
+    let _recent_roots = api.fetch_merkle_roots_in_range(from, finalized).await?;
+    let before_subscription: Subscription<alloy::rpc::types::Log> = api.subscribe_logs().await?;
+    drop(before_subscription);
+
+    let api = api.reconnect().await?;
+    let max_block_number_after = api.max_block_number().await?;
+    let _max_block_distance = api.max_block_distance().await?;
+    let after_subscription: Subscription<alloy::rpc::types::Log> = api.subscribe_logs().await?;
+    drop(after_subscription);
+
+    assert_eq!(
+        max_block_number, max_block_number_after,
+        "MessageQueue max block number changed across reconnect"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Hoodi Ethereum RPC and MessageQueue contract"]
+async fn live_ethereum_block_subscription_recreated_after_reconnect() -> anyhow::Result<()> {
+    let api = EthApi::new_with_retries(
+        &eth_endpoint(),
+        &eth_message_queue_address(),
+        None,
+        Some(3),
+        Some(Duration::from_secs(2)),
+        None,
+        None,
+    )
+    .await?;
+
+    let subscription = api.subscribe_blocks().await?;
+    drop(subscription);
+
+    let api = api.reconnect().await?;
+    let subscription = api.subscribe_blocks().await?;
+    let mut stream = subscription.into_result_stream();
+    let header = tokio::time::timeout(Duration::from_secs(75), stream.next())
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Ethereum block subscription ended after reconnect"))??;
+
+    assert!(
+        header.number > 0,
+        "recreated Ethereum block subscription yielded an invalid block number"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires live Hoodi Ethereum RPC and MessageQueue contract"]
+async fn live_ethereum_contract_range_queries_survive_repeated_reconnects() -> anyhow::Result<()> {
+    let mut api = EthApi::new_with_retries(
+        &eth_endpoint(),
+        &eth_message_queue_address(),
+        None,
+        Some(3),
+        Some(Duration::from_secs(2)),
+        None,
+        None,
+    )
+    .await?;
+
+    let finalized = api.finalized_block_number().await?;
+    let from = finalized.saturating_sub(256);
+    let baseline_distance = api.max_block_distance().await?;
+
+    for attempt in 0..3 {
+        api = api.reconnect().await?;
+        let distance = api.max_block_distance().await?;
+        let _roots = api.fetch_merkle_roots_in_range(from, finalized).await?;
+        assert_eq!(
+            baseline_distance, distance,
+            "MessageQueue max distance changed on reconnect attempt {attempt}"
+        );
+    }
+
+    Ok(())
+}
+
+struct CountingStorage {
+    from_block: u32,
+    added: AtomicUsize,
+}
+
+impl CountingStorage {
+    async fn wait_for_added(&self, expected: usize, timeout: Duration) -> usize {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let added = self.added.load(Ordering::SeqCst);
+            if added >= expected || tokio::time::Instant::now() >= deadline {
+                return added;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl UnprocessedBlocksStorage for CountingStorage {
+    async fn unprocessed_blocks(&self) -> UnprocessedBlocks {
+        UnprocessedBlocks {
+            blocks: Vec::new(),
+            first_block: Some((primitive_types::H256::zero(), self.from_block)),
+            last_block: None,
+        }
+    }
+
+    async fn add_block(
+        &self,
+        _api: &gear_rpc_client::GearApi,
+        _block: &GearBlock,
+    ) -> anyhow::Result<()> {
+        self.added.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}

--- a/relayer/tests/podman_rpc_failure.rs
+++ b/relayer/tests/podman_rpc_failure.rs
@@ -1,0 +1,350 @@
+use std::{
+    env,
+    net::TcpListener,
+    process::{Command, Output},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::Context;
+use ethereum_client::PollingEthApi;
+use gear_common::api_provider::ApiProvider;
+use relayer::rpc::{self, RetryDecision};
+
+const DEFAULT_GEAR_ENDPOINT: &str = "wss://testnet-archive.vara.network";
+const DEFAULT_GEAR_RPC_RETRIES: u8 = 3;
+const DEFAULT_ETH_ENDPOINT: &str = "wss://hoodi-reth-rpc.gear-tech.io/ws";
+const DEFAULT_WEBSOCAT_IMAGE: &str = "ghcr.io/vi/websocat:latest";
+
+fn gear_endpoint() -> String {
+    env::var("GEAR_ENDPOINT")
+        .or_else(|_| env::var("GEAR_DOMAIN"))
+        .unwrap_or_else(|_| DEFAULT_GEAR_ENDPOINT.to_string())
+}
+
+fn gear_retries() -> u8 {
+    env::var("GEAR_RPC_RETRIES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_GEAR_RPC_RETRIES)
+}
+
+fn eth_endpoint() -> String {
+    env::var("ETHEREUM_RPC")
+        .or_else(|_| env::var("ETHEREUM_ENDPOINT"))
+        .or_else(|_| env::var("ETH_RPC"))
+        .unwrap_or_else(|_| DEFAULT_ETH_ENDPOINT.to_string())
+}
+
+async fn gear_latest_number(
+    connection: &mut gear_common::api_provider::ApiProviderConnection,
+) -> anyhow::Result<u32> {
+    rpc::retry_gear(
+        connection,
+        "podman test gear latest finalized",
+        |api| async move {
+            let hash = api.latest_finalized_block().await?;
+            api.block_hash_to_number(hash).await
+        },
+    )
+    .await
+}
+
+async fn eth_finalized_with_reconnect(api: &mut PollingEthApi) -> anyhow::Result<u64> {
+    loop {
+        match tokio::time::timeout(Duration::from_secs(5), api.finalized_block()).await {
+            Ok(Ok(block)) => return Ok(block.header.number),
+            Ok(Err(err)) if rpc::classify_anyhow(&err) == RetryDecision::Retry => {
+                reconnect_polling_api(api).await?;
+            }
+            Err(_) => reconnect_polling_api(api).await?,
+            Ok(Err(err)) => return Err(err),
+        }
+    }
+}
+
+async fn reconnect_polling_api(api: &mut PollingEthApi) -> anyhow::Result<()> {
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    loop {
+        match tokio::time::timeout(Duration::from_secs(10), api.reconnect()).await {
+            Ok(Ok(reconnected)) => {
+                *api = reconnected;
+                return Ok(());
+            }
+            Ok(Err(reconnect_err))
+                if rpc::classify_anyhow(&reconnect_err) == RetryDecision::Retry =>
+            {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(_) => tokio::time::sleep(Duration::from_millis(500)).await,
+            Ok(Err(reconnect_err)) => return Err(reconnect_err),
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires podman and live Vara testnet RPC"]
+async fn podman_gear_worker_survives_real_proxy_outage_while_sibling_reconnects(
+) -> anyhow::Result<()> {
+    init_logging();
+    let proxy = PodmanWebsocketProxy::start("gear", gear_endpoint()).await?;
+    let provider = ApiProvider::new(proxy.local_url(), gear_retries()).await?;
+    let mut setup_connection = provider.connection();
+    let mut worker_connection = provider.connection();
+    let mut reconnect_connection = provider.connection();
+    provider.spawn();
+
+    let baseline = gear_latest_number(&mut setup_connection).await?;
+    proxy.stop_container().await?;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let proxy_for_restart = proxy.clone();
+    let restarter = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(750)).await;
+        proxy_for_restart.start_container().await
+    });
+
+    let worker = tokio::spawn(async move {
+        let mut observed = Vec::new();
+        for _ in 0..4 {
+            eprintln!("gear worker requesting latest finalized block");
+            observed.push(gear_latest_number(&mut worker_connection).await?);
+            eprintln!("gear worker observed finalized block");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        anyhow::Ok(observed)
+    });
+
+    let sibling_reconnector = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        eprintln!("gear sibling requesting provider reconnect");
+        reconnect_connection.reconnect().await?;
+        eprintln!("gear sibling provider reconnect returned");
+        gear_latest_number(&mut reconnect_connection).await
+    });
+
+    tokio::time::timeout(Duration::from_secs(30), restarter)
+        .await
+        .context("timed out waiting for Gear proxy restart")???;
+    let sibling_block = tokio::time::timeout(Duration::from_secs(90), sibling_reconnector)
+        .await
+        .context("timed out waiting for sibling Gear reconnect")???;
+    let observed = tokio::time::timeout(Duration::from_secs(90), worker)
+        .await
+        .context("timed out waiting for Gear worker to resume")???;
+
+    assert!(
+        sibling_block >= baseline,
+        "sibling reconnect saw finalized block regression: baseline={baseline}, sibling={sibling_block}"
+    );
+    assert_eq!(
+        observed.len(),
+        4,
+        "worker did not finish all calls after real proxy outage"
+    );
+    assert!(
+        observed.iter().all(|block| *block >= baseline),
+        "worker saw finalized block regression after proxy outage: baseline={baseline}, observed={observed:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires podman and live Hoodi Ethereum RPC"]
+async fn podman_ethereum_polling_recovers_after_real_proxy_outage() -> anyhow::Result<()> {
+    init_logging();
+    let proxy = PodmanWebsocketProxy::start("eth", eth_endpoint()).await?;
+    let api = PollingEthApi::new_with_retries(
+        &proxy.local_url(),
+        Some(1),
+        Some(Duration::from_millis(250)),
+    )
+    .await?;
+    let mut worker_api = api.clone();
+    let mut sibling_api = api;
+
+    let baseline = worker_api.finalized_block().await?.header.number;
+    proxy.stop_container().await?;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let proxy_for_restart = proxy.clone();
+    let restarter = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(750)).await;
+        proxy_for_restart.start_container().await
+    });
+
+    let worker = tokio::spawn(async move {
+        let mut observed = Vec::new();
+        for _ in 0..3 {
+            observed.push(eth_finalized_with_reconnect(&mut worker_api).await?);
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        anyhow::Ok(observed)
+    });
+
+    let sibling_reconnector = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        eth_finalized_with_reconnect(&mut sibling_api).await
+    });
+
+    tokio::time::timeout(Duration::from_secs(30), restarter)
+        .await
+        .context("timed out waiting for Ethereum proxy restart")???;
+    let sibling_block = tokio::time::timeout(Duration::from_secs(90), sibling_reconnector)
+        .await
+        .context("timed out waiting for sibling Ethereum reconnect")???;
+    let observed = tokio::time::timeout(Duration::from_secs(90), worker)
+        .await
+        .context("timed out waiting for Ethereum worker to resume")???;
+
+    assert!(
+        sibling_block >= baseline,
+        "sibling Ethereum reconnect saw finalized block regression: baseline={baseline}, sibling={sibling_block}"
+    );
+    assert!(
+        observed.iter().all(|block| *block >= baseline),
+        "Ethereum worker saw finalized block regression after proxy outage: baseline={baseline}, observed={observed:?}"
+    );
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct PodmanWebsocketProxy {
+    inner: Arc<PodmanWebsocketProxyInner>,
+}
+
+struct PodmanWebsocketProxyInner {
+    name: String,
+    port: u16,
+    upstream: String,
+    image: String,
+}
+
+impl PodmanWebsocketProxy {
+    async fn start(label: &str, upstream: String) -> anyhow::Result<Self> {
+        let image = env::var("PODMAN_WEBSOCAT_IMAGE")
+            .unwrap_or_else(|_| DEFAULT_WEBSOCAT_IMAGE.to_string());
+        ensure_image(&image).await?;
+
+        let proxy = Self {
+            inner: Arc::new(PodmanWebsocketProxyInner {
+                name: unique_container_name(label),
+                port: reserve_local_port()?,
+                upstream,
+                image,
+            }),
+        };
+        proxy.start_container().await?;
+        Ok(proxy)
+    }
+
+    fn local_url(&self) -> String {
+        format!("ws://127.0.0.1:{}", self.inner.port)
+    }
+
+    async fn start_container(&self) -> anyhow::Result<()> {
+        eprintln!(
+            "starting podman proxy {} on ws://127.0.0.1:{} -> {}",
+            self.inner.name, self.inner.port, self.inner.upstream
+        );
+        let _ = podman_output(vec!["rm".into(), "-f".into(), self.inner.name.clone()]).await;
+        run_podman(vec![
+            "run".into(),
+            "--rm".into(),
+            "-d".into(),
+            "--name".into(),
+            self.inner.name.clone(),
+            "-p".into(),
+            format!("127.0.0.1:{}:8080", self.inner.port),
+            "--entrypoint".into(),
+            "sh".into(),
+            self.inner.image.clone(),
+            "-c".into(),
+            format!(
+                "while true; do /usr/local/bin/websocat --text -B 4194304 ws-l:0.0.0.0:8080 {}; sleep 0.2; done",
+                shell_quote(&self.inner.upstream)
+            ),
+        ])
+        .await?;
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        Ok(())
+    }
+
+    async fn stop_container(&self) -> anyhow::Result<()> {
+        eprintln!("stopping podman proxy {}", self.inner.name);
+        run_podman(vec![
+            "stop".into(),
+            "-t".into(),
+            "0".into(),
+            self.inner.name.clone(),
+        ])
+        .await
+    }
+}
+
+impl Drop for PodmanWebsocketProxyInner {
+    fn drop(&mut self) {
+        let _ = Command::new("podman")
+            .args(["rm", "-f", self.name.as_str()])
+            .output();
+    }
+}
+
+async fn ensure_image(image: &str) -> anyhow::Result<()> {
+    if podman_output(vec!["image".into(), "exists".into(), image.into()])
+        .await?
+        .status
+        .success()
+    {
+        return Ok(());
+    }
+
+    run_podman(vec!["pull".into(), image.into()]).await
+}
+
+async fn run_podman(args: Vec<String>) -> anyhow::Result<()> {
+    let command = format!("podman {}", args.join(" "));
+    let output = podman_output(args).await?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "{command} failed with status {:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+async fn podman_output(args: Vec<String>) -> anyhow::Result<Output> {
+    tokio::task::spawn_blocking(move || Command::new("podman").args(args).output())
+        .await?
+        .map_err(Into::into)
+}
+
+fn reserve_local_port() -> anyhow::Result<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn unique_container_name(label: &str) -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!(
+        "gear-bridges-rpc-proxy-{label}-{}-{now}",
+        std::process::id()
+    )
+}
+
+fn init_logging() {
+    let _ = pretty_env_logger::try_init_timed();
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}

--- a/tools/signed-block-id-tool/Cargo.toml
+++ b/tools/signed-block-id-tool/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "signed-block-id-tool"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+cli-utils.workspace = true
+dotenv.workspace = true
+gear-rpc-client.workspace = true
+primitive-types = { workspace = true, features = ["std"] }
+tokio.workspace = true

--- a/tools/signed-block-id-tool/src/main.rs
+++ b/tools/signed-block-id-tool/src/main.rs
@@ -1,0 +1,84 @@
+use anyhow::{Context, Result as AnyResult};
+use clap::{ArgGroup, Parser};
+use cli_utils::GearConnectionArgs;
+use primitive_types::H256;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+#[command(group(
+    ArgGroup::new("block")
+        .required(true)
+        .multiple(false)
+        .args(["block_number", "block_hash"])
+))]
+struct Cli {
+    #[clap(flatten)]
+    gear: GearConnectionArgs,
+
+    /// Gear block number to fetch a signed block ID for.
+    #[arg(long)]
+    block_number: Option<u32>,
+
+    /// Gear block hash to fetch a signed block ID for.
+    #[arg(long)]
+    block_hash: Option<H256>,
+}
+
+#[tokio::main]
+async fn main() -> AnyResult<()> {
+    let _ = dotenv::dotenv();
+
+    let cli = Cli::parse();
+    let endpoint = cli.gear.get_endpoint()?;
+    let api = gear_rpc_client::GearApi::new(&endpoint, cli.gear.max_reconnect_attempts)
+        .await
+        .context("Failed to connect to Gear RPC")?;
+
+    let (requested_block_number, requested_block_hash) = match (cli.block_number, cli.block_hash) {
+        (Some(block_number), None) => {
+            let block_hash = api
+                .block_number_to_hash(block_number)
+                .await
+                .with_context(|| format!("Failed to fetch hash for block #{block_number}"))?;
+
+            (block_number, block_hash)
+        }
+        (None, Some(block_hash)) => {
+            let block_number = api
+                .block_hash_to_number(block_hash)
+                .await
+                .with_context(|| format!("Failed to fetch number for block {block_hash:?}"))?;
+
+            (block_number, block_hash)
+        }
+        _ => unreachable!("clap enforces exactly one block selector"),
+    };
+
+    let (justification, _) = api
+        .grandpa_prove_finality(requested_block_number)
+        .await
+        .with_context(|| {
+            format!("Failed to fetch finality proof after block #{requested_block_number}")
+        })?;
+    let signed_block_hash = H256::from(justification.commit.target_hash.0);
+
+    println!("requested_block_number = {requested_block_number}");
+    println!("requested_block_hash = {requested_block_hash:?}");
+    println!(
+        "signed_block_number = {}",
+        justification.commit.target_number
+    );
+    println!("signed_block_hash = {signed_block_hash:?}");
+    println!(
+        "signed_block_id = ({}, {:?})",
+        justification.commit.target_number, signed_block_hash
+    );
+    println!("justification_round = {}", justification.round);
+    println!(
+        "precommit_count = {}",
+        justification.commit.precommits.len()
+    );
+
+    Ok(())
+}

--- a/utils-prometheus/src/lib.rs
+++ b/utils-prometheus/src/lib.rs
@@ -1,13 +1,14 @@
 use axum::{routing::get, Router};
 use prometheus::{core::Collector, Encoder, Registry, TextEncoder};
+use std::collections::{BTreeMap, HashMap};
 use tokio::net::TcpListener;
 
 pub struct MetricsBuilder {
-    registry: Registry,
+    registries: Vec<Registry>,
 }
 
 pub struct Metrics {
-    registry: Registry,
+    registries: Vec<Registry>,
 }
 
 pub trait MeteredService {
@@ -71,23 +72,78 @@ macro_rules! impl_metered_service {
 impl MetricsBuilder {
     pub fn new() -> MetricsBuilder {
         MetricsBuilder {
-            registry: Registry::new(),
+            registries: vec![Registry::new()],
         }
     }
 
-    pub fn register_service(self, service: &impl MeteredService) -> Self {
-        for source in service.get_sources() {
-            self.registry
-                .register(source)
-                .expect("Failed to register metric source");
-        }
+    pub fn register_service(mut self, service: &impl MeteredService) -> Self {
+        self.register_service_mut(service);
+        self
+    }
+
+    pub fn register_service_mut(&mut self, service: &impl MeteredService) -> &mut Self {
+        let registry = self
+            .registries
+            .first()
+            .expect("metrics builder always has a default registry");
+        register_service(registry, service);
+
+        self
+    }
+
+    pub fn register_labeled_service<K, V, I>(
+        mut self,
+        service: &impl MeteredService,
+        labels: I,
+    ) -> Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        self.register_labeled_service_mut(service, labels);
+        self
+    }
+
+    pub fn register_labeled_service_mut<K, V, I>(
+        &mut self,
+        service: &impl MeteredService,
+        labels: I,
+    ) -> &mut Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let labels = labels
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect::<HashMap<_, _>>();
+        let registry = Registry::new_custom(None, Some(labels))
+            .expect("Failed to create labeled metrics registry");
+        register_service(&registry, service);
+        self.registries.push(registry);
+
+        self
+    }
+
+    pub fn append(&mut self, other: MetricsBuilder) -> &mut Self {
+        self.registries.extend(other.registries);
         self
     }
 
     pub fn build(self) -> Metrics {
         Metrics {
-            registry: self.registry,
+            registries: self.registries,
         }
+    }
+}
+
+fn register_service(registry: &Registry, service: &impl MeteredService) {
+    for source in service.get_sources() {
+        registry
+            .register(source)
+            .expect("Failed to register metric source");
     }
 }
 
@@ -99,9 +155,12 @@ impl Default for MetricsBuilder {
 
 impl Metrics {
     pub async fn run(self, endpoint: String) {
-        let reg = self.registry.clone();
+        let registries = self.registries.clone();
 
-        let app = Router::new().route("/metrics", get(move || Self::gather_metrics(reg)));
+        let app = Router::new().route(
+            "/metrics",
+            get(move || Self::gather_metrics(registries.clone())),
+        );
         let listener = TcpListener::bind(&endpoint)
             .await
             .expect("Failed to create TcpListener");
@@ -111,15 +170,90 @@ impl Metrics {
         });
     }
 
-    async fn gather_metrics(registry: Registry) -> String {
+    async fn gather_metrics(registries: Vec<Registry>) -> String {
         let mut buffer = vec![];
 
         let encoder = TextEncoder::new();
-        let metric_families = registry.gather();
+        let metric_families = Self::gather_metric_families(&registries);
         encoder
             .encode(&metric_families, &mut buffer)
             .expect("Failed to encode metrics");
 
         String::from_utf8(buffer).expect("Failed to convert metrics to string")
+    }
+
+    fn gather_metric_families(registries: &[Registry]) -> Vec<prometheus::proto::MetricFamily> {
+        let mut mf_by_name = BTreeMap::new();
+
+        for registry in registries {
+            for mut mf in registry.gather() {
+                if mf.get_metric().is_empty() {
+                    continue;
+                }
+
+                let name = mf.get_name().to_owned();
+                match mf_by_name.entry(name) {
+                    std::collections::btree_map::Entry::Vacant(entry) => {
+                        entry.insert(mf);
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut entry) => {
+                        entry.get_mut().mut_metric().extend(mf.take_metric());
+                    }
+                }
+            }
+        }
+
+        mf_by_name.into_values().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus::IntGauge;
+
+    crate::impl_metered_service! {
+        struct TestMetrics {
+            value: IntGauge = IntGauge::new(
+                "duplicate_metric_name",
+                "Metric that intentionally appears in more than one labeled registry",
+            ),
+        }
+    }
+
+    #[test]
+    fn labeled_registries_allow_duplicate_metric_names() {
+        let first = TestMetrics::new();
+        first.value.set(1);
+        let second = TestMetrics::new();
+        second.value.set(2);
+
+        let metrics = MetricsBuilder::new()
+            .register_labeled_service(&first, [("relayer", "a")])
+            .register_labeled_service(&second, [("relayer", "b")])
+            .build();
+
+        let families = Metrics::gather_metric_families(&metrics.registries);
+
+        assert_eq!(families.len(), 1);
+        assert_eq!(families[0].get_metric().len(), 2);
+
+        let values = families[0]
+            .get_metric()
+            .iter()
+            .map(|metric| {
+                let relayer = metric
+                    .get_label()
+                    .iter()
+                    .find(|label| label.get_name() == "relayer")
+                    .expect("relayer label must be present")
+                    .get_value()
+                    .to_string();
+                (relayer, metric.get_gauge().get_value() as i64)
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(values.get("a"), Some(&1));
+        assert_eq!(values.get("b"), Some(&2));
     }
 }


### PR DESCRIPTION
- Add relayer/src/rpc.rs: centralized retry module with exponential backoff, jitter, and error classification for Alloy RPC and Subxt errors
- Add configurable WS reconnect params (ws_max_retry, ws_retry_interval) to Ethereum client PollingEthApi and EthApi
- Improve gear-common ApiProvider reconnect: exponential backoff (1s→90s cap), per-attempt 15s timeout with abort, infinite retry loop
- Wrap all Gear RPC calls in merkle_roots and message_relayer with rpc::retry_gear() for automatic retry with reconnect on recoverable errors
- MerkleRootSubmitter now retries recoverable ETH errors in a loop instead of failing the request
- Fix KillSwitchRelayer reconnect: properly replace the API instance after reconnect
- Deposit/message event extractors: exit on non-recoverable errors, retry recoverable ones with capped exponential backoff
- Ethereum block listener: persist from_block progress, retry reconnect in a loop
- Gear block listener: improve gap-filling, batch block fetches, handle disconnections gracefully
- Proof storage: atomic writes (tmp + rename) to prevent corruption on crash
- Add integration tests: live_rpc_reconnect, podman_rpc_failure
- Add tools/signed-block-id-tool for inspecting signed block IDs
- Minor: use .context() instead of manual .map_err() in gear-rpc-client


TODO:
- [x] Support running multiple relayers in the same binary for separate networks
- [x] Ergonomic config.toml instead of annoying CLI flags
