### PR TITLE
perf: optimize proof generation and storage inclusion

### DIFF
--- a/gnark-wrapper/main.go
+++ b/gnark-wrapper/main.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/kzg"
@@ -104,16 +105,82 @@ func dataFile(dataDir string, name string) string {
 	return filepath.Join(dataDir, name)
 }
 
-//export prove
-func prove(circuitData *C.char, dataPath *C.char) *C.char {
-	dataDir := C.GoString(dataPath)
-	pk, err := loadProvingKey(dataDir)
-	if err != nil {
-		compile(circuitData, dataDir)
-		pk, _ = loadProvingKey(dataDir)
+type provingArtifacts struct {
+	pk   plonk.ProvingKey
+	r1cs constraint.ConstraintSystem
+	vk   plonk.VerifyingKey
+}
+
+type provingArtifactsCacheEntry struct {
+	once      sync.Once
+	artifacts *provingArtifacts
+	err       error
+}
+
+// Proving keys, R1CS, and verifying keys are immutable for a generated
+// circuit. Keep them in memory for the lifetime of the Go archive instead of
+// deserializing all three files for every cgo prove call. A data directory must
+// not be replaced with artifacts for another circuit while this process runs.
+var provingArtifactsCache sync.Map // map[absolute data dir]*provingArtifactsCacheEntry
+
+func normalizedDataDir(dataDir string) string {
+	if dataDir == "" {
+		dataDir = defaultDataDir
+	}
+	absolute, err := filepath.Abs(dataDir)
+	if err == nil {
+		return absolute
+	}
+	return filepath.Clean(dataDir)
+}
+
+func loadProvingArtifacts(dataDir string, circuitData string) (*provingArtifacts, error) {
+	dataDir = normalizedDataDir(dataDir)
+	entry := &provingArtifactsCacheEntry{}
+	actual, _ := provingArtifactsCache.LoadOrStore(dataDir, entry)
+	entry = actual.(*provingArtifactsCacheEntry)
+
+	load := func() (*provingArtifacts, error) {
+		pk, err := loadProvingKey(dataDir)
+		if err != nil {
+			return nil, fmt.Errorf("load proving key: %w", err)
+		}
+		r1cs, err := loadR1CS(dataDir)
+		if err != nil {
+			return nil, fmt.Errorf("load R1CS: %w", err)
+		}
+		vk, err := loadVerifyingKey(dataDir)
+		if err != nil {
+			return nil, fmt.Errorf("load verifying key: %w", err)
+		}
+		return &provingArtifacts{pk: pk, r1cs: r1cs, vk: vk}, nil
 	}
 
-	r1cs := loadR1CS(dataDir)
+	entry.once.Do(func() {
+		artifacts, err := load()
+		if err != nil {
+			// Preserve the existing behavior of generating artifacts on a cache
+			// miss, while also recovering from a partially written artifact set.
+			compile(circuitData, dataDir)
+			artifacts, err = load()
+		}
+		if err != nil {
+			entry.err = err
+			return
+		}
+		entry.artifacts = artifacts
+	})
+
+	return entry.artifacts, entry.err
+}
+
+//export prove
+func prove(circuitData *C.char, dataPath *C.char) *C.char {
+	dataDir := normalizedDataDir(C.GoString(dataPath))
+	artifacts, err := loadProvingArtifacts(dataDir, C.GoString(circuitData))
+	if err != nil {
+		panic(err)
+	}
 
 	assignment, err := deserializeCircuit(C.GoString(circuitData))
 	if err != nil {
@@ -121,18 +188,17 @@ func prove(circuitData *C.char, dataPath *C.char) *C.char {
 	}
 	witness, _ := frontend.NewWitness(&assignment, ecc.BN254.ScalarField())
 
-	proof, err := plonk.Prove(r1cs, pk, witness)
+	proof, err := plonk.Prove(artifacts.r1cs, artifacts.pk, witness)
 	if err != nil {
 		errorString := fmt.Sprintf("Prover error: %s. Gnark circuit may be outdated or plonky2 proof is incorrect", err)
 		panic(errorString)
 	}
 
-	vk := loadVerifyingKey(dataDir)
 	publicWitness, err := witness.Public()
 	if err != nil {
 		panic(err)
 	}
-	err = plonk.Verify(proof, vk, publicWitness)
+	err = plonk.Verify(proof, artifacts.vk, publicWitness)
 	if err != nil {
 		errorString := fmt.Sprintf("Verifier error: %s. Gnark circuit may be outdated, please recompile it", err)
 		panic(errorString)
@@ -143,8 +209,8 @@ func prove(circuitData *C.char, dataPath *C.char) *C.char {
 	return C.CString(rawProof)
 }
 
-func compile(circuitData *C.char, dataDir string) {
-	circuit, err := deserializeCircuit(C.GoString(circuitData))
+func compile(circuitData string, dataDir string) {
+	circuit, err := deserializeCircuit(circuitData)
 	if err != nil {
 		panic(err)
 	}
@@ -290,19 +356,18 @@ func compressPublicInputs(pis []gl.Variable) []frontend.Variable {
 	return compressedPis
 }
 
-func loadVerifyingKey(dataDir string) plonk.VerifyingKey {
+func loadVerifyingKey(dataDir string) (plonk.VerifyingKey, error) {
 	vkFile, err := os.Open(dataFile(dataDir, "verifying.key"))
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
-	vk := plonk.NewVerifyingKey(ecc.BN254)
-	_, err = vk.ReadFrom(vkFile)
-	if err != nil {
-		fmt.Println(err)
-	}
-	vkFile.Close()
+	defer vkFile.Close()
 
-	return vk
+	vk := plonk.NewVerifyingKey(ecc.BN254)
+	if _, err = vk.ReadFrom(vkFile); err != nil {
+		return nil, err
+	}
+	return vk, nil
 }
 
 func loadProvingKey(dataDir string) (plonk.ProvingKey, error) {
@@ -310,31 +375,27 @@ func loadProvingKey(dataDir string) (plonk.ProvingKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer pkFile.Close()
+
 	pk := plonk.NewProvingKey(ecc.BN254)
-	pkReader := bufio.NewReader(pkFile)
-	_, err = pk.ReadFrom(pkReader)
-	if err != nil {
+	if _, err = pk.ReadFrom(bufio.NewReader(pkFile)); err != nil {
 		return nil, err
 	}
-	pkFile.Close()
-
 	return pk, nil
 }
 
-func loadR1CS(dataDir string) constraint.ConstraintSystem {
+func loadR1CS(dataDir string) (constraint.ConstraintSystem, error) {
 	r1cs := plonk.NewCS(ecc.BN254)
 	r1csFile, err := os.Open(dataFile(dataDir, "r1cs"))
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
-	r1csReader := bufio.NewReader(r1csFile)
-	_, err = r1cs.ReadFrom(r1csReader)
-	if err != nil {
-		fmt.Println(err)
-	}
-	r1csFile.Close()
+	defer r1csFile.Close()
 
-	return r1cs
+	if _, err = r1cs.ReadFrom(bufio.NewReader(r1csFile)); err != nil {
+		return nil, err
+	}
+	return r1cs, nil
 }
 
 func loadSRS(dataDir string) kzg.SRS {

--- a/prover/src/block_finality/validator_set_hash.rs
+++ b/prover/src/block_finality/validator_set_hash.rs
@@ -59,7 +59,7 @@ impl ValidatorSetHash {
 
         const MAX_DATA_LENGTH_ESTIMATION: usize = ED25519_PUBLIC_KEY_SIZE * MAX_VALIDATOR_COUNT;
 
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof = circuit.prove::<MAX_DATA_LENGTH_ESTIMATION>(
             self.validator_set
                 .into_iter()

--- a/prover/src/block_finality/validator_signs_chain/indexed_validator_sign.rs
+++ b/prover/src/block_finality/validator_signs_chain/indexed_validator_sign.rs
@@ -6,17 +6,25 @@ use plonky2::{
         target::Target,
         witness::{PartialWitness, WitnessWrite},
     },
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData, VerifierCircuitData},
+        proof::ProofWithPublicInputsTarget,
+    },
 };
 
 use plonky2_field::types::Field;
+use std::sync::{Arc, OnceLock};
 
-use super::{single_validator_sign::SingleValidatorSign, GrandpaMessageTarget};
+use super::{
+    single_validator_sign::{PublicInputsTarget as SingleValidatorSignTarget, SingleValidatorSign},
+    GrandpaMessageTarget,
+};
 use crate::{
     block_finality::validator_set_hash::ValidatorSetHashTarget,
     common::{
         targets::{impl_target_set, Blake2Target, TargetSet},
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     consts::GRANDPA_VOTE_LENGTH,
     prelude::*,
@@ -47,6 +55,85 @@ pub struct IndexedValidatorSign {
     pub signature: [u8; consts::ED25519_SIGNATURE_SIZE],
 }
 
+struct IndexedValidatorSignCircuitTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    validator_set_hash_proof: ProofWithPublicInputsTarget<D>,
+    sign_proof: ProofWithPublicInputsTarget<D>,
+    index_target: Target,
+}
+
+impl IndexedValidatorSignCircuitTemplate {
+    fn cached(
+        validator_set_hash_proof: &ProofWithCircuitData<ValidatorSetHashTarget>,
+        sign_proof: &ProofWithCircuitData<SingleValidatorSignTarget>,
+    ) -> &'static Self {
+        // The recursive circuit shape is independent of the validator index,
+        // signature, and message. Reuse it while supplying those proofs as
+        // witnesses for each signer.
+        static CACHE: OnceLock<IndexedValidatorSignCircuitTemplate> = OnceLock::new();
+        CACHE.get_or_init(|| Self::build(validator_set_hash_proof, sign_proof))
+    }
+
+    fn build(
+        validator_set_hash_proof: &ProofWithCircuitData<ValidatorSetHashTarget>,
+        sign_proof: &ProofWithCircuitData<SingleValidatorSignTarget>,
+    ) -> Self {
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+
+        let validator_set_hash_data = validator_set_hash_proof.circuit_data();
+        let validator_set_hash_proof_target =
+            builder.add_virtual_proof_with_pis(&validator_set_hash_data.common);
+        let validator_set_hash_verifier =
+            builder.constant_verifier_data(&validator_set_hash_data.verifier_only);
+        builder.verify_proof::<C>(
+            &validator_set_hash_proof_target,
+            &validator_set_hash_verifier,
+            &validator_set_hash_data.common,
+        );
+        let validator_set_hash_target = ValidatorSetHashTarget::parse_exact(
+            &mut validator_set_hash_proof_target
+                .public_inputs
+                .clone()
+                .into_iter(),
+        );
+
+        let index_target = builder.add_virtual_target();
+        let validator = validator_set_hash_target
+            .validator_set
+            .random_read(index_target, &mut builder);
+
+        let sign_data = sign_proof.circuit_data();
+        let sign_proof_target = builder.add_virtual_proof_with_pis(&sign_data.common);
+        let sign_verifier = builder.constant_verifier_data(&sign_data.verifier_only);
+        builder.verify_proof::<C>(&sign_proof_target, &sign_verifier, &sign_data.common);
+        let sign_target = SingleValidatorSignTarget::parse_exact(
+            &mut sign_proof_target.public_inputs.clone().into_iter(),
+        );
+
+        validator.connect(&sign_target.public_key, &mut builder);
+
+        IndexedValidatorSignTarget {
+            validator_set_hash: validator_set_hash_target.hash,
+            validator_count: validator_set_hash_target.validator_set_length,
+            validator_idx: index_target,
+            message: sign_target.message,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            validator_set_hash_proof: validator_set_hash_proof_target,
+            sign_proof: sign_proof_target,
+            index_target,
+        }
+    }
+}
+
 impl IndexedValidatorSign {
     pub fn prove(
         &self,
@@ -60,33 +147,21 @@ impl IndexedValidatorSign {
             message: self.message,
         }
         .prove();
+        let template =
+            IndexedValidatorSignCircuitTemplate::cached(valiadtor_set_hash_proof, &sign_proof);
 
-        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
         let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(
+            &template.validator_set_hash_proof,
+            &valiadtor_set_hash_proof.proof(),
+        );
+        witness.set_proof_with_pis_target(&template.sign_proof, &sign_proof.proof());
+        witness.set_target(template.index_target, F::from_canonical_usize(self.index));
 
-        let validator_set_hash_target =
-            builder.recursively_verify_constant_proof(valiadtor_set_hash_proof, &mut witness);
-
-        let index_target = builder.add_virtual_target();
-        witness.set_target(index_target, F::from_canonical_usize(self.index));
-
-        let validator = validator_set_hash_target
-            .validator_set
-            .random_read(index_target, &mut builder);
-
-        let sign_target = builder.recursively_verify_constant_proof(&sign_proof, &mut witness);
-
-        validator.connect(&sign_target.public_key, &mut builder);
-
-        IndexedValidatorSignTarget {
-            validator_set_hash: validator_set_hash_target.hash,
-            validator_count: validator_set_hash_target.validator_set_length,
-
-            validator_idx: index_target,
-            message: sign_target.message,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        ProofWithCircuitData::prove_from_builder(builder, witness)
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &template.circuit_data,
+            Arc::clone(&template.verifier_data),
+            witness,
+        )
     }
 }

--- a/prover/src/block_finality/validator_signs_chain/mod.rs
+++ b/prover/src/block_finality/validator_signs_chain/mod.rs
@@ -7,21 +7,28 @@ use plonky2::{
     },
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, CircuitData, CommonCircuitData},
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget,
+        },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
     recursion::dummy_circuit::cyclic_base_proof,
 };
 use plonky2_field::types::Field;
 use rayon::ThreadPoolBuilder;
-use std::{iter, time::Instant};
+use std::{
+    iter,
+    sync::{Arc, Mutex, OnceLock},
+    time::Instant,
+};
 
 mod indexed_validator_sign;
 mod single_validator_sign;
 
 use crate::{
     common::{
-        array_to_bits, common_data_for_recursion,
+        array_to_bits, common_data_for_recursion, get_env_variable,
         targets::{
             impl_parsable_target_set, impl_target_set, Blake2Target, ParsableTargetSet, TargetSet,
             VerifierDataTarget,
@@ -131,94 +138,99 @@ impl ValidatorSignsChain {
         self.pre_commits
             .sort_by(|a, b| a.validator_idx.cmp(&b.validator_idx));
 
-        let (sender, receiver) = std::sync::mpsc::channel::<Request>();
-        let thread = std::thread::spawn(move || {
-            let Ok(request) = receiver.recv() else {
-                return None;
-            };
+        // Bound the queue so slow recursive composition cannot retain every
+        // large signer proof while workers continue producing them.
+        let channel_capacity = get_env_variable("SIGN_PROOF_CHANNEL_CAPACITY", 2usize).max(1);
+        let (sender, receiver) = std::sync::mpsc::sync_channel::<Request>(channel_capacity);
+        let composed_result = Arc::new(Mutex::new(None));
 
-            let (proof_initial, proof_maybe) = request.into();
+        // Keep one bounded pool for both concurrent signer proofs. The old
+        // implementation nested a two-thread scheduler around two pools of
+        // `worker_thread_count` threads, which could create roughly twice the
+        // requested workers and contend with Plonky2's parallel prover.
+        // One worker is needed for composition while another proves a signer.
+        let worker_thread_count = self.count_thread.unwrap_or(30).max(2);
+        let pool = ThreadPoolBuilder::new()
+            .stack_size(get_env_variable(
+                "RUST_MIN_STACK",
+                crate::consts::SIZE_THREAD_STACK_MIN,
+            ))
+            .num_threads(worker_thread_count)
+            .build()
+            .expect("ValidatorSignsChain: failed to create ThreadPool");
 
-            let initial_data = SignCompositionInitialData {
-                validator_set_hash,
+        let worker_func = |pre_commit: &ProcessedPreCommit| {
+            let proof = IndexedValidatorSign {
+                public_key: pre_commit.public_key,
+                index: pre_commit.validator_idx,
+                signature: pre_commit.signature,
                 message: self.message,
-            };
-            let mut composed_proof =
-                SignComposition::build(&proof_initial).prove_initial(initial_data);
-            if let Some(proof) = proof_maybe {
-                composed_proof =
-                    SignComposition::build(&proof).prove_recursive(composed_proof.proof());
             }
+            .prove(&validator_set_hash_proof);
 
-            while let Ok(request) = receiver.recv() {
-                let (proof, proof_maybe) = request.into();
-
-                composed_proof =
-                    SignComposition::build(&proof).prove_recursive(composed_proof.proof());
-                if let Some(proof) = proof_maybe {
-                    composed_proof =
-                        SignComposition::build(&proof).prove_recursive(composed_proof.proof());
-                }
-            }
-
-            Some(composed_proof)
-        });
-
-        let pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
-        let worker_thread_count = self.count_thread.unwrap_or(30);
-        let pools = [
-            ThreadPoolBuilder::new()
-                .num_threads(worker_thread_count)
-                .build()
-                .unwrap(),
-            ThreadPoolBuilder::new()
-                .num_threads(worker_thread_count)
-                .build()
-                .unwrap(),
-        ];
-
-        let worker_func = |pre_commit: &ProcessedPreCommit, pool: &rayon::ThreadPool| {
-            let (index, proof) = pool.install(|| {
-                let proof = IndexedValidatorSign {
-                    public_key: pre_commit.public_key,
-                    index: pre_commit.validator_idx,
-                    signature: pre_commit.signature,
-                    message: self.message,
-                }
-                .prove(&validator_set_hash_proof);
-
-                (pre_commit.validator_idx, proof)
-            });
-
-            (index, proof)
+            (pre_commit.validator_idx, proof)
         };
 
-        send_proof_requests_for_pre_commits(
-            &self.pre_commits,
-            |left, right| {
-                let (result_1, result_2) = pool.join(
-                    || worker_func(left, &pools[0]),
-                    || worker_func(right, &pools[1]),
-                );
+        // Run composition inside the same pool as signer proofs, rather than
+        // creating a separate OS thread that falls back to Rayon’s global pool.
+        pool.scope(|scope| {
+            let composed_result = Arc::clone(&composed_result);
+            scope.spawn(move |_| {
+                let result = (|| {
+                    let Ok(request) = receiver.recv() else {
+                        return None;
+                    };
 
-                sender
-                    .send(Request::Pair(Box::new((result_1, result_2))))
-                    .unwrap();
-            },
-            |single| {
-                sender
-                    .send(Request::SingleItem(Box::new(worker_func(
-                        single, &pools[1],
-                    ))))
-                    .unwrap();
-            },
-        );
+                    let (proof_initial, proof_maybe) = request.into();
+                    let initial_data = SignCompositionInitialData {
+                        validator_set_hash,
+                        message: self.message,
+                    };
+                    let mut composed_proof =
+                        SignComposition::build(&proof_initial).prove_initial(initial_data);
+                    if let Some(proof) = proof_maybe {
+                        composed_proof =
+                            SignComposition::build(&proof).prove_recursive(composed_proof.proof());
+                    }
 
-        drop(sender);
-        let composed_proof = thread
-            .join()
-            .expect("should be joinable")
-            .expect("there is a proof");
+                    while let Ok(request) = receiver.recv() {
+                        let (proof, proof_maybe) = request.into();
+                        composed_proof =
+                            SignComposition::build(&proof).prove_recursive(composed_proof.proof());
+                        if let Some(proof) = proof_maybe {
+                            composed_proof = SignComposition::build(&proof)
+                                .prove_recursive(composed_proof.proof());
+                        }
+                    }
+
+                    Some(composed_proof)
+                })();
+                *composed_result.lock().unwrap() = result;
+            });
+
+            send_proof_requests_for_pre_commits(
+                &self.pre_commits,
+                |left, right| {
+                    let (result_1, result_2) =
+                        pool.join(|| worker_func(left), || worker_func(right));
+
+                    sender
+                        .send(Request::Pair(Box::new((result_1, result_2))))
+                        .unwrap();
+                },
+                |single| {
+                    let result = pool.install(|| worker_func(single));
+                    sender.send(Request::SingleItem(Box::new(result))).unwrap();
+                },
+            );
+
+            drop(sender);
+        });
+        let composed_proof = composed_result
+            .lock()
+            .unwrap()
+            .take()
+            .expect("composition worker should return");
 
         log::info!("inner_proofs time: {}ms", now.elapsed().as_millis());
 
@@ -283,87 +295,49 @@ struct SignCompositionInitialData {
     message: [u8; GRANDPA_VOTE_LENGTH],
 }
 
-/// Inner cyclic recursion proof.
-struct SignComposition {
-    cyclic_circuit_data: CircuitData<F, C, D>,
-
-    common_data: CommonCircuitData<F, D>,
-
+/// Circuit shape shared by all signer-composition layers.
+///
+/// The inner proof and verifier data are supplied through the witness for each
+/// use; only the recursive circuit shape is cached.
+struct SignCompositionCircuitTemplate {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
     condition: BoolTarget,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
-
-    witness: PartialWitness<F>,
+    verifier_data_target: VerifierCircuitTarget,
 }
 
-impl SignComposition {
-    fn prove_initial(
-        mut self,
-        initial_data: SignCompositionInitialData,
-    ) -> ProofWithCircuitData<SignCompositionTarget> {
-        log::debug!("    Proving sign composition recursion layer(initial)...");
-
-        let validator_set_hash = array_to_bits(&initial_data.validator_set_hash);
-        let message = array_to_bits(&initial_data.message);
-
-        let public_inputs = validator_set_hash
-            .into_iter()
-            .map(|bit| bit as usize)
-            .chain(iter::once(0))
-            .chain(message.into_iter().map(|bit| bit as usize))
-            .chain(iter::once(0))
-            .chain(iter::once(0))
-            .map(F::from_canonical_usize);
-
-        // Length check.
-        SignCompositionTargetWithoutCircuitData::parse_public_inputs_exact(
-            &mut public_inputs.clone(),
-        );
-
-        let public_inputs = public_inputs.enumerate().collect();
-
-        self.witness.set_bool_target(self.condition, false);
-        self.witness.set_proof_with_pis_target::<C, D>(
-            &self.inner_cyclic_proof_with_pis,
-            &cyclic_base_proof(
-                &self.common_data,
-                &self.cyclic_circuit_data.verifier_only,
-                public_inputs,
-            ),
-        );
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven sign composition recursion layer(initial)...");
-
-        result
+impl SignCompositionCircuitTemplate {
+    fn cached(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> &'static Self {
+        // All IndexedValidatorSign proofs in one proving run use the same
+        // circuit. Keep one recursion template instead of rebuilding it for
+        // every validator signature. This process-wide cache assumes all
+        // signer proofs use the deployment's single circuit configuration.
+        static CACHE: OnceLock<SignCompositionCircuitTemplate> = OnceLock::new();
+        CACHE.get_or_init(|| Self::build(inner_proof))
     }
 
-    fn prove_recursive(
-        mut self,
-        composed_proof: ProofWithPublicInputs<F, C, D>,
-    ) -> ProofWithCircuitData<SignCompositionTarget> {
-        log::debug!("    Proving sign composition recursion layer...");
-        self.witness.set_bool_target(self.condition, true);
-        self.witness
-            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven sign composition recursion layer");
-
-        result
-    }
-
-    fn build(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> SignComposition {
-        log::debug!("    Building sign composition recursion layer...");
+    fn build(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> Self {
+        log::debug!("    Building sign composition recursion template...");
 
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::new(config);
-        let mut pw = PartialWitness::new();
+        let mut inner_proof_witness = PartialWitness::new();
 
-        let inner_proof_pis = builder.recursively_verify_constant_proof(inner_proof, &mut pw);
+        let inner_circuit_data = inner_proof.circuit_data();
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_circuit_data.common);
+        let inner_verifier_data = builder.constant_verifier_data(&inner_circuit_data.verifier_only);
+        builder.verify_proof::<C>(
+            &inner_proof_with_pis,
+            &inner_verifier_data,
+            &inner_circuit_data.common,
+        );
+        inner_proof_witness.set_proof_with_pis_target(&inner_proof_with_pis, &inner_proof.proof());
+        let inner_proof_pis = IndexedValidatorSignTarget::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         let mut virtual_targets = iter::repeat(()).map(|_| builder.add_virtual_target());
         let future_inner_cyclic_proof_pis =
@@ -438,18 +412,116 @@ impl SignComposition {
             )
             .expect("Failed to build circuit");
 
-        let cyclic_circuit_data = builder.build::<C>();
+        let cyclic_circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(cyclic_circuit_data.verifier_data());
 
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        log::debug!("    Built sign composition recursion template");
 
-        log::debug!("    Built sign composition recursion layer");
-
-        SignComposition {
+        Self {
             cyclic_circuit_data,
-            common_data,
+            verifier_data,
+            common_data: Arc::new(common_data),
             condition,
+            inner_proof_with_pis,
             inner_cyclic_proof_with_pis,
-            witness: pw,
+            verifier_data_target,
+        }
+    }
+}
+
+/// Inner cyclic recursion proof.
+struct SignComposition {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
+    condition: BoolTarget,
+    inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    witness: PartialWitness<F>,
+}
+
+impl SignComposition {
+    fn prove_initial(
+        mut self,
+        initial_data: SignCompositionInitialData,
+    ) -> ProofWithCircuitData<SignCompositionTarget> {
+        log::debug!("    Proving sign composition recursion layer(initial)...");
+
+        let validator_set_hash = array_to_bits(&initial_data.validator_set_hash);
+        let message = array_to_bits(&initial_data.message);
+
+        let public_inputs = validator_set_hash
+            .into_iter()
+            .map(|bit| bit as usize)
+            .chain(iter::once(0))
+            .chain(message.into_iter().map(|bit| bit as usize))
+            .chain(iter::once(0))
+            .chain(iter::once(0))
+            .map(F::from_canonical_usize);
+
+        // Length check.
+        SignCompositionTargetWithoutCircuitData::parse_public_inputs_exact(
+            &mut public_inputs.clone(),
+        );
+
+        let public_inputs = public_inputs.enumerate().collect();
+
+        self.witness.set_bool_target(self.condition, false);
+        self.witness.set_proof_with_pis_target::<C, D>(
+            &self.inner_cyclic_proof_with_pis,
+            &cyclic_base_proof(
+                &self.common_data,
+                &self.cyclic_circuit_data.verifier_only,
+                public_inputs,
+            ),
+        );
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.cyclic_circuit_data,
+            Arc::clone(&self.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven sign composition recursion layer(initial)...");
+
+        result
+    }
+
+    fn prove_recursive(
+        mut self,
+        composed_proof: ProofWithPublicInputs<F, C, D>,
+    ) -> ProofWithCircuitData<SignCompositionTarget> {
+        log::debug!("    Proving sign composition recursion layer...");
+        self.witness.set_bool_target(self.condition, true);
+        self.witness
+            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.cyclic_circuit_data,
+            Arc::clone(&self.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven sign composition recursion layer");
+
+        result
+    }
+
+    fn build(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> Self {
+        let template = SignCompositionCircuitTemplate::cached(inner_proof);
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&template.inner_proof_with_pis, &inner_proof.proof());
+        witness.set_verifier_data_target(
+            &template.verifier_data_target,
+            &template.cyclic_circuit_data.verifier_only,
+        );
+
+        Self {
+            cyclic_circuit_data: Arc::clone(&template.cyclic_circuit_data),
+            verifier_data: Arc::clone(&template.verifier_data),
+            common_data: Arc::clone(&template.common_data),
+            condition: template.condition,
+            inner_cyclic_proof_with_pis: template.inner_cyclic_proof_with_pis.clone(),
+            witness,
         }
     }
 }

--- a/prover/src/common/blake2/mod.rs
+++ b/prover/src/common/blake2/mod.rs
@@ -32,7 +32,6 @@ use plonky2_blake2b256::circuit::{
 use plonky2_field::types::Field;
 use std::{
     env, fs, io, iter,
-    marker::PhantomData,
     sync::{Arc, LazyLock},
     time::Instant,
 };
@@ -168,6 +167,9 @@ impl BuilderTargets {
 /// the valid inputs.
 pub struct CircuitTargets {
     circuit: CircuitData<F, C, D>,
+    // The verifier data is immutable. Keep one shared copy instead of cloning
+    // CommonCircuitData for every hash proof.
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     target_block_count: Target,
     target_proof: ProofWithPublicInputsTarget<D>,
 }
@@ -179,6 +181,7 @@ impl From<BuilderTargets> for CircuitTargets {
         let now = Instant::now();
 
         let circuit = value.builder.build::<C>();
+        let verifier_data = Arc::new(circuit.verifier_data());
 
         log::trace!(
             "From<BuilderTargets> for CircuitTargets exit. Time: {}ms",
@@ -187,6 +190,7 @@ impl From<BuilderTargets> for CircuitTargets {
 
         Self {
             circuit,
+            verifier_data,
             target_block_count: value.target_block_count,
             target_proof: value.target_proof,
         }
@@ -198,6 +202,15 @@ impl CircuitTargets {
         let builder_targets = BuilderTargets::new();
 
         builder_targets.into()
+    }
+
+    /// Return the process-wide generic Blake2 circuit. Its shape and verifier
+    /// data are independent of the input, so rebuilding it per hash is wasted
+    /// work and duplicates a large CommonCircuitData allocation. The cache is
+    /// process-wide and assumes one deployment configuration per process.
+    pub fn cached() -> &'static Self {
+        static CACHE: LazyLock<CircuitTargets> = LazyLock::new(CircuitTargets::new);
+        &CACHE
     }
 
     pub fn prove<const MAX_DATA_LENGTH_ESTIMATION: usize>(
@@ -239,14 +252,24 @@ impl CircuitTargets {
             now.elapsed().as_millis()
         );
 
-        ProofWithCircuitData {
-            proof,
-            circuit_data: Arc::from(self.circuit.verifier_data()),
-            public_inputs,
-            public_inputs_parser: PhantomData,
-        }
+        ProofWithCircuitData::from_proof_and_shared_circuit_data(
+            ProofWithPublicInputs {
+                proof,
+                public_inputs,
+            },
+            Arc::clone(&self.verifier_data),
+        )
     }
 
+    pub fn common(&self) -> &CommonCircuitData<F, D> {
+        &self.circuit.common
+    }
+
+    pub fn verifier_only(&self) -> &VerifierOnlyCircuitData<C, D> {
+        &self.circuit.verifier_only
+    }
+
+    #[allow(dead_code)]
     pub fn into_inner(self) -> (CircuitData<F, C, D>, Target, ProofWithPublicInputsTarget<D>) {
         (self.circuit, self.target_block_count, self.target_proof)
     }

--- a/prover/src/common/blake2/variative.rs
+++ b/prover/src/common/blake2/variative.rs
@@ -1,44 +1,74 @@
 use super::*;
 use plonky2::plonk::circuit_data::ProverCircuitData;
 
-static CACHED_PROVER_TARGETS2: LazyLock<(ProverCircuitData<F, C, D>, Vec<Target>)> =
-    LazyLock::new(|| {
-        let index = 2;
+struct CachedProverTargets {
+    prover_data: ProverCircuitData<F, C, D>,
+    targets: Vec<Target>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+}
 
-        let path = env::var("VBLAKE2_CACHE_PATH")
-            .expect(r#"VariativeBlake2: "VBLAKE2_CACHE_PATH" is set"#);
-        let serializer_gate = GateSerializer;
-        let serializer_generator = GeneratorSerializer::<C, D>::default();
+fn load_cached_prover_targets(index: usize) -> CachedProverTargets {
+    let path =
+        env::var("VBLAKE2_CACHE_PATH").expect(r#"VariativeBlake2: "VBLAKE2_CACHE_PATH" is set"#);
+    let serializer_gate = GateSerializer;
+    let serializer_generator = GeneratorSerializer::<C, D>::default();
 
-        let now = Instant::now();
-        let prover_data = {
-            let file = fs::OpenOptions::new()
-                .read(true)
-                .open(format!("{path}/prover_circuit_data-{index}"))
-                .expect("VariativeBlake2: open a file with correctly formed data for read");
-            let reader = io::BufReader::with_capacity(*BUFFER_SIZE, file);
+    let now = Instant::now();
+    let prover_data = {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .open(format!("{path}/prover_circuit_data-{index}"))
+            .expect("VariativeBlake2: open a file with correctly formed data for read");
+        let reader = io::BufReader::with_capacity(*BUFFER_SIZE, file);
 
-            let mut read_adapter = ReadAdapter::new(reader, None);
+        let mut read_adapter = ReadAdapter::new(reader, None);
 
-            read_adapter
-                .read_prover_circuit_data::<F, C, D>(&serializer_gate, &serializer_generator)
-                .expect("Correctly formed serialized data")
-        };
+        read_adapter
+            .read_prover_circuit_data::<F, C, D>(&serializer_gate, &serializer_generator)
+            .expect("Correctly formed serialized data")
+    };
 
-        log::trace!(
-            "Loading CACHED_PROVER_TARGETS2 time: {}ms",
-            now.elapsed().as_millis()
-        );
+    log::trace!(
+        "Loading cached VariativeBlake2 circuit (index = {index}) time: {}ms",
+        now.elapsed().as_millis()
+    );
 
-        let serialized = fs::read(format!("{path}/prover_circuit_data-targets-{index}"))
-            .expect("VariativeBlake2: Good file with serialized data");
-        let mut buffer_read = Buffer::new(&serialized[..]);
-        let targets = buffer_read
-            .read_target_vec()
-            .expect("VariativeBlake2: buffer_read.read_target_vec()");
+    let serialized = fs::read(format!("{path}/prover_circuit_data-targets-{index}"))
+        .expect("VariativeBlake2: Good file with serialized data");
+    let mut buffer_read = Buffer::new(&serialized[..]);
+    let targets = buffer_read
+        .read_target_vec()
+        .expect("VariativeBlake2: buffer_read.read_target_vec()");
 
-        (prover_data, targets)
+    // Clone the common data once when populating the process cache. Every
+    // proof below shares this Arc rather than cloning the 655k-gate metadata.
+    let verifier_data = Arc::new(VerifierCircuitData {
+        verifier_only: VERIFIER_DATA_BY_BLOCK_COUNT[index - 1].clone(),
+        common: prover_data.common.clone(),
     });
+
+    CachedProverTargets {
+        prover_data,
+        targets,
+        verifier_data,
+    }
+}
+
+static CACHED_PROVER_TARGETS1: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(1));
+static CACHED_PROVER_TARGETS2: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(2));
+// Production traces show indices 3, 4, and 15 are also hot in storage and
+// validator-set proofs. Each serialized prover circuit is large, so keep this
+// explicit bounded set rather than retaining all 50 possible block counts.
+static CACHED_PROVER_TARGETS3: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(3));
+static CACHED_PROVER_TARGETS4: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(4));
+static CACHED_PROVER_TARGETS15: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(15));
+static CACHED_PROVER_TARGETS16: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(16));
 
 impl_target_set! {
     pub struct VariativeBlake2Target {
@@ -57,9 +87,68 @@ impl VariativeBlake2 {
     pub fn prove(data: &[u8]) -> ProofWithCircuitData<VariativeBlake2Target> {
         let index = data.len().div_ceil(BLOCK_BYTES).max(1);
 
-        if index == 2 {
-            let (ref prover_data, ref targets) = *CACHED_PROVER_TARGETS2;
-            return Self::prove_inner(index, prover_data, targets, data);
+        match index {
+            1 => {
+                let cached = &*CACHED_PROVER_TARGETS1;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            2 => {
+                let cached = &*CACHED_PROVER_TARGETS2;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            3 => {
+                let cached = &*CACHED_PROVER_TARGETS3;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            4 => {
+                let cached = &*CACHED_PROVER_TARGETS4;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            15 => {
+                let cached = &*CACHED_PROVER_TARGETS15;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            16 => {
+                let cached = &*CACHED_PROVER_TARGETS16;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            _ => {}
         }
 
         let path = env::var("VBLAKE2_CACHE_PATH")
@@ -94,13 +183,19 @@ impl VariativeBlake2 {
             .read_target_vec()
             .expect("VariativeBlake2: buffer_read.read_target_vec()");
 
-        Self::prove_inner(index, &prover_data, &targets, data)
+        let verifier_data = Arc::new(VerifierCircuitData {
+            verifier_only: VERIFIER_DATA_BY_BLOCK_COUNT[index - 1].clone(),
+            common: prover_data.common.clone(),
+        });
+
+        Self::prove_inner(index, &prover_data, &targets, verifier_data, data)
     }
 
     fn prove_inner(
-        index: usize,
+        _index: usize,
         prover_data: &ProverCircuitData<F, C, D>,
         targets: &[Target],
+        verifier_data: Arc<VerifierCircuitData<F, C, D>>,
         data: &[u8],
     ) -> ProofWithCircuitData<VariativeBlake2Target> {
         let witness = Self::set_witness(targets, data);
@@ -117,15 +212,13 @@ impl VariativeBlake2 {
             now.elapsed().as_millis()
         );
 
-        ProofWithCircuitData {
-            proof,
-            circuit_data: Arc::from(VerifierCircuitData {
-                verifier_only: VERIFIER_DATA_BY_BLOCK_COUNT[index - 1].clone(),
-                common: prover_data.common.clone(),
-            }),
-            public_inputs,
-            public_inputs_parser: PhantomData,
-        }
+        ProofWithCircuitData::from_proof_and_shared_circuit_data(
+            ProofWithPublicInputs {
+                proof,
+                public_inputs,
+            },
+            verifier_data,
+        )
     }
 
     #[allow(dead_code)]

--- a/prover/src/common/mod.rs
+++ b/prover/src/common/mod.rs
@@ -164,6 +164,11 @@ where
         &self.circuit_data
     }
 
+    /// Clone the shared verifier data handle without cloning circuit metadata.
+    pub(crate) fn shared_circuit_data(&self) -> Arc<VerifierCircuitData<F, C, D>> {
+        Arc::clone(&self.circuit_data)
+    }
+
     /// Get type-erased public inouts.
     pub fn public_inputs(&self) -> Vec<GoldilocksField> {
         self.public_inputs.clone()

--- a/prover/src/common/mod.rs
+++ b/prover/src/common/mod.rs
@@ -86,9 +86,20 @@ where
             public_inputs,
         } = circuit_data.prove(witness).unwrap();
 
-        ProofWithCircuitData {
+        // Move the verifier data out of the owned circuit instead of cloning the
+        // (potentially very large) common circuit data.
+        let CircuitData {
+            verifier_only,
+            common,
+            ..
+        } = circuit_data;
+
+        Self {
             proof,
-            circuit_data: Arc::from(circuit_data.verifier_data()),
+            circuit_data: Arc::new(VerifierCircuitData {
+                verifier_only,
+                common,
+            }),
             public_inputs,
             public_inputs_parser: PhantomData,
         }
@@ -99,14 +110,24 @@ where
         circuit_data: &CircuitData<F, C, D>,
         witness: PartialWitness<F>,
     ) -> ProofWithCircuitData<TS> {
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+        Self::prove_from_shared_circuit_data(circuit_data, verifier_data, witness)
+    }
+
+    /// Prove using circuit data and verifier data shared by a cached circuit.
+    pub(crate) fn prove_from_shared_circuit_data(
+        circuit_data: &CircuitData<F, C, D>,
+        verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+        witness: PartialWitness<F>,
+    ) -> ProofWithCircuitData<TS> {
         let ProofWithPublicInputs {
             proof,
             public_inputs,
         } = circuit_data.prove(witness).unwrap();
 
-        ProofWithCircuitData {
+        Self {
             proof,
-            circuit_data: Arc::from(circuit_data.verifier_data()),
+            circuit_data: verifier_data,
             public_inputs,
             public_inputs_parser: PhantomData,
         }
@@ -117,6 +138,14 @@ where
         proof: ProofWithPublicInputs<F, C, D>,
         circuit_data: VerifierCircuitData<F, C, D>,
     ) -> Self {
+        Self::from_proof_and_shared_circuit_data(proof, Arc::new(circuit_data))
+    }
+
+    /// Create a new `ProofWithCircuitData` using shared verifier data.
+    pub(crate) fn from_proof_and_shared_circuit_data(
+        proof: ProofWithPublicInputs<F, C, D>,
+        circuit_data: Arc<VerifierCircuitData<F, C, D>>,
+    ) -> Self {
         let ProofWithPublicInputs {
             proof,
             public_inputs,
@@ -124,7 +153,7 @@ where
 
         Self {
             proof,
-            circuit_data: Arc::from(circuit_data),
+            circuit_data,
             public_inputs,
             public_inputs_parser: PhantomData,
         }
@@ -187,15 +216,18 @@ pub trait CircuitImplBuilder {
 
 pub struct CircuitDataCache<BUILDER: CircuitImplBuilder> {
     circuit_data: CircuitData<F, C, D>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     witness_targets: BUILDER::WitnessTargets,
 }
 
 impl<BUILDER: CircuitImplBuilder> CircuitDataCache<BUILDER> {
     pub fn new() -> CircuitDataCache<BUILDER> {
         let (circuit_data, witness_targets) = BUILDER::build();
+        let verifier_data = Arc::new(circuit_data.verifier_data());
 
         CircuitDataCache {
             circuit_data,
+            verifier_data,
             witness_targets,
         }
     }
@@ -206,7 +238,11 @@ impl<BUILDER: CircuitImplBuilder> CircuitDataCache<BUILDER> {
     ) -> ProofWithCircuitData<BUILDER::PublicInputsTarget> {
         let mut witness = PartialWitness::new();
         impl_builder.set_witness(self.witness_targets.clone(), &mut witness);
-        ProofWithCircuitData::prove_from_circuit_data(&self.circuit_data, witness)
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.circuit_data,
+            Arc::clone(&self.verifier_data),
+            witness,
+        )
     }
 }
 

--- a/prover/src/final_proof/message_sent.rs
+++ b/prover/src/final_proof/message_sent.rs
@@ -5,6 +5,7 @@ use crate::{
     common::{
         array_to_bits,
         blake2::{CircuitTargets as Blake2CircuitTargets, MAX_DATA_BYTES},
+        get_env_variable,
         targets::{
             impl_target_set, ArrayTarget, Blake2Target, Blake2TargetGoldilocks,
             MessageTargetGoldilocks, TargetBitOperations, TargetSet,
@@ -25,10 +26,24 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
 };
 use rayon::{
-    iter::{IntoParallelIterator, ParallelIterator},
-    ThreadPoolBuilder,
+    iter::{IntoParallelRefIterator, ParallelIterator},
+    ThreadPool, ThreadPoolBuilder,
 };
-use std::env;
+
+use std::sync::LazyLock;
+
+fn header_thread_pool() -> &'static ThreadPool {
+    static POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
+        let stack_size = get_env_variable("RUST_MIN_STACK", crate::consts::SIZE_THREAD_STACK_MIN);
+        let thread_count = get_env_variable("HEADER_PROOF_THREADS", 5usize).max(1);
+        ThreadPoolBuilder::new()
+            .stack_size(stack_size)
+            .num_threads(thread_count)
+            .build()
+            .expect("MessageSent: failed to create ThreadPool")
+    });
+    &POOL
+}
 
 impl_target_set! {
     /// Public inputs for `MessageSent`.
@@ -93,38 +108,37 @@ impl MessageSent {
         let finality_proof_target =
             builder.recursively_verify_constant_proof(&finality_proof, &mut witness);
 
-        // prove chain of headers
-        let thread_pool = ThreadPoolBuilder::new()
-            .stack_size(
-                env::var("RUST_MIN_STACK")
-                    .expect("RUST_MIN_STACK should be set")
-                    .parse::<usize>()
-                    .expect("RUST_MIN_STACK should have the correct value"),
-            )
-            // TODO: 782
-            .num_threads(5)
-            .build()
-            .expect("MessageSent: failed to create ThreadPool");
+        // Prove the header chain in bounded chunks. The old implementation
+        // retained every per-header proof and nested a local pool inside the
+        // global Rayon pool. Both behaviors caused large memory spikes on long
+        // chains. Hash one chunk in a single explicit pool, fold it into the
+        // already-proven suffix, then release the chunk before continuing.
+        let chunk_size = get_env_variable("HEADER_PROOF_CHUNK_SIZE", 8usize).max(1);
+        let thread_pool = header_thread_pool();
 
-        let circuit_blake2 = Blake2CircuitTargets::new();
+        let circuit_blake2 = Blake2CircuitTargets::cached();
+        let circuit_chain = HeaderChainCircuit::cached();
         let mut headers = self.headers;
         headers.sort_by_key(|header| header.number);
 
-        let proof_hashes = headers
-            .into_par_iter()
-            .map(|header| {
-                thread_pool
-                    .scope(|_| circuit_blake2.prove::<MAX_DATA_BYTES>(header.encode().as_ref()))
-            })
-            .collect::<Vec<_>>();
+        let mut proof_chain = None;
+        for header_chunk in headers.rchunks(chunk_size) {
+            let proof_hashes = thread_pool.install(|| {
+                header_chunk
+                    .par_iter()
+                    .map(|header| circuit_blake2.prove::<MAX_DATA_BYTES>(header.encode().as_ref()))
+                    .collect::<Vec<_>>()
+            });
 
-        let circuit_chain = HeaderChainCircuit::default();
-        let proof_chain =
-            proof_hashes
-                .into_iter()
-                .rfold(None, |proof_recursive, proof_header_hash| {
+            // rchunks yields newest-to-oldest chunks. Folding each chunk from
+            // newest to oldest preserves the original parent-link direction.
+            proof_chain = proof_hashes.into_iter().rfold(
+                proof_chain,
+                |proof_recursive, proof_header_hash| {
                     Some(circuit_chain.prove(&proof_header_hash, proof_recursive.as_ref()))
-                });
+                },
+            );
+        }
         let proof_chain = proof_chain.expect("Headers is not an empty list");
 
         let target_proof_chain = builder.add_virtual_proof_with_pis(circuit_chain.common());

--- a/prover/src/header_chain.rs
+++ b/prover/src/header_chain.rs
@@ -16,14 +16,17 @@ use plonky2::{
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::{
-            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
-            VerifierOnlyCircuitData,
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget, VerifierOnlyCircuitData,
         },
         proof::ProofWithPublicInputsTarget,
     },
     recursion::dummy_circuit,
 };
-use std::time::Instant;
+use std::{
+    sync::{Arc, LazyLock},
+    time::Instant,
+};
 
 impl_parsable_target_set! {
     pub struct HeaderChainTarget {
@@ -58,12 +61,12 @@ impl BuilderTargets {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let one = builder.one();
 
-        let (circuit, ..) = Blake2CircuitTargets::new().into_inner();
+        let circuit = Blake2CircuitTargets::cached();
 
-        let target_proof_inner = builder.add_virtual_proof_with_pis(&circuit.common);
-        let target_verifier = builder.constant_verifier_data(&circuit.verifier_only);
+        let target_proof_inner = builder.add_virtual_proof_with_pis(circuit.common());
+        let target_verifier = builder.constant_verifier_data(circuit.verifier_only());
 
-        builder.verify_proof::<C>(&target_proof_inner, &target_verifier, &circuit.common);
+        builder.verify_proof::<C>(&target_proof_inner, &target_verifier, circuit.common());
 
         let mut iter_public_inputs = target_proof_inner.public_inputs.iter().copied();
         let GenericBlake2Target {
@@ -146,6 +149,7 @@ impl BuilderTargets {
 
 pub struct CircuitTargets {
     circuit: CircuitData<F, C, D>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     target_verifier_circuit: VerifierCircuitTarget,
     target_proof_inner: ProofWithPublicInputsTarget<D>,
     target_condition: BoolTarget,
@@ -164,6 +168,7 @@ impl From<BuilderTargets> for CircuitTargets {
         let now = Instant::now();
 
         let circuit = value.builder.build::<C>();
+        let verifier_data = Arc::new(circuit.verifier_data());
 
         log::trace!(
             "From<BuilderTargets> for CircuitTargets exit. Time: {}ms",
@@ -172,6 +177,7 @@ impl From<BuilderTargets> for CircuitTargets {
 
         Self {
             circuit,
+            verifier_data,
             target_verifier_circuit: value.target_verifier_circuit,
             target_proof_inner: value.target_proof_inner,
             target_condition: value.target_condition,
@@ -181,6 +187,14 @@ impl From<BuilderTargets> for CircuitTargets {
 }
 
 impl CircuitTargets {
+    /// Return the process-wide header-chain circuit. The circuit shape is
+    /// independent of the headers being proved. The cache assumes one
+    /// deployment circuit configuration per process.
+    pub fn cached() -> &'static Self {
+        static CACHE: LazyLock<CircuitTargets> = LazyLock::new(CircuitTargets::default);
+        &CACHE
+    }
+
     pub fn prove(
         &self,
         proof_inner: &ProofWithCircuitData<GenericBlake2Target>,
@@ -231,7 +245,10 @@ impl CircuitTargets {
             now.elapsed().as_millis()
         );
 
-        ProofWithCircuitData::from_proof_and_circuit_data(proof, self.circuit.verifier_data())
+        ProofWithCircuitData::from_proof_and_shared_circuit_data(
+            proof,
+            Arc::clone(&self.verifier_data),
+        )
     }
 
     pub fn common(&self) -> &CommonCircuitData<F, D> {

--- a/prover/src/storage_inclusion/block_header_parser.rs
+++ b/prover/src/storage_inclusion/block_header_parser.rs
@@ -46,7 +46,7 @@ pub struct BlockHeaderParser {
 
 impl BlockHeaderParser {
     pub fn prove(self) -> ProofWithCircuitData<BlockHeaderParserTarget> {
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof = circuit.prove::<MAX_DATA_BYTES>(&self.header_data);
 
         let config = CircuitConfig::standard_recursion_config();

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -142,6 +142,7 @@ struct CircuitTemplate {
     inner_common_num_gates: usize,
     inner_common_num_public_inputs: usize,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+    inner_common_data: CommonCircuitData<F, D>,
 }
 
 impl CircuitTemplate {
@@ -161,6 +162,14 @@ impl CircuitTemplate {
         assert_eq!(
             template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
             "BranchNodeChain cache received incompatible inner circuit digest"
+        );
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "BranchNodeChain cache received incompatible inner common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "BranchNodeChain cache received incompatible inner verifier data"
         );
         template
     }
@@ -271,6 +280,7 @@ impl CircuitTemplate {
             inner_common_num_gates: inner_data.common.gates.len(),
             inner_common_num_public_inputs: inner_data.common.num_public_inputs,
             inner_verifier_only: inner_data.verifier_only.clone(),
+            inner_common_data: inner_data.common.clone(),
         }
     }
 }

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -71,6 +71,7 @@ struct FinalProjectionTemplate {
     circuit_data: Arc<CircuitData<F, C, D>>,
     verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_common_data: CommonCircuitData<F, D>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
@@ -83,15 +84,18 @@ impl FinalProjectionTemplate {
         // carried by the per-call inner proof witness.
         static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "BranchNodeChain final projection received incompatible common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "BranchNodeChain final projection received incompatible verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "BranchNodeChain final projection received incompatible common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "BranchNodeChain final projection received incompatible verifier data"
+            );
+        }
         template
     }
 
@@ -135,6 +139,7 @@ impl FinalProjectionTemplate {
             circuit_data,
             verifier_data,
             inner_proof_with_pis,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_common_data: inner_data.common.clone(),
             inner_verifier_only: inner_data.verifier_only.clone(),
         }
@@ -217,8 +222,7 @@ struct CircuitTemplate {
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
     condition: BoolTarget,
     verifier_data_target: VerifierCircuitTarget,
-    inner_common_num_gates: usize,
-    inner_common_num_public_inputs: usize,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
     inner_common_data: CommonCircuitData<F, D>,
 }
@@ -227,28 +231,18 @@ impl CircuitTemplate {
     fn cached(inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>) -> &'static Self {
         static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            template.inner_common_num_gates,
-            inner_data.common.gates.len(),
-            "BranchNodeChain cache received incompatible inner circuit gate count"
-        );
-        assert_eq!(
-            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
-            "BranchNodeChain cache received incompatible inner public-input count"
-        );
-        assert_eq!(
-            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
-            "BranchNodeChain cache received incompatible inner circuit digest"
-        );
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "BranchNodeChain cache received incompatible inner common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "BranchNodeChain cache received incompatible inner verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "BranchNodeChain cache received incompatible inner common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "BranchNodeChain cache received incompatible inner verifier data"
+            );
+        }
         template
     }
 
@@ -355,8 +349,7 @@ impl CircuitTemplate {
             inner_cyclic_proof_with_pis,
             condition,
             verifier_data_target,
-            inner_common_num_gates: inner_data.common.gates.len(),
-            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_verifier_only: inner_data.verifier_only.clone(),
             inner_common_data: inner_data.common.clone(),
         }

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -67,26 +67,104 @@ pub struct BranchNodeChain {
     pub nodes: Vec<BranchNodeData>,
 }
 
+struct FinalProjectionTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_common_data: CommonCircuitData<F, D>,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+}
+
+impl FinalProjectionTemplate {
+    fn cached(
+        inner_proof: &ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData>,
+    ) -> &'static Self {
+        // The projection has one fixed inner proof shape; chain contents are
+        // carried by the per-call inner proof witness.
+        static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "BranchNodeChain final projection received incompatible common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "BranchNodeChain final projection received incompatible verifier data"
+        );
+        template
+    }
+
+    fn instantiate(
+        &self,
+        inner_proof: &ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData>,
+    ) -> FinalProjectionCircuit<'_> {
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        FinalProjectionCircuit {
+            template: self,
+            witness,
+        }
+    }
+
+    fn build(
+        inner_proof: &ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData>,
+    ) -> Self {
+        log::debug!("Building branch node chain final projection template...");
+
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(&inner_proof_with_pis, &inner_verifier, &inner_data.common);
+        let inner_target = BranchNodeChainParserTargetWithVerifierData::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        BranchNodeChainParserTarget {
+            root_hash: inner_target.inner.root_hash,
+            leaf_hash: inner_target.inner.leaf_hash,
+            partial_address: inner_target.inner.partial_address,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            inner_proof_with_pis,
+            inner_common_data: inner_data.common.clone(),
+            inner_verifier_only: inner_data.verifier_only.clone(),
+        }
+    }
+}
+
+struct FinalProjectionCircuit<'a> {
+    template: &'a FinalProjectionTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl FinalProjectionCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<BranchNodeChainParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
 impl BranchNodeChain {
     pub fn prove(self) -> ProofWithCircuitData<BranchNodeChainParserTarget> {
         log::debug!("Proving branch node chain...");
 
         let inner = self.inner_proof();
 
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut witness = PartialWitness::new();
-
-        let public_inputs = builder.recursively_verify_constant_proof(&inner, &mut witness);
-
-        BranchNodeChainParserTarget {
-            root_hash: public_inputs.inner.root_hash,
-            leaf_hash: public_inputs.inner.leaf_hash,
-            partial_address: public_inputs.inner.partial_address,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        let result = ProofWithCircuitData::prove_from_builder(builder, witness);
+        let result = FinalProjectionTemplate::cached(&inner)
+            .instantiate(&inner)
+            .prove();
 
         log::debug!("Proven branch node chain");
 

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -7,17 +7,25 @@ use plonky2::{
     },
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, CircuitData, CommonCircuitData},
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget, VerifierOnlyCircuitData,
+        },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
     recursion::dummy_circuit::cyclic_base_proof,
 };
 use plonky2_field::types::Field;
 use sp_core::{Blake2Hasher, Hasher};
-use std::iter;
+use std::{
+    iter,
+    sync::{Arc, OnceLock},
+};
 
 use super::{
-    hashed_branch_parser::HashedBranchParser, storage_address::StorageAddressTarget, BranchNodeData,
+    hashed_branch_parser::{HashedBranchParser, HashedBranchParserTarget},
+    storage_address::StorageAddressTarget,
+    BranchNodeData,
 };
 use crate::{
     common::{
@@ -108,7 +116,8 @@ impl BranchNodeChain {
                 },
             };
 
-            let circuit = Circuit::build(inner_circuit);
+            let inner_proof = inner_circuit.prove();
+            let circuit = CircuitTemplate::cached(&inner_proof).instantiate(&inner_proof);
 
             let new_proof = if let Some(composed_proof) = composed_proof {
                 circuit.prove_recursive(composed_proof.proof())
@@ -122,76 +131,71 @@ impl BranchNodeChain {
     }
 }
 
-struct Circuit {
-    cyclic_circuit_data: CircuitData<F, C, D>,
-
-    common_data: CommonCircuitData<F, D>,
-
-    condition: BoolTarget,
+struct CircuitTemplate {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
-
-    witness: PartialWitness<F>,
+    condition: BoolTarget,
+    verifier_data_target: VerifierCircuitTarget,
+    inner_common_num_gates: usize,
+    inner_common_num_public_inputs: usize,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
 
-impl Circuit {
-    fn prove_initial(
-        mut self,
-        root_hash: [u8; BLAKE2_DIGEST_SIZE],
-    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
-        log::debug!("    Proving storage trie recursion layer(initial)...");
-
-        let root_hash_bits = array_to_bits(&root_hash);
-        let public_inputs = root_hash_bits
-            .into_iter()
-            .map(F::from_bool)
-            .enumerate()
-            .collect();
-
-        self.witness.set_bool_target(self.condition, false);
-        self.witness.set_proof_with_pis_target::<C, D>(
-            &self.inner_cyclic_proof_with_pis,
-            &cyclic_base_proof(
-                &self.common_data,
-                &self.cyclic_circuit_data.verifier_only,
-                public_inputs,
-            ),
+impl CircuitTemplate {
+    fn cached(inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>) -> &'static Self {
+        static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            template.inner_common_num_gates,
+            inner_data.common.gates.len(),
+            "BranchNodeChain cache received incompatible inner circuit gate count"
         );
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven storage trie recursion layer(initial)...");
-
-        result
+        assert_eq!(
+            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
+            "BranchNodeChain cache received incompatible inner public-input count"
+        );
+        assert_eq!(
+            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
+            "BranchNodeChain cache received incompatible inner circuit digest"
+        );
+        template
     }
 
-    fn prove_recursive(
-        mut self,
-        composed_proof: ProofWithPublicInputs<F, C, D>,
-    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
-        log::debug!("    Proving storage trie recursion layer...");
-        self.witness.set_bool_target(self.condition, true);
-        self.witness
-            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven storage trie recursion layer");
-
-        result
+    fn instantiate<'a>(
+        &'a self,
+        inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>,
+    ) -> Circuit<'a> {
+        let mut witness = PartialWitness::new();
+        witness.set_verifier_data_target(
+            &self.verifier_data_target,
+            &self.cyclic_circuit_data.verifier_only,
+        );
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        Circuit {
+            template: self,
+            witness,
+        }
     }
 
-    fn build(inner: HashedBranchParser) -> Circuit {
-        let inner_proof = inner.prove();
+    fn build(inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>) -> Self {
+        log::debug!("    Building storage trie recursion template...");
 
-        log::debug!("    Building storage trie recursion layer...");
-
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut pw = PartialWitness::new();
-
-        let inner_proof_pis = builder.recursively_verify_constant_proof(&inner_proof, &mut pw);
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier_data = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(
+            &inner_proof_with_pis,
+            &inner_verifier_data,
+            &inner_data.common,
+        );
+        let inner_proof_pis = HashedBranchParserTarget::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         let mut virtual_targets = iter::repeat(()).map(|_| builder.add_virtual_target());
         let future_inner_cyclic_proof_pis =
@@ -251,18 +255,83 @@ impl Circuit {
             )
             .expect("Failed to build circuit");
 
-        let cyclic_circuit_data = builder.build::<C>();
+        let cyclic_circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(cyclic_circuit_data.verifier_data());
 
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        log::debug!("    Built storage trie recursion template");
 
-        log::debug!("    Built storage parser recursion layer");
-
-        Circuit {
+        Self {
             cyclic_circuit_data,
-            common_data,
-            condition,
+            verifier_data,
+            common_data: Arc::new(common_data),
+            inner_proof_with_pis,
             inner_cyclic_proof_with_pis,
-            witness: pw,
+            condition,
+            verifier_data_target,
+            inner_common_num_gates: inner_data.common.gates.len(),
+            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_only: inner_data.verifier_only.clone(),
         }
+    }
+}
+
+struct Circuit<'a> {
+    template: &'a CircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl Circuit<'_> {
+    fn prove_initial(
+        mut self,
+        root_hash: [u8; BLAKE2_DIGEST_SIZE],
+    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
+        log::debug!("    Proving storage trie recursion layer(initial)...");
+
+        let root_hash_bits = array_to_bits(&root_hash);
+        let public_inputs = root_hash_bits
+            .into_iter()
+            .map(F::from_bool)
+            .enumerate()
+            .collect();
+
+        self.witness.set_bool_target(self.template.condition, false);
+        self.witness.set_proof_with_pis_target::<C, D>(
+            &self.template.inner_cyclic_proof_with_pis,
+            &cyclic_base_proof(
+                &self.template.common_data,
+                &self.template.cyclic_circuit_data.verifier_only,
+                public_inputs,
+            ),
+        );
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven storage trie recursion layer(initial)...");
+
+        result
+    }
+
+    fn prove_recursive(
+        mut self,
+        composed_proof: ProofWithPublicInputs<F, C, D>,
+    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
+        log::debug!("    Proving storage trie recursion layer...");
+        self.witness.set_bool_target(self.template.condition, true);
+        self.witness
+            .set_proof_with_pis_target(&self.template.inner_cyclic_proof_with_pis, &composed_proof);
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven storage trie recursion layer");
+
+        result
     }
 }

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
@@ -44,7 +44,7 @@ impl HashedBranchParser {
         const MAX_DATA_LENGTH_ESTIMATION: usize =
             MAX_BRANCH_NODE_DATA_LENGTH_IN_BLOCKS * NODE_DATA_BLOCK_BYTES;
 
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof =
             circuit.prove::<MAX_DATA_LENGTH_ESTIMATION>(&self.branch_parser.node_data);
         let branch_parser_proof = self.branch_parser.prove();

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
@@ -1,15 +1,23 @@
 //! Circuit that's used to prove correct parsing of branch node.
 
 use plonky2::{
-    iop::witness::PartialWitness,
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    iop::witness::{PartialWitness, WitnessWrite},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierOnlyCircuitData,
+        },
+        proof::ProofWithPublicInputsTarget,
+    },
 };
+use std::sync::{Arc, OnceLock};
 
 use crate::{
     common::{
-        blake2::CircuitTargets as Blake2CircuitTargets,
+        blake2::{CircuitTargets as Blake2CircuitTargets, GenericBlake2Target},
         targets::{impl_parsable_target_set, Blake2Target, TargetSet},
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     prelude::*,
     storage_inclusion::storage_trie_proof::node_parser::{
@@ -17,7 +25,10 @@ use crate::{
     },
 };
 
-use super::{node_parser::branch_parser::BranchParser, storage_address::StorageAddressTarget};
+use super::{
+    node_parser::branch_parser::{BranchParser, BranchParserTarget},
+    storage_address::StorageAddressTarget,
+};
 
 impl_parsable_target_set! {
     /// Public inputs for `HashedBranchParser`.
@@ -39,6 +50,151 @@ pub struct HashedBranchParser {
     pub branch_parser: BranchParser,
 }
 
+struct HashedBranchParserCircuitTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    hasher_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    branch_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    hasher_common_data: CommonCircuitData<F, D>,
+    hasher_verifier_only: VerifierOnlyCircuitData<C, D>,
+    branch_common_data: CommonCircuitData<F, D>,
+    branch_verifier_only: VerifierOnlyCircuitData<C, D>,
+}
+
+impl HashedBranchParserCircuitTemplate {
+    fn cached(
+        hasher_proof: &ProofWithCircuitData<GenericBlake2Target>,
+        branch_proof: &ProofWithCircuitData<BranchParserTarget>,
+    ) -> &'static Self {
+        // Both inner proof shapes are fixed by the deployment circuit config;
+        // node contents remain per-call witnesses.
+        static CACHE: OnceLock<HashedBranchParserCircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(hasher_proof, branch_proof));
+        let hasher_data = hasher_proof.circuit_data();
+        let branch_data = branch_proof.circuit_data();
+        assert_eq!(
+            &template.hasher_common_data, &hasher_data.common,
+            "HashedBranchParser cache received incompatible hasher common data"
+        );
+        assert_eq!(
+            &template.hasher_verifier_only, &hasher_data.verifier_only,
+            "HashedBranchParser cache received incompatible hasher verifier data"
+        );
+        assert_eq!(
+            &template.branch_common_data, &branch_data.common,
+            "HashedBranchParser cache received incompatible branch common data"
+        );
+        assert_eq!(
+            &template.branch_verifier_only, &branch_data.verifier_only,
+            "HashedBranchParser cache received incompatible branch verifier data"
+        );
+        template
+    }
+
+    fn instantiate(
+        &self,
+        hasher_proof: &ProofWithCircuitData<GenericBlake2Target>,
+        branch_proof: &ProofWithCircuitData<BranchParserTarget>,
+    ) -> HashedBranchParserCircuit<'_> {
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.hasher_proof_with_pis, &hasher_proof.proof());
+        witness.set_proof_with_pis_target(&self.branch_proof_with_pis, &branch_proof.proof());
+        HashedBranchParserCircuit {
+            template: self,
+            witness,
+        }
+    }
+
+    fn build(
+        hasher_proof: &ProofWithCircuitData<GenericBlake2Target>,
+        branch_proof: &ProofWithCircuitData<BranchParserTarget>,
+    ) -> Self {
+        log::debug!("Building hashed branch parser circuit template...");
+
+        let hasher_data = hasher_proof.circuit_data();
+        let branch_data = branch_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+
+        let hasher_proof_with_pis = builder.add_virtual_proof_with_pis(&hasher_data.common);
+        let hasher_verifier = builder.constant_verifier_data(&hasher_data.verifier_only);
+        builder.verify_proof::<C>(
+            &hasher_proof_with_pis,
+            &hasher_verifier,
+            &hasher_data.common,
+        );
+        let hasher_target = GenericBlake2Target::parse_exact(
+            &mut hasher_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        let branch_proof_with_pis = builder.add_virtual_proof_with_pis(&branch_data.common);
+        let branch_verifier = builder.constant_verifier_data(&branch_data.verifier_only);
+        builder.verify_proof::<C>(
+            &branch_proof_with_pis,
+            &branch_verifier,
+            &branch_data.common,
+        );
+        let branch_target = BranchParserTarget::parse_exact(
+            &mut branch_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        hasher_target
+            .length
+            .connect(&branch_target.node_data_length, &mut builder);
+
+        let mut branch_parser_node_data = branch_target.padded_node_data.into_targets_iter();
+        let mut hasher_node_data = hasher_target.data.into_targets_iter();
+        loop {
+            let branch_parser_byte = branch_parser_node_data.next();
+            let hasher_byte = hasher_node_data.next();
+
+            match (branch_parser_byte, hasher_byte) {
+                (Some(a), Some(b)) => builder.connect(a, b),
+                (Some(_), None) => {
+                    panic!("Generic blake2 hasher circuit have insifficient maximum data length")
+                }
+                _ => break,
+            }
+        }
+
+        HashedBranchParserTarget {
+            node_hash: hasher_target.hash,
+            child_node_hash: branch_target.child_node_hash,
+            partial_address: branch_target.partial_address,
+            resulting_partial_address: branch_target.resulting_partial_address,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            hasher_proof_with_pis,
+            branch_proof_with_pis,
+            hasher_common_data: hasher_data.common.clone(),
+            hasher_verifier_only: hasher_data.verifier_only.clone(),
+            branch_common_data: branch_data.common.clone(),
+            branch_verifier_only: branch_data.verifier_only.clone(),
+        }
+    }
+}
+
+struct HashedBranchParserCircuit<'a> {
+    template: &'a HashedBranchParserCircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl HashedBranchParserCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<HashedBranchParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
 impl HashedBranchParser {
     pub fn prove(self) -> ProofWithCircuitData<HashedBranchParserTarget> {
         const MAX_DATA_LENGTH_ESTIMATION: usize =
@@ -50,45 +206,11 @@ impl HashedBranchParser {
         let branch_parser_proof = self.branch_parser.prove();
 
         log::debug!("Composing hasher proof and branch parser proof...");
-
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut witness = PartialWitness::new();
-
-        let hasher_target = builder.recursively_verify_constant_proof(&hasher_proof, &mut witness);
-        let branch_parser_target =
-            builder.recursively_verify_constant_proof(&branch_parser_proof, &mut witness);
-
-        hasher_target
-            .length
-            .connect(&branch_parser_target.node_data_length, &mut builder);
-
-        let mut branch_parser_node_data = branch_parser_target.padded_node_data.into_targets_iter();
-        let mut hasher_node_data = hasher_target.data.into_targets_iter();
-        loop {
-            let branch_parser_byte = branch_parser_node_data.next();
-            let hasher_byte = hasher_node_data.next();
-
-            match (branch_parser_byte, hasher_byte) {
-                (Some(a), Some(b)) => {
-                    builder.connect(a, b);
-                }
-                (Some(_), None) => {
-                    panic!("Generic blake2 hasher circuit have insifficient maximum data length");
-                }
-                _ => break,
-            }
-        }
-
-        HashedBranchParserTarget {
-            node_hash: hasher_target.hash,
-            child_node_hash: branch_parser_target.child_node_hash,
-            partial_address: branch_parser_target.partial_address,
-            resulting_partial_address: branch_parser_target.resulting_partial_address,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        let result = ProofWithCircuitData::prove_from_builder(builder, witness);
+        let template =
+            HashedBranchParserCircuitTemplate::cached(&hasher_proof, &branch_parser_proof);
+        let result = template
+            .instantiate(&hasher_proof, &branch_parser_proof)
+            .prove();
 
         log::debug!("Composed hasher proof and branch parser proof");
 

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
@@ -55,8 +55,10 @@ struct HashedBranchParserCircuitTemplate {
     verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     hasher_proof_with_pis: ProofWithPublicInputsTarget<D>,
     branch_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    hasher_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     hasher_common_data: CommonCircuitData<F, D>,
     hasher_verifier_only: VerifierOnlyCircuitData<C, D>,
+    branch_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     branch_common_data: CommonCircuitData<F, D>,
     branch_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
@@ -70,24 +72,30 @@ impl HashedBranchParserCircuitTemplate {
         // node contents remain per-call witnesses.
         static CACHE: OnceLock<HashedBranchParserCircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(hasher_proof, branch_proof));
-        let hasher_data = hasher_proof.circuit_data();
-        let branch_data = branch_proof.circuit_data();
-        assert_eq!(
-            &template.hasher_common_data, &hasher_data.common,
-            "HashedBranchParser cache received incompatible hasher common data"
-        );
-        assert_eq!(
-            &template.hasher_verifier_only, &hasher_data.verifier_only,
-            "HashedBranchParser cache received incompatible hasher verifier data"
-        );
-        assert_eq!(
-            &template.branch_common_data, &branch_data.common,
-            "HashedBranchParser cache received incompatible branch common data"
-        );
-        assert_eq!(
-            &template.branch_verifier_only, &branch_data.verifier_only,
-            "HashedBranchParser cache received incompatible branch verifier data"
-        );
+        let hasher_verifier_data = hasher_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.hasher_verifier_data, &hasher_verifier_data) {
+            let hasher_data = hasher_verifier_data.as_ref();
+            assert_eq!(
+                &template.hasher_common_data, &hasher_data.common,
+                "HashedBranchParser cache received incompatible hasher common data"
+            );
+            assert_eq!(
+                &template.hasher_verifier_only, &hasher_data.verifier_only,
+                "HashedBranchParser cache received incompatible hasher verifier data"
+            );
+        }
+        let branch_verifier_data = branch_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.branch_verifier_data, &branch_verifier_data) {
+            let branch_data = branch_verifier_data.as_ref();
+            assert_eq!(
+                &template.branch_common_data, &branch_data.common,
+                "HashedBranchParser cache received incompatible branch common data"
+            );
+            assert_eq!(
+                &template.branch_verifier_only, &branch_data.verifier_only,
+                "HashedBranchParser cache received incompatible branch verifier data"
+            );
+        }
         template
     }
 
@@ -172,8 +180,10 @@ impl HashedBranchParserCircuitTemplate {
             verifier_data,
             hasher_proof_with_pis,
             branch_proof_with_pis,
+            hasher_verifier_data: hasher_proof.shared_circuit_data(),
             hasher_common_data: hasher_data.common.clone(),
             hasher_verifier_only: hasher_data.verifier_only.clone(),
+            branch_verifier_data: branch_proof.shared_circuit_data(),
             branch_common_data: branch_data.common.clone(),
             branch_verifier_only: branch_data.verifier_only.clone(),
         }

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_leaf_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_leaf_parser.rs
@@ -44,7 +44,7 @@ impl HashedLeafParser {
         const MAX_DATA_LENGTH_ESTIMATION: usize =
             MAX_LEAF_NODE_DATA_LENGTH_IN_BLOCKS * NODE_DATA_BLOCK_BYTES;
 
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof = circuit.prove::<MAX_DATA_LENGTH_ESTIMATION>(&self.leaf_parser.node_data);
         let leaf_parser_proof = self.leaf_parser.prove();
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/child_node_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/child_node_parser.rs
@@ -5,14 +5,17 @@ use plonky2::{
         target::{BoolTarget, Target},
         witness::{PartialWitness, WitnessWrite},
     },
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData},
+    },
 };
 use plonky2_field::types::Field;
 
 use crate::{
     common::{
         targets::{impl_parsable_target_set, ArrayTarget, Blake2Target, TargetSet},
-        ProofWithCircuitData,
+        CircuitDataCache, CircuitImplBuilder, ProofWithCircuitData,
     },
     prelude::{
         consts::{BLAKE2_DIGEST_SIZE, BLAKE2_DIGEST_SIZE_IN_BITS},
@@ -60,24 +63,31 @@ impl ChildNodeParser {
     pub fn prove(self) -> ProofWithCircuitData<ChildNodeParserTarget> {
         log::debug!("Proving child node parser...");
 
+        static CACHE: std::sync::OnceLock<CircuitDataCache<ChildNodeParser>> =
+            std::sync::OnceLock::new();
+        let data = CACHE.get_or_init(CircuitDataCache::new).prove(self);
+
+        log::debug!("Proven child node parser");
+
+        data
+    }
+}
+
+impl CircuitImplBuilder for ChildNodeParser {
+    type WitnessTargets = ChildNodeParserWitnessTargets;
+    type PublicInputsTarget = ChildNodeParserTarget;
+
+    fn build() -> (CircuitData<F, C, D>, Self::WitnessTargets) {
         let mut config = CircuitConfig::standard_recursion_config();
         config.num_wires = 160;
         config.num_routed_wires = 130;
 
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let mut pw = PartialWitness::new();
 
         let node_data = BranchNodeDataPaddedTarget::add_virtual_unsafe(&mut builder);
-        node_data.set_witness(&self.node_data, &mut pw);
-
         let read_offset = builder.add_virtual_target();
-        pw.set_target(read_offset, F::from_canonical_usize(self.read_offset));
-
         let assert_child_hash = builder.add_virtual_bool_target_unsafe();
-        pw.set_bool_target(assert_child_hash, self.assert_child_hash);
-
         let claimed_child_hash = Blake2Target::add_virtual_unsafe(&mut builder);
-        claimed_child_hash.set_witness(&self.claimed_child_hash, &mut pw);
 
         // Read only one byte as we don't support compact integers in other modes than single-byte.
         let encoded_length_size = builder.one();
@@ -126,20 +136,43 @@ impl ChildNodeParser {
         ]);
 
         ChildNodeParserTarget {
-            node_data,
+            node_data: node_data.clone(),
             read_offset,
             resulting_read_offset,
             assert_child_hash,
-            claimed_child_hash,
+            claimed_child_hash: claimed_child_hash.clone(),
         }
         .register_as_public_inputs(&mut builder);
 
-        let data = ProofWithCircuitData::prove_from_builder(builder, pw);
+        let witness_targets = ChildNodeParserWitnessTargets {
+            node_data: node_data.clone(),
+            read_offset,
+            assert_child_hash,
+            claimed_child_hash: claimed_child_hash.clone(),
+        };
 
-        log::debug!("Proven child node parser");
-
-        data
+        (builder.build::<C>(), witness_targets)
     }
+
+    fn set_witness(&self, targets: Self::WitnessTargets, witness: &mut PartialWitness<F>) {
+        targets.node_data.set_witness(&self.node_data, witness);
+        witness.set_target(
+            targets.read_offset,
+            F::from_canonical_usize(self.read_offset),
+        );
+        witness.set_bool_target(targets.assert_child_hash, self.assert_child_hash);
+        targets
+            .claimed_child_hash
+            .set_witness(&self.claimed_child_hash, witness);
+    }
+}
+
+#[derive(Clone)]
+pub struct ChildNodeParserWitnessTargets {
+    node_data: BranchNodeDataPaddedTarget,
+    read_offset: Target,
+    assert_child_hash: BoolTarget,
+    claimed_child_hash: Blake2Target,
 }
 
 #[cfg(test)]

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -176,6 +176,7 @@ struct CircuitTemplate {
     inner_common_num_gates: usize,
     inner_common_num_public_inputs: usize,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+    inner_common_data: CommonCircuitData<F, D>,
 }
 
 impl CircuitTemplate {
@@ -195,6 +196,14 @@ impl CircuitTemplate {
         assert_eq!(
             template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
             "ChildNodeArrayParser cache received incompatible inner circuit digest"
+        );
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "ChildNodeArrayParser cache received incompatible inner common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "ChildNodeArrayParser cache received incompatible inner verifier data"
         );
         template
     }
@@ -321,6 +330,7 @@ impl CircuitTemplate {
             inner_common_num_gates: inner_data.common.gates.len(),
             inner_common_num_public_inputs: inner_data.common.num_public_inputs,
             inner_verifier_only: inner_data.verifier_only.clone(),
+            inner_common_data: inner_data.common.clone(),
         }
     }
 }

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -7,14 +7,17 @@ use plonky2::{
     },
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, CircuitData, CommonCircuitData},
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
+            VerifierOnlyCircuitData,
+        },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
     recursion::dummy_circuit::cyclic_base_proof,
 };
 use plonky2_field::types::Field;
 
-use self::child_node_parser::ChildNodeParser;
+use self::child_node_parser::{ChildNodeParser, ChildNodeParserTarget};
 use crate::{
     common::{
         array_to_bits, common_data_for_recursion,
@@ -29,7 +32,10 @@ use crate::{
         BranchNodeDataPaddedTarget, MAX_BRANCH_NODE_DATA_LENGTH_IN_BLOCKS, NODE_DATA_BLOCK_BYTES,
     },
 };
-use std::iter;
+use std::{
+    iter,
+    sync::{Arc, OnceLock},
+};
 
 mod child_node_parser;
 
@@ -121,7 +127,8 @@ impl ChildNodeArrayParser {
                 claimed_child_hash,
             };
 
-            let circuit = Circuit::build(inner_circuit);
+            let inner_proof = inner_circuit.prove();
+            let circuit = CircuitTemplate::cached(&inner_proof).instantiate(&inner_proof);
 
             cyclic_proof = Some(if let Some(cyclic_proof) = cyclic_proof {
                 circuit.prove_recursive(cyclic_proof.proof())
@@ -158,94 +165,72 @@ impl_target_set! {
     }
 }
 
-struct Circuit {
-    cyclic_circuit_data: CircuitData<F, C, D>,
-
-    common_data: CommonCircuitData<F, D>,
-
-    condition: BoolTarget,
+struct CircuitTemplate {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<plonky2::plonk::circuit_data::VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
-
-    witness: PartialWitness<F>,
+    condition: BoolTarget,
+    verifier_data_target: VerifierCircuitTarget,
+    inner_common_num_gates: usize,
+    inner_common_num_public_inputs: usize,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
 
-impl Circuit {
-    fn prove_initial(
-        mut self,
-        initial_data: InitialData,
-    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
-        log::debug!("    Proving child node parser recursion layer(initial)...");
-
-        let public_inputs = initial_data
-            .node_data
-            .into_iter()
-            .flatten()
-            .map(|byte| byte as usize)
-            .chain(iter::once(initial_data.read_offset))
-            .chain(iter::once(0))
-            .chain(iter::once(0))
-            .chain(iter::once(initial_data.claimed_child_index_in_array))
-            .chain(
-                array_to_bits(&initial_data.claimed_child_hash)
-                    .into_iter()
-                    .map(|bit| bit as usize),
-            )
-            .map(F::from_canonical_usize);
-
-        // Length check.
-        CyclicRecursionTarget::parse_public_inputs_exact(&mut public_inputs.clone());
-
-        let public_inputs = public_inputs.enumerate().collect();
-
-        self.witness.set_bool_target(self.condition, false);
-        self.witness.set_proof_with_pis_target::<C, D>(
-            &self.inner_cyclic_proof_with_pis,
-            &cyclic_base_proof(
-                &self.common_data,
-                &self.cyclic_circuit_data.verifier_only,
-                public_inputs,
-            ),
+impl CircuitTemplate {
+    fn cached(inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>) -> &'static Self {
+        static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            template.inner_common_num_gates,
+            inner_data.common.gates.len(),
+            "ChildNodeArrayParser cache received incompatible inner circuit gate count"
         );
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven child node parser recursion layer(initial)...");
-
-        result
+        assert_eq!(
+            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
+            "ChildNodeArrayParser cache received incompatible inner public-input count"
+        );
+        assert_eq!(
+            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
+            "ChildNodeArrayParser cache received incompatible inner circuit digest"
+        );
+        template
     }
 
-    fn prove_recursive(
-        mut self,
-        composed_proof: ProofWithPublicInputs<F, C, D>,
-    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
-        log::debug!("    Proving child node parser recursion layer...");
-        self.witness.set_bool_target(self.condition, true);
-        self.witness
-            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven child node parser recursion layer");
-
-        result
+    fn instantiate<'a>(
+        &'a self,
+        inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>,
+    ) -> Circuit<'a> {
+        let mut witness = PartialWitness::new();
+        witness.set_verifier_data_target(
+            &self.verifier_data_target,
+            &self.cyclic_circuit_data.verifier_only,
+        );
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        Circuit {
+            template: self,
+            witness,
+        }
     }
 
-    fn build(inner_circuit: ChildNodeParser) -> Circuit {
-        log::debug!("    Proving child node correctness...");
+    fn build(inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>) -> Self {
+        log::debug!("    Building child node parser recursion template...");
 
-        let inner_proof = inner_circuit.prove();
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
 
-        log::debug!("    Proven child node correctness");
-
-        log::debug!("    Building child node parser recursion layer...");
-
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut pw = PartialWitness::new();
-
-        let inner_proof_pis = builder.recursively_verify_constant_proof(&inner_proof, &mut pw);
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier_data = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(
+            &inner_proof_with_pis,
+            &inner_verifier_data,
+            &inner_data.common,
+        );
+        let inner_proof_pis = ChildNodeParserTarget::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         let mut virtual_targets = iter::repeat(()).map(|_| builder.add_virtual_target());
         let future_inner_cyclic_proof_pis = CyclicRecursionTarget::parse(&mut virtual_targets);
@@ -320,19 +305,96 @@ impl Circuit {
             )
             .expect("Failed to build circuit");
 
-        let cyclic_circuit_data = builder.build::<C>();
+        let cyclic_circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(cyclic_circuit_data.verifier_data());
 
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        log::debug!("    Built child node parser recursion template");
 
-        log::debug!("    Built child node parser recursion layer");
-
-        Circuit {
+        Self {
             cyclic_circuit_data,
-            common_data,
-            condition,
+            verifier_data,
+            common_data: Arc::new(common_data),
+            inner_proof_with_pis,
             inner_cyclic_proof_with_pis,
-            witness: pw,
+            condition,
+            verifier_data_target,
+            inner_common_num_gates: inner_data.common.gates.len(),
+            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_only: inner_data.verifier_only.clone(),
         }
+    }
+}
+
+struct Circuit<'a> {
+    template: &'a CircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl Circuit<'_> {
+    fn prove_initial(
+        mut self,
+        initial_data: InitialData,
+    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
+        log::debug!("    Proving child node parser recursion layer(initial)...");
+
+        let public_inputs = initial_data
+            .node_data
+            .into_iter()
+            .flatten()
+            .map(|byte| byte as usize)
+            .chain(iter::once(initial_data.read_offset))
+            .chain(iter::once(0))
+            .chain(iter::once(0))
+            .chain(iter::once(initial_data.claimed_child_index_in_array))
+            .chain(
+                array_to_bits(&initial_data.claimed_child_hash)
+                    .into_iter()
+                    .map(|bit| bit as usize),
+            )
+            .map(F::from_canonical_usize);
+
+        CyclicRecursionTarget::parse_public_inputs_exact(&mut public_inputs.clone());
+        let public_inputs = public_inputs.enumerate().collect();
+
+        self.witness.set_bool_target(self.template.condition, false);
+        self.witness.set_proof_with_pis_target::<C, D>(
+            &self.template.inner_cyclic_proof_with_pis,
+            &cyclic_base_proof(
+                &self.template.common_data,
+                &self.template.cyclic_circuit_data.verifier_only,
+                public_inputs,
+            ),
+        );
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven child node parser recursion layer(initial)...");
+
+        result
+    }
+
+    fn prove_recursive(
+        mut self,
+        composed_proof: ProofWithPublicInputs<F, C, D>,
+    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
+        log::debug!("    Proving child node parser recursion layer...");
+        self.witness.set_bool_target(self.template.condition, true);
+        self.witness
+            .set_proof_with_pis_target(&self.template.inner_cyclic_proof_with_pis, &composed_proof);
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven child node parser recursion layer");
+
+        result
     }
 }
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -8,8 +8,8 @@ use plonky2::{
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::{
-            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
-            VerifierOnlyCircuitData,
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget, VerifierOnlyCircuitData,
         },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
@@ -25,7 +25,7 @@ use crate::{
             impl_parsable_target_set, impl_target_set, Blake2Target, ParsableTargetSet, TargetSet,
             VerifierDataTarget,
         },
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     prelude::{consts::BLAKE2_DIGEST_SIZE, *},
     storage_inclusion::storage_trie_proof::node_parser::{
@@ -79,27 +79,102 @@ pub struct ChildNodeArrayParser {
     pub children_lengths: Vec<usize>,
 }
 
-impl ChildNodeArrayParser {
-    pub fn prove(self) -> ProofWithCircuitData<ChildNodeArrayParserTarget> {
-        let inner_proof = self.inner_proof();
+struct FinalProjectionTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_common_data: CommonCircuitData<F, D>,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+}
 
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
+impl FinalProjectionTemplate {
+    fn cached(
+        inner_proof: &ProofWithCircuitData<CyclicRecursionTargetWithVerifierData>,
+    ) -> &'static Self {
+        // The projection has one fixed inner proof shape; child contents are
+        // carried by the per-call inner proof witness.
+        static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "ChildNodeArrayParser final projection received incompatible common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "ChildNodeArrayParser final projection received incompatible verifier data"
+        );
+        template
+    }
+
+    fn instantiate(
+        &self,
+        inner_proof: &ProofWithCircuitData<CyclicRecursionTargetWithVerifierData>,
+    ) -> FinalProjectionCircuit<'_> {
         let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        FinalProjectionCircuit {
+            template: self,
+            witness,
+        }
+    }
 
-        let inner_proof_pis = builder.recursively_verify_constant_proof(&inner_proof, &mut witness);
+    fn build(inner_proof: &ProofWithCircuitData<CyclicRecursionTargetWithVerifierData>) -> Self {
+        log::debug!("Building child node array parser final projection template...");
+
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(&inner_proof_with_pis, &inner_verifier, &inner_data.common);
+        let inner_target = CyclicRecursionTargetWithVerifierData::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         ChildNodeArrayParserTarget {
-            node_data: inner_proof_pis.inner.node_data,
-            initial_read_offset: inner_proof_pis.inner.initial_read_offset,
-            final_read_offset: inner_proof_pis.inner.read_offset,
-            overall_children_amount: inner_proof_pis.inner.overall_children_amount,
-            claimed_child_index_in_array: inner_proof_pis.inner.claimed_child_index_in_array,
-            claimed_child_hash: inner_proof_pis.inner.claimed_child_hash,
+            node_data: inner_target.inner.node_data,
+            initial_read_offset: inner_target.inner.initial_read_offset,
+            final_read_offset: inner_target.inner.read_offset,
+            overall_children_amount: inner_target.inner.overall_children_amount,
+            claimed_child_index_in_array: inner_target.inner.claimed_child_index_in_array,
+            claimed_child_hash: inner_target.inner.claimed_child_hash,
         }
         .register_as_public_inputs(&mut builder);
 
-        ProofWithCircuitData::prove_from_builder(builder, witness)
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            inner_proof_with_pis,
+            inner_common_data: inner_data.common.clone(),
+            inner_verifier_only: inner_data.verifier_only.clone(),
+        }
+    }
+}
+
+struct FinalProjectionCircuit<'a> {
+    template: &'a FinalProjectionTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl FinalProjectionCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<ChildNodeArrayParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
+impl ChildNodeArrayParser {
+    pub fn prove(self) -> ProofWithCircuitData<ChildNodeArrayParserTarget> {
+        let inner_proof = self.inner_proof();
+        FinalProjectionTemplate::cached(&inner_proof)
+            .instantiate(&inner_proof)
+            .prove()
     }
 
     fn inner_proof(self) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -83,6 +83,7 @@ struct FinalProjectionTemplate {
     circuit_data: Arc<CircuitData<F, C, D>>,
     verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_common_data: CommonCircuitData<F, D>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
@@ -95,15 +96,18 @@ impl FinalProjectionTemplate {
         // carried by the per-call inner proof witness.
         static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "ChildNodeArrayParser final projection received incompatible common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "ChildNodeArrayParser final projection received incompatible verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "ChildNodeArrayParser final projection received incompatible common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "ChildNodeArrayParser final projection received incompatible verifier data"
+            );
+        }
         template
     }
 
@@ -148,6 +152,7 @@ impl FinalProjectionTemplate {
             circuit_data,
             verifier_data,
             inner_proof_with_pis,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_common_data: inner_data.common.clone(),
             inner_verifier_only: inner_data.verifier_only.clone(),
         }
@@ -248,8 +253,7 @@ struct CircuitTemplate {
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
     condition: BoolTarget,
     verifier_data_target: VerifierCircuitTarget,
-    inner_common_num_gates: usize,
-    inner_common_num_public_inputs: usize,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
     inner_common_data: CommonCircuitData<F, D>,
 }
@@ -258,28 +262,18 @@ impl CircuitTemplate {
     fn cached(inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>) -> &'static Self {
         static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            template.inner_common_num_gates,
-            inner_data.common.gates.len(),
-            "ChildNodeArrayParser cache received incompatible inner circuit gate count"
-        );
-        assert_eq!(
-            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
-            "ChildNodeArrayParser cache received incompatible inner public-input count"
-        );
-        assert_eq!(
-            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
-            "ChildNodeArrayParser cache received incompatible inner circuit digest"
-        );
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "ChildNodeArrayParser cache received incompatible inner common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "ChildNodeArrayParser cache received incompatible inner verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "ChildNodeArrayParser cache received incompatible inner common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "ChildNodeArrayParser cache received incompatible inner verifier data"
+            );
+        }
         template
     }
 
@@ -402,8 +396,7 @@ impl CircuitTemplate {
             inner_cyclic_proof_with_pis,
             condition,
             verifier_data_target,
-            inner_common_num_gates: inner_data.common.gates.len(),
-            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_verifier_only: inner_data.verifier_only.clone(),
             inner_common_data: inner_data.common.clone(),
         }

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -15,7 +15,7 @@ use plonky2::{
         proof::ProofWithPublicInputsTarget,
     },
 };
-use plonky2_field::types::Field;
+use plonky2_field::types::{Field, PrimeField64};
 use sp_core::H256;
 use std::sync::{Arc, OnceLock};
 use trie_db::{node::Node, ChildReference, NodeCodec, TrieLayout};
@@ -46,6 +46,16 @@ use child_node_array_parser::ChildNodeArrayParser;
 
 mod bitmap_parser;
 mod child_node_array_parser;
+
+/// Circuit digest used by the deployed recursive and Gnark verifier artifacts.
+/// An intentional circuit change must update every dependent artifact before
+/// this fingerprint is changed.
+const DEPLOYED_BRANCH_PARSER_CIRCUIT_DIGEST: [u64; 4] = [
+    17_409_790_683_616_089_390,
+    15_806_974_348_444_331_405,
+    16_311_428_230_950_506_818,
+    9_327_205_214_850_258_051,
+];
 
 impl_parsable_target_set! {
     /// `BranchParser` public inputs.
@@ -229,6 +239,15 @@ impl BranchParserCircuitTemplate {
         .register_as_public_inputs(&mut builder);
 
         let circuit_data = Arc::new(builder.build::<C>());
+        assert_eq!(
+            circuit_data
+                .verifier_only
+                .circuit_digest
+                .elements
+                .map(|element| element.to_canonical_u64()),
+            DEPLOYED_BRANCH_PARSER_CIRCUIT_DIGEST,
+            "BranchParser circuit digest changed; regenerate all dependent recursive and Gnark artifacts before deployment",
+        );
         let verifier_data = Arc::new(circuit_data.verifier_data());
 
         Self {
@@ -436,12 +455,7 @@ mod tests {
                 .circuit_digest
                 .elements
                 .map(|element| element.to_canonical_u64()),
-            [
-                17_409_790_683_616_089_390,
-                15_806_974_348_444_331_405,
-                16_311_428_230_950_506_818,
-                9_327_205_214_850_258_051,
-            ],
+            DEPLOYED_BRANCH_PARSER_CIRCUIT_DIGEST,
             "BranchParser circuit digest changed; existing recursive and Gnark artifacts must remain compatible",
         );
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -6,10 +6,18 @@ use plonky2::{
         target::Target,
         witness::{PartialWitness, WitnessWrite},
     },
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierOnlyCircuitData,
+        },
+        proof::ProofWithPublicInputsTarget,
+    },
 };
 use plonky2_field::types::Field;
 use sp_core::H256;
+use std::sync::{Arc, OnceLock};
 use trie_db::{node::Node, ChildReference, NodeCodec, TrieLayout};
 
 use super::{
@@ -20,7 +28,7 @@ use super::{
 use crate::{
     common::{
         targets::{Blake2Target, HalfByteTarget, TargetSet},
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     consts::BLAKE2_DIGEST_SIZE,
     impl_parsable_target_set,
@@ -75,13 +83,194 @@ struct Metadata {
     claimed_child_hash: [u8; BLAKE2_DIGEST_SIZE],
 }
 
+struct BranchParserCircuitTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    child_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    partial_address: StorageAddressTarget,
+    claimed_child_node_nibble: Target,
+    child_common_data: CommonCircuitData<F, D>,
+    child_verifier_only: VerifierOnlyCircuitData<C, D>,
+    child_num_public_inputs: usize,
+}
+
+impl BranchParserCircuitTemplate {
+    fn cached(child_proof: &ProofWithCircuitData<ChildNodeArrayParserTarget>) -> &'static Self {
+        // Node bytes, addresses, and child metadata are witnesses; the parser
+        // circuit shape is fixed by the compile-time trie bounds.
+        static CACHE: OnceLock<BranchParserCircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(child_proof));
+        let child_data = child_proof.circuit_data();
+        assert_eq!(
+            template.child_common_num_gates(),
+            child_data.common.gates.len(),
+            "BranchParser cache received incompatible child circuit gate count"
+        );
+        assert_eq!(
+            template.child_num_public_inputs, child_data.common.num_public_inputs,
+            "BranchParser cache received incompatible child public-input count"
+        );
+        assert_eq!(
+            template.child_verifier_only.circuit_digest, child_data.verifier_only.circuit_digest,
+            "BranchParser cache received incompatible child circuit digest"
+        );
+        assert_eq!(
+            &template.child_common_data, &child_data.common,
+            "BranchParser cache received incompatible child common data"
+        );
+        assert_eq!(
+            &template.child_verifier_only, &child_data.verifier_only,
+            "BranchParser cache received incompatible child verifier data"
+        );
+        template
+    }
+
+    fn child_common_num_gates(&self) -> usize {
+        self.child_common_data.gates.len()
+    }
+
+    fn instantiate(
+        &self,
+        child_proof: &ProofWithCircuitData<ChildNodeArrayParserTarget>,
+        partial_address_nibbles: &[u8],
+        claimed_child_node_nibble: u8,
+    ) -> BranchParserCircuit<'_> {
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.child_proof_with_pis, &child_proof.proof());
+        self.partial_address
+            .set_witness(partial_address_nibbles, &mut witness);
+        witness.set_target(
+            self.claimed_child_node_nibble,
+            F::from_canonical_u8(claimed_child_node_nibble),
+        );
+        BranchParserCircuit {
+            template: self,
+            witness,
+        }
+    }
+
+    fn build(child_proof: &ProofWithCircuitData<ChildNodeArrayParserTarget>) -> Self {
+        log::debug!("Building branch parser circuit template...");
+
+        let child_data = child_proof.circuit_data();
+        let mut config = CircuitConfig::standard_recursion_config();
+        config.num_wires = 160;
+        config.num_routed_wires = 130;
+
+        let mut builder = CircuitBuilder::new(config);
+        let child_proof_with_pis = builder.add_virtual_proof_with_pis(&child_data.common);
+        let child_verifier = builder.constant_verifier_data(&child_data.verifier_only);
+        builder.verify_proof::<C>(&child_proof_with_pis, &child_verifier, &child_data.common);
+        let child_target = ChildNodeArrayParserTarget::parse_exact(
+            &mut child_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        let node_data_target = BranchNodeDataPaddedTarget::add_virtual_safe(&mut builder);
+        let partial_address_target = StorageAddressTarget::add_virtual_unsafe(&mut builder);
+        let node_data_length_target = builder.add_virtual_target();
+        let claimed_child_node_nibble_target = builder.add_virtual_target();
+        let claimed_child_node_nibble_target =
+            HalfByteTarget::from_target_safe(claimed_child_node_nibble_target, &mut builder);
+        let child_node_hash_target = Blake2Target::add_virtual_safe(&mut builder);
+
+        let first_node_data_block = node_data_target.constant_read(0);
+        let parsed_node_header = header_parser::define(
+            HeaderParserInputTarget {
+                first_bytes: first_node_data_block.constant_read_array(0),
+            },
+            header_parser::HeaderDescriptor::branch_without_value(),
+            &mut builder,
+        );
+        let parsed_nibbles = nibble_parser::define(
+            NibbleParserInputTarget {
+                first_node_data_block: first_node_data_block.clone(),
+                read_offset: parsed_node_header.resulting_offset,
+                nibble_count: parsed_node_header.nibble_count,
+                partial_address: partial_address_target.clone(),
+            },
+            &mut builder,
+        );
+        let child_nibble_address_part = StorageAddressTarget::from_single_nibble_target(
+            claimed_child_node_nibble_target,
+            &mut builder,
+        );
+        let resulting_address = parsed_nibbles
+            .partial_address
+            .append(child_nibble_address_part, &mut builder);
+        let parsed_bitmap = bitmap_parser::define(
+            BitmapParserInputTarget {
+                first_node_data_block,
+                read_offset: parsed_nibbles.resulting_offset,
+                claimed_child_node_nibble: claimed_child_node_nibble_target,
+            },
+            &mut builder,
+        );
+
+        child_target
+            .node_data
+            .connect(&node_data_target, &mut builder);
+        child_target
+            .initial_read_offset
+            .connect(&parsed_bitmap.resulting_offset, &mut builder);
+        child_target
+            .final_read_offset
+            .connect(&node_data_length_target, &mut builder);
+        child_target
+            .overall_children_amount
+            .connect(&parsed_bitmap.overall_children_amount, &mut builder);
+        child_target
+            .claimed_child_index_in_array
+            .connect(&parsed_bitmap.child_index_in_array, &mut builder);
+        child_target
+            .claimed_child_hash
+            .connect(&child_node_hash_target, &mut builder);
+
+        BranchParserTarget {
+            padded_node_data: node_data_target.clone(),
+            node_data_length: node_data_length_target,
+            child_node_hash: child_node_hash_target,
+            partial_address: partial_address_target.clone(),
+            resulting_partial_address: resulting_address,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            child_proof_with_pis,
+            partial_address: partial_address_target,
+            claimed_child_node_nibble: claimed_child_node_nibble_target.to_target(),
+            child_common_data: child_data.common.clone(),
+            child_verifier_only: child_data.verifier_only.clone(),
+            child_num_public_inputs: child_data.common.num_public_inputs,
+        }
+    }
+}
+
+struct BranchParserCircuit<'a> {
+    template: &'a BranchParserCircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl BranchParserCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<BranchParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
 impl BranchParser {
     pub fn prove(self) -> ProofWithCircuitData<BranchParserTarget> {
         let metadata = self.parse_metadata();
-
         let child_node_parser_proof = ChildNodeArrayParser {
             initial_data: child_node_array_parser::InitialData {
-                node_data: compose_padded_node_data(self.node_data),
+                node_data: compose_padded_node_data(self.node_data.clone()),
                 read_offset: metadata.children_data_offset,
                 claimed_child_index_in_array: metadata.claimed_child_index_in_array,
                 claimed_child_hash: metadata.claimed_child_hash,
@@ -91,100 +280,13 @@ impl BranchParser {
         .prove();
 
         log::debug!("Proving branch node parser...");
-
-        let mut config = CircuitConfig::standard_recursion_config();
-        config.num_wires = 160;
-        config.num_routed_wires = 130;
-
-        let mut builder = CircuitBuilder::new(config);
-        let mut witness = PartialWitness::new();
-
-        let node_data_target = BranchNodeDataPaddedTarget::add_virtual_safe(&mut builder);
-
-        let partial_address_target = StorageAddressTarget::add_virtual_unsafe(&mut builder);
-        partial_address_target.set_witness(&self.partial_address_nibbles, &mut witness);
-
-        let node_data_length_target: Target = builder.add_virtual_target();
-
-        let claimed_child_node_nibble_target = builder.add_virtual_target();
-        witness.set_target(
-            claimed_child_node_nibble_target,
-            F::from_canonical_u8(self.claimed_child_node_nibble),
+        let template = BranchParserCircuitTemplate::cached(&child_node_parser_proof);
+        let circuit = template.instantiate(
+            &child_node_parser_proof,
+            &self.partial_address_nibbles,
+            self.claimed_child_node_nibble,
         );
-        let claimed_child_node_nibble_target =
-            HalfByteTarget::from_target_safe(claimed_child_node_nibble_target, &mut builder);
-
-        let child_node_hash_target = Blake2Target::add_virtual_safe(&mut builder);
-
-        let first_node_data_block = node_data_target.constant_read(0);
-
-        let parsed_node_header = {
-            let first_bytes = first_node_data_block.constant_read_array(0);
-
-            let input = HeaderParserInputTarget { first_bytes };
-            header_parser::define(
-                input,
-                header_parser::HeaderDescriptor::branch_without_value(),
-                &mut builder,
-            )
-        };
-
-        let parsed_nibbles = {
-            let input = NibbleParserInputTarget {
-                first_node_data_block: first_node_data_block.clone(),
-                read_offset: parsed_node_header.resulting_offset,
-                nibble_count: parsed_node_header.nibble_count,
-                partial_address: partial_address_target.clone(),
-            };
-            nibble_parser::define(input, &mut builder)
-        };
-
-        let child_nibble_address_part = StorageAddressTarget::from_single_nibble_target(
-            claimed_child_node_nibble_target,
-            &mut builder,
-        );
-        let resulting_address = parsed_nibbles
-            .partial_address
-            .append(child_nibble_address_part, &mut builder);
-
-        let parsed_bitmap = {
-            let input = BitmapParserInputTarget {
-                first_node_data_block,
-                read_offset: parsed_nibbles.resulting_offset,
-                claimed_child_node_nibble: claimed_child_node_nibble_target,
-            };
-
-            bitmap_parser::define(input, &mut builder)
-        };
-
-        {
-            let ChildNodeArrayParserTarget {
-                node_data,
-                initial_read_offset,
-                final_read_offset,
-                overall_children_amount,
-                claimed_child_index_in_array,
-                claimed_child_hash,
-            } = builder.recursively_verify_constant_proof(&child_node_parser_proof, &mut witness);
-
-            node_data.connect(&node_data_target, &mut builder);
-            initial_read_offset.connect(&parsed_bitmap.resulting_offset, &mut builder);
-            final_read_offset.connect(&node_data_length_target, &mut builder);
-            overall_children_amount.connect(&parsed_bitmap.overall_children_amount, &mut builder);
-            claimed_child_index_in_array.connect(&parsed_bitmap.child_index_in_array, &mut builder);
-            claimed_child_hash.connect(&child_node_hash_target, &mut builder);
-        }
-
-        BranchParserTarget {
-            padded_node_data: node_data_target,
-            node_data_length: node_data_length_target,
-            child_node_hash: child_node_hash_target,
-            partial_address: partial_address_target,
-            resulting_partial_address: resulting_address,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        let result = ProofWithCircuitData::prove_from_builder(builder, witness);
+        let result = circuit.prove();
 
         log::debug!("Proven branch node parser");
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -147,13 +147,11 @@ impl BranchParserCircuitTemplate {
         config.num_routed_wires = 130;
 
         let mut builder = CircuitBuilder::new(config);
-        let child_proof_with_pis = builder.add_virtual_proof_with_pis(&child_data.common);
-        let child_verifier = builder.constant_verifier_data(&child_data.verifier_only);
-        builder.verify_proof::<C>(&child_proof_with_pis, &child_verifier, &child_data.common);
-        let child_target = ChildNodeArrayParserTarget::parse_exact(
-            &mut child_proof_with_pis.public_inputs.clone().into_iter(),
-        );
 
+        // Keep the recursive child verifier at the same position as the
+        // pre-cache circuit. Plonky2 target/gate order is part of the circuit
+        // digest, so moving it earlier would invalidate existing recursive and
+        // Gnark verifier artifacts even though the constraints are equivalent.
         let node_data_target = BranchNodeDataPaddedTarget::add_virtual_safe(&mut builder);
         let partial_address_target = StorageAddressTarget::add_virtual_unsafe(&mut builder);
         let node_data_length_target = builder.add_virtual_target();
@@ -193,6 +191,13 @@ impl BranchParserCircuitTemplate {
                 claimed_child_node_nibble: claimed_child_node_nibble_target,
             },
             &mut builder,
+        );
+
+        let child_proof_with_pis = builder.add_virtual_proof_with_pis(&child_data.common);
+        let child_verifier = builder.constant_verifier_data(&child_data.verifier_only);
+        builder.verify_proof::<C>(&child_proof_with_pis, &child_verifier, &child_data.common);
+        let child_target = ChildNodeArrayParserTarget::parse_exact(
+            &mut child_proof_with_pis.public_inputs.clone().into_iter(),
         );
 
         child_target
@@ -339,6 +344,7 @@ impl BranchParser {
 
 #[cfg(test)]
 mod tests {
+    use plonky2_field::types::PrimeField64;
     use std::iter;
     use trie_db::NibbleSlice;
 
@@ -423,6 +429,21 @@ mod tests {
             BranchParserTarget::parse_public_inputs_exact(&mut proof.public_inputs().into_iter());
 
         assert!(proof.verify());
+        assert_eq!(
+            proof
+                .circuit_data()
+                .verifier_only
+                .circuit_digest
+                .elements
+                .map(|element| element.to_canonical_u64()),
+            [
+                17_409_790_683_616_089_390,
+                15_806_974_348_444_331_405,
+                16_311_428_230_950_506_818,
+                9_327_205_214_850_258_051,
+            ],
+            "BranchParser circuit digest changed; existing recursive and Gnark artifacts must remain compatible",
+        );
 
         assert_eq!(
             pis.resulting_partial_address.length,

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -89,9 +89,9 @@ struct BranchParserCircuitTemplate {
     child_proof_with_pis: ProofWithPublicInputsTarget<D>,
     partial_address: StorageAddressTarget,
     claimed_child_node_nibble: Target,
+    child_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     child_common_data: CommonCircuitData<F, D>,
     child_verifier_only: VerifierOnlyCircuitData<C, D>,
-    child_num_public_inputs: usize,
 }
 
 impl BranchParserCircuitTemplate {
@@ -100,33 +100,22 @@ impl BranchParserCircuitTemplate {
         // circuit shape is fixed by the compile-time trie bounds.
         static CACHE: OnceLock<BranchParserCircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(child_proof));
-        let child_data = child_proof.circuit_data();
-        assert_eq!(
-            template.child_common_num_gates(),
-            child_data.common.gates.len(),
-            "BranchParser cache received incompatible child circuit gate count"
-        );
-        assert_eq!(
-            template.child_num_public_inputs, child_data.common.num_public_inputs,
-            "BranchParser cache received incompatible child public-input count"
-        );
-        assert_eq!(
-            template.child_verifier_only.circuit_digest, child_data.verifier_only.circuit_digest,
-            "BranchParser cache received incompatible child circuit digest"
-        );
-        assert_eq!(
-            &template.child_common_data, &child_data.common,
-            "BranchParser cache received incompatible child common data"
-        );
-        assert_eq!(
-            &template.child_verifier_only, &child_data.verifier_only,
-            "BranchParser cache received incompatible child verifier data"
-        );
+        let child_verifier_data = child_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.child_verifier_data, &child_verifier_data) {
+            // The normal hot path reuses the exact cached verifier-data Arc.
+            // Retain a full fallback check for separately allocated but
+            // compatible circuit data.
+            let child_data = child_verifier_data.as_ref();
+            assert_eq!(
+                &template.child_common_data, &child_data.common,
+                "BranchParser cache received incompatible child common data"
+            );
+            assert_eq!(
+                &template.child_verifier_only, &child_data.verifier_only,
+                "BranchParser cache received incompatible child verifier data"
+            );
+        }
         template
-    }
-
-    fn child_common_num_gates(&self) -> usize {
-        self.child_common_data.gates.len()
     }
 
     fn instantiate(
@@ -243,9 +232,9 @@ impl BranchParserCircuitTemplate {
             child_proof_with_pis,
             partial_address: partial_address_target,
             claimed_child_node_nibble: claimed_child_node_nibble_target.to_target(),
+            child_verifier_data: child_proof.shared_circuit_data(),
             child_common_data: child_data.common.clone(),
             child_verifier_only: child_data.verifier_only.clone(),
-            child_num_public_inputs: child_data.common.num_public_inputs,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Cache reusable recursive prover circuit data and verifier data.
- Bound header and validator-sign concurrency and add chunked header proving.
- Cache storage-inclusion child/branch recursion and composition shells.
- Fast-path cached circuit-shape validation with verifier-data identity while retaining full compatibility checks for separately allocated data.
- Cache gnark proving artifacts per normalized data directory.

## Validation

- `cargo check -p prover`
- `cargo check -p relayer`
- `cargo clippy -p prover --lib -- -D warnings`
- `cargo test -p prover --lib --no-run`
- Targeted child-array recursion and branch-parser tests
- `go test ./...` in `gnark-wrapper` (no Go tests present)

Full prover end-to-end tests require generated `VBLAKE2_CACHE_PATH` artifacts and are not available in the local checkout.

## Deployment

The image built from the deployed optimization branch passed the container build workflow and was deployed to the combined relayer host as:

`ghcr.io/gear-tech/bridge-relayer:proof-optimization-deploy.dcc88104da1d89983c19d2d5cc01940d2b37eadb`

The `merkle-root-relayers` service restarted successfully and is running without recent startup errors. The previous `.env` is backed up on the host as `.env.pre-dcc88104-20260807`.

## Performance notes

Local branch-parser proving improved from approximately 220s to 167s versus the pre-optimization baseline. Production RSS and end-to-end storage-inclusion timings should be monitored before reducing host memory.
