### PR TITLE
fix(relayer): prevent Ethereum nonce gaps

### DIFF
--- a/docs/running-the-bridge.md
+++ b/docs/running-the-bridge.md
@@ -78,6 +78,8 @@ RUST_MIN_STACK=4194304 \
 
 The flag names map to environment variables such as `GEAR_ENDPOINT`, `ETH_MESSAGE_QUEUE_ADDRESS`, `ETH_FEE_PAYER`, `GENESIS_CONFIG_AUTHORITY_SET_HASH`, `GENESIS_CONFIG_AUTHORITY_SET_ID`, `WEB_SERVER_TOKEN`, and `GEAR_BLOCK_STORAGE`. The CLI help is authoritative for defaults and required values. Commands for token relayers, manual relays, the kill switch, queue cleaner, root fetching, and verifier generation expose different argument groups; do not reuse a core command's flags without checking that subcommand's help.
 
+Each Ethereum fee-payer account must have exactly one submitting process. The in-process nonce lock is shared by clients in one relayer process, but it cannot coordinate replicas, manual relay commands, or external signer tools. Assign distinct fee-payer accounts to those writers, and do not run active-active replicas with the same `ETH_FEE_PAYER`.
+
 ## Run with Docker
 
 The [Dockerfile](../Dockerfile) builds the complete relayer image. Build it from the repository root:

--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -18,7 +18,13 @@ use alloy::{
 use anyhow::{Context, Result as AnyResult};
 use primitive_types::{H160, H256};
 use reqwest::Url;
-use std::{ops::Deref, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    ops::Deref,
+    str::FromStr,
+    sync::{Arc, OnceLock, Weak},
+    time::Duration,
+};
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
 pub use alloy::primitives::TxHash;
@@ -42,6 +48,31 @@ pub struct ContentMessageSubmissionError {
 /// Holds exclusive ownership of Ethereum account submissions across retries.
 pub struct SubmissionGuard {
     _guard: OwnedMutexGuard<()>,
+}
+
+// Every EthApi for the same signer on the same chain must coordinate nonce allocation, including
+// independently constructed instances in this process. Weak entries avoid
+// retaining one lock per signer forever.
+type SubmissionAccount = (u64, Address);
+type SubmissionLocks = HashMap<SubmissionAccount, Weak<Mutex<()>>>;
+
+static SUBMISSION_LOCKS: OnceLock<std::sync::Mutex<SubmissionLocks>> = OnceLock::new();
+
+fn submission_lock(chain_id: u64, public_key: Address) -> Arc<Mutex<()>> {
+    let registry = SUBMISSION_LOCKS.get_or_init(Default::default);
+    let mut locks = registry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    locks.retain(|_, lock| lock.strong_count() != 0);
+    let key = (chain_id, public_key);
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+
+    let lock = Arc::new(Mutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
 }
 
 // 2 Gwei
@@ -341,6 +372,7 @@ impl EthApi {
             .connect_ws(ws)
             .await?;
 
+        let chain_id = provider.get_chain_id().await?;
         let contracts = Contracts::new(
             provider,
             message_queue_address.into_array(),
@@ -355,7 +387,7 @@ impl EthApi {
             wallet,
             ws_max_retry,
             ws_retry_interval,
-            submission_lock: Arc::new(Mutex::new(())),
+            submission_lock: submission_lock(chain_id, public_key),
         })
     }
 
@@ -571,6 +603,17 @@ impl EthApi {
                     matches!(error, Error::ErrorSendingTransaction(_)).then_some(account_nonce);
                 ContentMessageSubmissionError { error, nonce }
             })
+    }
+
+    /// Returns whether `account_nonce` has been consumed by a mined transaction.
+    /// A nonce that only exists in the pending pool is deliberately not considered
+    /// consumed and must remain pinned for replacement retries.
+    pub async fn is_account_nonce_consumed(&self, account_nonce: u64) -> Result<bool, Error> {
+        let latest_nonce = self
+            .raw_provider()
+            .get_transaction_count(self.public_key)
+            .await?;
+        Ok(latest_nonce > account_nonce)
     }
 
     pub async fn is_message_processed(&self, nonce: [u8; 32]) -> Result<bool, Error> {
@@ -971,5 +1014,25 @@ impl Contracts {
         };
 
         Ok(status)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn submission_locks_are_shared_per_chain_and_public_key() {
+        let first_key = Address::from([1; 20]);
+        let second_key = Address::from([2; 20]);
+
+        let first = submission_lock(1, first_key);
+        let same_account = submission_lock(1, first_key);
+        let different_key = submission_lock(1, second_key);
+        let different_chain = submission_lock(2, first_key);
+
+        assert!(Arc::ptr_eq(&first, &same_account));
+        assert!(!Arc::ptr_eq(&first, &different_key));
+        assert!(!Arc::ptr_eq(&first, &different_chain));
     }
 }

--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -5,7 +5,7 @@ use alloy::{
     providers::{
         fillers::{
             BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
-            WalletFiller,
+            SimpleNonceManager, WalletFiller,
         },
         Identity, PendingTransactionBuilder, Provider, ProviderBuilder, RootProvider,
     },
@@ -18,7 +18,8 @@ use alloy::{
 use anyhow::{Context, Result as AnyResult};
 use primitive_types::{H160, H256};
 use reqwest::Url;
-use std::{ops::Deref, str::FromStr, time::Duration};
+use std::{ops::Deref, str::FromStr, sync::Arc, time::Duration};
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 pub use alloy::primitives::TxHash;
 
@@ -31,21 +32,33 @@ use abi::{
 pub mod error;
 pub use error::Error;
 
+#[derive(Debug)]
+pub struct ContentMessageSubmissionError {
+    pub error: Error,
+    /// Ethereum account nonce selected for this submission, when allocation succeeded.
+    pub nonce: Option<u64>,
+}
+
+/// Holds exclusive ownership of Ethereum account submissions across retries.
+pub struct SubmissionGuard {
+    _guard: OwnedMutexGuard<()>,
+}
+
 // 2 Gwei
 const MAX_FEE_PER_GAS: u128 = 2_000_000_000;
 // 0.5 Gwei
 const MAX_PRIORITY_FEE_PER_GAS: u128 = 500_000_000;
 
-type ProviderType = FillProvider<
+type ProviderFillers = JoinFill<
     JoinFill<
-        JoinFill<
-            Identity,
-            JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-        >,
-        WalletFiller<EthereumWallet>,
+        JoinFill<JoinFill<Identity, GasFiller>, BlobGasFiller>,
+        NonceFiller<SimpleNonceManager>,
     >,
-    RootProvider<Ethereum>,
+    ChainIdFiller,
 >;
+
+type ProviderType =
+    FillProvider<JoinFill<ProviderFillers, WalletFiller<EthereumWallet>>, RootProvider<Ethereum>>;
 
 #[derive(Clone)]
 pub struct Contracts {
@@ -255,6 +268,9 @@ pub struct EthApi {
     url: Url,
     ws_max_retry: Option<u32>,
     ws_retry_interval: Option<Duration>,
+    // Simple nonce management queries the pending nonce for every send. Serialize
+    // submissions across all EthApi clones so concurrent calls cannot reuse it.
+    submission_lock: Arc<Mutex<()>>,
 }
 
 impl EthApi {
@@ -316,6 +332,11 @@ impl EthApi {
         }
 
         let provider: ProviderType = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_gas_estimation()
+            .with_blob_gas_estimation()
+            .with_simple_nonce_management()
+            .fetch_chain_id()
             .wallet(wallet.clone())
             .connect_ws(ws)
             .await?;
@@ -334,6 +355,7 @@ impl EthApi {
             wallet,
             ws_max_retry,
             ws_retry_interval,
+            submission_lock: Arc::new(Mutex::new(())),
         })
     }
 
@@ -346,6 +368,11 @@ impl EthApi {
             ws = ws.with_retry_interval(ws_retry_interval);
         }
         let provider: ProviderType = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_gas_estimation()
+            .with_blob_gas_estimation()
+            .with_simple_nonce_management()
+            .fetch_chain_id()
             .wallet(self.wallet.clone())
             .connect_ws(ws)
             .await?;
@@ -364,12 +391,19 @@ impl EthApi {
             wallet: self.wallet.clone(),
             ws_max_retry: self.ws_max_retry,
             ws_retry_interval: self.ws_retry_interval,
+            submission_lock: self.submission_lock.clone(),
         })
     }
 
     // TODO: Don't expose provider here.
     pub fn raw_provider(&self) -> &ProviderType {
         &self.contracts.provider
+    }
+
+    pub async fn reserve_submission(&self) -> SubmissionGuard {
+        SubmissionGuard {
+            _guard: self.submission_lock.clone().lock_owned().await,
+        }
     }
 
     /// Returns the maximum block number that can be submitted as part of a
@@ -413,6 +447,7 @@ impl EthApi {
         merkle_root: [u8; 32],
         proof: Vec<u8>,
     ) -> Result<PendingTransactionBuilder<Ethereum>, Error> {
+        let _submission_guard = self.submission_lock.lock().await;
         self.contracts
             .provide_merkle_root(
                 U256::from(block_number),
@@ -423,6 +458,7 @@ impl EthApi {
     }
 
     pub async fn send_challenge_root(&self) -> Result<TxHash, Error> {
+        let _submission_guard = self.submission_lock.lock().await;
         self.contracts.challenge_root().await
     }
 
@@ -489,6 +525,7 @@ impl EthApi {
     #[allow(clippy::too_many_arguments)]
     pub async fn provide_content_message(
         &self,
+        _submission_guard: &SubmissionGuard,
         block_number: u32,
         total_leaves: u32,
         leaf_index: u32,
@@ -497,7 +534,21 @@ impl EthApi {
         receiver: [u8; 20],
         payload: Vec<u8>,
         proof: Vec<[u8; 32]>,
-    ) -> Result<TxHash, Error> {
+        account_nonce: Option<u64>,
+    ) -> Result<(TxHash, u64), ContentMessageSubmissionError> {
+        let account_nonce = match account_nonce {
+            Some(nonce) => nonce,
+            None => self
+                .raw_provider()
+                .get_transaction_count(self.public_key)
+                .pending()
+                .await
+                .map_err(|error| ContentMessageSubmissionError {
+                    error: error.into(),
+                    nonce: None,
+                })?,
+        };
+
         self.contracts
             .provide_content_message(
                 U256::from(block_number),
@@ -508,8 +559,18 @@ impl EthApi {
                 Address::from(receiver),
                 Bytes::from(payload),
                 proof.into_iter().map(B256::from).collect(),
+                account_nonce,
             )
             .await
+            .map(|tx_hash| (tx_hash, account_nonce))
+            .map_err(|error| {
+                // Only pin the nonce after eth_sendRawTransaction was attempted.
+                // Pre-send failures must re-query pending nonce on retry because
+                // another serialized submission may use this nonce meanwhile.
+                let nonce =
+                    matches!(error, Error::ErrorSendingTransaction(_)).then_some(account_nonce);
+                ContentMessageSubmissionError { error, nonce }
+            })
     }
 
     pub async fn is_message_processed(&self, nonce: [u8; 32]) -> Result<bool, Error> {
@@ -744,6 +805,7 @@ impl Contracts {
         destination: Address,
         payload: Bytes,
         proof: Vec<B256>,
+        account_nonce: u64,
     ) -> Result<TxHash, Error> {
         log::trace!(
             "provide_content_message: block_number = {block_number}, total_leaves = {total_leaves}, leaf_index = {leaf_index}, nonce = {nonce}, source = {source}, destination = {destination}, payload = {payload}, proof = {proof:?}",
@@ -800,6 +862,7 @@ impl Contracts {
             .unwrap_or(MAX_PRIORITY_FEE_PER_GAS);
 
         let call = call
+            .nonce(account_nonce)
             .max_fee_per_gas(max_fee_per_gas)
             .max_priority_fee_per_gas(max_priority_fee_per_gas);
 

--- a/relayer/src/message_relayer/common/ethereum/message_sender.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_sender.rs
@@ -1,5 +1,8 @@
-use crate::{common::BASE_RETRY_DELAY, message_relayer::common::RelayedMerkleRoot};
-use ethereum_client::{abi::IMessageQueue::IMessageQueueErrors, EthApi, TxHash};
+use crate::{
+    common::{is_transport_error_recoverable, BASE_RETRY_DELAY},
+    message_relayer::common::RelayedMerkleRoot,
+};
+use ethereum_client::{abi::IMessageQueue::IMessageQueueErrors, EthApi, SubmissionGuard, TxHash};
 use gear_rpc_client::dto::{MerkleProof, Message};
 use prometheus::{Gauge, IntCounter};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
@@ -16,6 +19,7 @@ pub struct Request {
 pub enum Response {
     MessageAlreadyProcessed(Uuid),
     ProcessingStarted(TxHash, Uuid),
+    Failed(Uuid, String),
 }
 
 pub struct MessageSenderIo {
@@ -103,103 +107,191 @@ impl MessageSender {
 
 async fn task(
     mut this: MessageSender,
-    mut channel_message_data: UnboundedReceiver<Request>,
-    channel_tx_data: UnboundedSender<Response>,
+    mut requests: UnboundedReceiver<Request>,
+    responses: UnboundedSender<Response>,
 ) {
-    if let Ok(fee_payer_balance) = this.eth_api.get_approx_balance().await {
-        this.metrics.fee_payer_balance.set(fee_payer_balance);
+    match this.eth_api.get_approx_balance().await {
+        Ok(fee_payer_balance) => this.metrics.fee_payer_balance.set(fee_payer_balance),
+        Err(e) => log::warn!("Failed to update Ethereum fee payer balance metric: {e}"),
     }
 
-    loop {
-        let Err(e) = task_inner(&mut this, &mut channel_message_data, &channel_tx_data).await
-        else {
-            break;
-        };
+    while let Some(request) = requests.recv().await {
+        let submission_guard = this.eth_api.reserve_submission().await;
+        let mut account_nonce = None;
+        loop {
+            match process_request(
+                &mut this,
+                &request,
+                &submission_guard,
+                &mut account_nonce,
+                &responses,
+            )
+            .await
+            {
+                Ok(true) => break,
+                Ok(false) => return,
+                Err(e) => {
+                    let delay = BASE_RETRY_DELAY * 6;
+                    log::error!(
+                        r#"Ethereum message sender failed: "{e:?}". Retrying the same request in {delay:?}""#,
+                    );
 
-        let delay = BASE_RETRY_DELAY * 6;
-        log::error!(r#"Ethereum message sender failed: "{e:?}". Retrying in {delay:?}"#,);
-
-        tokio::time::sleep(delay).await;
-        match this.eth_api.reconnect().await {
-            Ok(eth_api) => {
-                this.eth_api = eth_api;
-                log::debug!("EthApi successfully reconnected");
-            }
-
-            Err(e) => {
-                log::error!(r#"Failed to reconnect to Ethereum: "{e:?}""#);
-                break;
+                    loop {
+                        tokio::time::sleep(delay).await;
+                        match this.eth_api.reconnect().await {
+                            Ok(eth_api) => {
+                                this.eth_api = eth_api;
+                                log::debug!("EthApi successfully reconnected");
+                                break;
+                            }
+                            Err(e) => {
+                                log::error!(
+                                    r#"Failed to reconnect to Ethereum: "{e:?}". Retrying in {delay:?}""#
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
     }
 }
 
-async fn task_inner(
+/// Processes one request. `Ok(true)` means the request reached a durable outcome,
+/// while `Ok(false)` means the response channel was closed and the task should stop.
+async fn process_request(
     this: &mut MessageSender,
-    requests: &mut UnboundedReceiver<Request>,
+    request: &Request,
+    submission_guard: &SubmissionGuard,
+    account_nonce: &mut Option<u64>,
     responses: &UnboundedSender<Response>,
-) -> anyhow::Result<()> {
-    while let Some(request) = requests.recv().await {
-        let Request {
-            message,
-            relayed_root,
-            proof,
-            tx_uuid,
-        } = request;
+) -> anyhow::Result<bool> {
+    let Request {
+        message,
+        relayed_root,
+        proof,
+        tx_uuid,
+    } = request;
 
-        let tx_hash = match this
-            .eth_api
-            .provide_content_message(
-                relayed_root.block.0,
-                proof.num_leaves as u32,
-                proof.leaf_index as u32,
-                message.nonce_be,
-                message.source,
-                message.destination,
-                message.payload.to_vec(),
-                proof.proof,
-            )
-            .await
-        {
-            Ok(tx_hash) => tx_hash,
-            Err(ethereum_client::Error::MessageQueue(
-                IMessageQueueErrors::MessageAlreadyProcessed(_),
-            )) => {
+    let tx_hash = match this
+        .eth_api
+        .provide_content_message(
+            submission_guard,
+            relayed_root.block.0,
+            proof.num_leaves as u32,
+            proof.leaf_index as u32,
+            message.nonce_be,
+            message.source,
+            message.destination,
+            message.payload.to_vec(),
+            proof.proof.clone(),
+            *account_nonce,
+        )
+        .await
+    {
+        Ok((tx_hash, nonce)) => {
+            *account_nonce = Some(nonce);
+            tx_hash
+        }
+        Err(submission) => {
+            if let Some(nonce) = submission.nonce {
+                *account_nonce = Some(nonce);
+            }
+
+            if matches!(
+                &submission.error,
+                ethereum_client::Error::MessageQueue(IMessageQueueErrors::MessageAlreadyProcessed(
+                    _
+                ))
+            ) {
                 log::info!(
                     "Message with nonce {} already processed, skipping: tx_uuid = {}",
                     hex::encode(message.nonce_be),
                     tx_uuid
                 );
                 if responses
-                    .send(Response::MessageAlreadyProcessed(tx_uuid))
+                    .send(Response::MessageAlreadyProcessed(*tx_uuid))
                     .is_err()
                 {
                     log::info!("Response channel closed, exiting");
-                    return Ok(());
+                    return Ok(false);
                 }
-                continue;
+                return Ok(true);
             }
-            Err(e) => return Err(anyhow::anyhow!("Failed to provide content message: {e}")),
-        };
 
-        log::info!(
-            "Message with nonce {} relaying started: tx_hash = {tx_hash}",
-            hex::encode(message.nonce_be)
-        );
+            let retry_same_nonce = match &submission.error {
+                ethereum_client::Error::ErrorSendingTransaction(error) => {
+                    is_same_nonce_retry_error(&error.to_string())
+                }
+                _ => false,
+            };
+            let error = anyhow::Error::new(submission.error);
+            if retry_same_nonce || is_transport_error_recoverable(&error) {
+                return Err(error);
+            }
 
-        this.metrics.total_submissions.inc();
-
-        if responses
-            .send(Response::ProcessingStarted(tx_hash, tx_uuid))
-            .is_err()
-        {
-            log::info!("Response channel closed, exiting");
-            return Ok(());
+            let error = format!("Failed to provide content message: {error}");
+            log::error!("{error}");
+            if responses.send(Response::Failed(*tx_uuid, error)).is_err() {
+                log::info!("Response channel closed, exiting");
+                return Ok(false);
+            }
+            return Ok(true);
         }
+    };
 
-        let fee_payer_balance = this.eth_api.get_approx_balance().await?;
-        this.metrics.fee_payer_balance.set(fee_payer_balance);
+    log::info!(
+        "Message with nonce {} relaying started: tx_hash = {tx_hash}",
+        hex::encode(message.nonce_be)
+    );
+
+    this.metrics.total_submissions.inc();
+
+    if responses
+        .send(Response::ProcessingStarted(tx_hash, *tx_uuid))
+        .is_err()
+    {
+        log::info!("Response channel closed, exiting");
+        return Ok(false);
     }
 
-    Ok(())
+    match this.eth_api.get_approx_balance().await {
+        Ok(fee_payer_balance) => this.metrics.fee_payer_balance.set(fee_payer_balance),
+        Err(e) => log::warn!("Failed to update Ethereum fee payer balance metric: {e}"),
+    }
+
+    Ok(true)
+}
+
+fn is_same_nonce_retry_error(error: &str) -> bool {
+    let error = error.to_ascii_lowercase();
+    error.contains("already known")
+        || error.contains("nonce too low")
+        || error.contains("replacement transaction underpriced")
+        || error.contains("replacement underpriced")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_same_nonce_retry_error;
+
+    #[test]
+    fn classifies_same_nonce_retry_errors() {
+        for error in [
+            "already known",
+            "nonce too low",
+            "replacement transaction underpriced",
+            "replacement underpriced",
+        ] {
+            assert!(is_same_nonce_retry_error(error), "{error}");
+        }
+
+        for error in [
+            "insufficient funds for gas * price + value",
+            "max fee per gas less than block base fee",
+            "intrinsic gas too low",
+        ] {
+            assert!(!is_same_nonce_retry_error(error), "{error}");
+        }
+    }
 }

--- a/relayer/src/message_relayer/common/ethereum/message_sender.rs
+++ b/relayer/src/message_relayer/common/ethereum/message_sender.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 use uuid::Uuid;
 
+#[derive(Clone)]
 pub struct Request {
     pub message: Message,
     pub relayed_root: RelayedMerkleRoot,
@@ -96,7 +97,12 @@ impl MessageSender {
         let (requests_tx, requests_rx) = mpsc::unbounded_channel();
         let (responses_tx, responses_rx) = mpsc::unbounded_channel();
 
-        tokio::task::spawn(task(self, requests_rx, responses_tx));
+        tokio::task::spawn(task(
+            self,
+            requests_tx.downgrade(),
+            requests_rx,
+            responses_tx,
+        ));
 
         MessageSenderIo {
             requests: requests_tx,
@@ -107,6 +113,7 @@ impl MessageSender {
 
 async fn task(
     mut this: MessageSender,
+    retry_requests: mpsc::WeakUnboundedSender<Request>,
     mut requests: UnboundedReceiver<Request>,
     responses: UnboundedSender<Response>,
 ) {
@@ -116,13 +123,19 @@ async fn task(
     }
 
     while let Some(request) = requests.recv().await {
-        let submission_guard = this.eth_api.reserve_submission().await;
+        let mut submission_guard = None;
         let mut account_nonce = None;
         loop {
+            if submission_guard.is_none() {
+                submission_guard = Some(this.eth_api.reserve_submission().await);
+            }
+
             match process_request(
                 &mut this,
                 &request,
-                &submission_guard,
+                submission_guard
+                    .as_ref()
+                    .expect("submission guard was just reserved"),
                 &mut account_nonce,
                 &responses,
             )
@@ -131,10 +144,36 @@ async fn task(
                 Ok(true) => break,
                 Ok(false) => return,
                 Err(e) => {
+                    // No nonce needs protecting when submission did not reach
+                    // eth_sendRawTransaction, or when a stale nonce was reset.
+                    // Release the guard while waiting so other Ethereum work is
+                    // not blocked by a transient contract state indefinitely.
+                    if account_nonce.is_none() {
+                        drop(submission_guard.take());
+                    }
+
                     let delay = BASE_RETRY_DELAY * 6;
                     log::error!(
                         r#"Ethereum message sender failed: "{e:?}". Retrying the same request in {delay:?}""#,
                     );
+
+                    if account_nonce.is_none() && is_retryable_contract_submission(&e) {
+                        // Paused/challenged messages must not head-of-line block
+                        // governance messages that are allowed to bypass those states.
+                        let request = request.clone();
+                        let retry_requests = retry_requests.clone();
+                        tokio::spawn(async move {
+                            tokio::time::sleep(delay).await;
+                            let Some(retry_requests) = retry_requests.upgrade() else {
+                                log::info!("Message sender request channel closed before retry");
+                                return;
+                            };
+                            if retry_requests.send(request).is_err() {
+                                log::info!("Message sender request channel closed before retry");
+                            }
+                        });
+                        break;
+                    }
 
                     loop {
                         tokio::time::sleep(delay).await;
@@ -204,19 +243,75 @@ async fn process_request(
                     _
                 ))
             ) {
-                log::info!(
-                    "Message with nonce {} already processed, skipping: tx_uuid = {}",
-                    hex::encode(message.nonce_be),
-                    tx_uuid
-                );
-                if responses
-                    .send(Response::MessageAlreadyProcessed(*tx_uuid))
-                    .is_err()
-                {
-                    log::info!("Response channel closed, exiting");
-                    return Ok(false);
+                return Ok(report_already_processed(
+                    message.nonce_be,
+                    *tx_uuid,
+                    responses,
+                ));
+            }
+
+            let nonce_too_low = match &submission.error {
+                ethereum_client::Error::ErrorSendingTransaction(error) => {
+                    is_nonce_too_low_error(&error.to_string())
                 }
-                return Ok(true);
+                _ => false,
+            };
+            if nonce_too_low {
+                match this.eth_api.is_message_processed(message.nonce_be).await {
+                    Ok(true) => {
+                        return Ok(report_already_processed(
+                            message.nonce_be,
+                            *tx_uuid,
+                            responses,
+                        ));
+                    }
+                    Ok(false) => {
+                        let Some(pinned_nonce) = *account_nonce else {
+                            return Err(anyhow::anyhow!(
+                                "nonce-too-low submission error did not preserve its account nonce"
+                            ));
+                        };
+
+                        match this.eth_api.is_account_nonce_consumed(pinned_nonce).await {
+                            Ok(true) => {
+                                log::warn!(
+                                    concat!(
+                                        "Pinned Ethereum account nonce {} was consumed, but message ",
+                                        "{} is not processed; resetting the account nonce before retry"
+                                    ),
+                                    pinned_nonce,
+                                    hex::encode(message.nonce_be),
+                                );
+                                *account_nonce = None;
+                            }
+                            Ok(false) => {
+                                log::info!(
+                                    concat!(
+                                        "Pinned Ethereum account nonce {} is still pending; retaining ",
+                                        "it while retrying message {}"
+                                    ),
+                                    pinned_nonce,
+                                    hex::encode(message.nonce_be),
+                                );
+                            }
+                            Err(reconciliation_error) => {
+                                return Err(anyhow::Error::new(reconciliation_error).context(
+                                    format!(
+                                        "failed to check pinned Ethereum account nonce {} while reconciling message {}",
+                                        pinned_nonce,
+                                        hex::encode(message.nonce_be),
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                    Err(reconciliation_error) => {
+                        return Err(anyhow::Error::new(reconciliation_error).context(format!(
+                            "failed to reconcile message {} after Ethereum account nonce was too low",
+                            hex::encode(message.nonce_be),
+                        )));
+                    }
+                }
             }
 
             let retry_same_nonce = match &submission.error {
@@ -225,8 +320,14 @@ async fn process_request(
                 }
                 _ => false,
             };
+            let retry_message_queue = match &submission.error {
+                ethereum_client::Error::MessageQueue(error) => {
+                    is_retryable_message_queue_error(error)
+                }
+                _ => false,
+            };
             let error = anyhow::Error::new(submission.error);
-            if retry_same_nonce || is_transport_error_recoverable(&error) {
+            if retry_same_nonce || retry_message_queue || is_transport_error_recoverable(&error) {
                 return Err(error);
             }
 
@@ -263,17 +364,62 @@ async fn process_request(
     Ok(true)
 }
 
+fn report_already_processed(
+    message_nonce: [u8; 32],
+    tx_uuid: Uuid,
+    responses: &UnboundedSender<Response>,
+) -> bool {
+    log::info!(
+        "Message with nonce {} already processed, skipping: tx_uuid = {}",
+        hex::encode(message_nonce),
+        tx_uuid,
+    );
+    if responses
+        .send(Response::MessageAlreadyProcessed(tx_uuid))
+        .is_err()
+    {
+        log::info!("Response channel closed, exiting");
+        return false;
+    }
+    true
+}
+
+fn is_nonce_too_low_error(error: &str) -> bool {
+    error.to_ascii_lowercase().contains("nonce too low")
+}
+
 fn is_same_nonce_retry_error(error: &str) -> bool {
     let error = error.to_ascii_lowercase();
     error.contains("already known")
-        || error.contains("nonce too low")
+        || is_nonce_too_low_error(&error)
         || error.contains("replacement transaction underpriced")
         || error.contains("replacement underpriced")
 }
 
+fn is_retryable_contract_submission(error: &anyhow::Error) -> bool {
+    matches!(
+        error.downcast_ref::<ethereum_client::Error>(),
+        Some(ethereum_client::Error::MessageQueue(error))
+            if is_retryable_message_queue_error(error)
+    )
+}
+
+fn is_retryable_message_queue_error(error: &IMessageQueueErrors) -> bool {
+    matches!(
+        error,
+        IMessageQueueErrors::ChallengeRoot(_)
+            | IMessageQueueErrors::EmergencyStop(_)
+            | IMessageQueueErrors::EnforcedPause(_)
+            | IMessageQueueErrors::MerkleRootDelayNotPassed(_)
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use super::is_same_nonce_retry_error;
+    use super::{
+        is_nonce_too_low_error, is_retryable_message_queue_error, is_same_nonce_retry_error,
+    };
+    use ethereum_client::abi::IMessageQueue::{self, IMessageQueueErrors};
 
     #[test]
     fn classifies_same_nonce_retry_errors() {
@@ -293,5 +439,29 @@ mod tests {
         ] {
             assert!(!is_same_nonce_retry_error(error), "{error}");
         }
+    }
+
+    #[test]
+    fn identifies_nonce_too_low_for_reconciliation() {
+        assert!(is_nonce_too_low_error("Nonce Too Low"));
+        assert!(!is_nonce_too_low_error("already known"));
+    }
+
+    #[test]
+    fn classifies_transient_message_queue_errors() {
+        for error in [
+            IMessageQueueErrors::ChallengeRoot(IMessageQueue::ChallengeRoot {}),
+            IMessageQueueErrors::EmergencyStop(IMessageQueue::EmergencyStop {}),
+            IMessageQueueErrors::EnforcedPause(IMessageQueue::EnforcedPause {}),
+            IMessageQueueErrors::MerkleRootDelayNotPassed(
+                IMessageQueue::MerkleRootDelayNotPassed {},
+            ),
+        ] {
+            assert!(is_retryable_message_queue_error(&error), "{error:?}");
+        }
+
+        let terminal =
+            IMessageQueueErrors::InvalidMerkleProof(IMessageQueue::InvalidMerkleProof {});
+        assert!(!is_retryable_message_queue_error(&terminal));
     }
 }

--- a/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
+++ b/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
@@ -1,7 +1,4 @@
-use crate::{
-    common::{self, BASE_RETRY_DELAY, MAX_RETRIES},
-    rpc,
-};
+use crate::common::{self, BASE_RETRY_DELAY, MAX_RETRIES};
 use alloy::providers::{
     PendingTransactionBuilder, PendingTransactionError, Provider, RootProvider,
 };
@@ -23,9 +20,17 @@ pub struct StatusFetcher {
     metrics: Metrics,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct Request {
     pub tx_uuid: Uuid,
     pub tx_hash: TxHash,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TrackedRequest {
+    tx_uuid: Uuid,
+    tx_hash: TxHash,
+    bridge_nonce: Option<[u8; 32]>,
 }
 
 pub enum Response {
@@ -39,22 +44,56 @@ const TX_VISIBILITY_RECHECK_DELAY: Duration = Duration::from_secs(15);
 const TX_VISIBILITY_RECHECKS: usize = 3;
 
 enum TxWatchError {
-    Receipt(Uuid, TxHash, PendingTransactionError),
-    VisibilityCheck(Uuid, TxHash),
+    Receipt(TrackedRequest, PendingTransactionError),
+    VisibilityCheck(TrackedRequest),
 }
 
-type TxWatchResult = Result<(Uuid, alloy::rpc::types::TransactionReceipt), TxWatchError>;
+enum Visibility {
+    Visible,
+    DefinitelyAbsent,
+    Inconclusive,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum WatcherFailure {
+    ConfirmationTimeout,
+    Infrastructure,
+}
+
+type TxWatchResult = Result<(TrackedRequest, alloy::rpc::types::TransactionReceipt), TxWatchError>;
 type TxWatch = BoxFuture<'static, TxWatchResult>;
+type VisibilityCheck = BoxFuture<'static, (TrackedRequest, Visibility, EthApi)>;
+type Reconciliation = BoxFuture<'static, (TrackedRequest, Result<bool, String>, EthApi)>;
 
 pub struct StatusFetcherIo {
-    requests: UnboundedSender<Request>,
+    requests: UnboundedSender<TrackedRequest>,
     responses: UnboundedReceiver<Response>,
 }
 
 impl StatusFetcherIo {
     pub fn send_request(&self, tx_uuid: Uuid, tx_hash: TxHash) -> bool {
-        let request = Request { tx_uuid, tx_hash };
-        self.requests.send(request).is_ok()
+        self.requests
+            .send(TrackedRequest {
+                tx_uuid,
+                tx_hash,
+                bridge_nonce: None,
+            })
+            .is_ok()
+    }
+
+    pub fn send_request_with_bridge_nonce(
+        &self,
+        tx_uuid: Uuid,
+        tx_hash: TxHash,
+        bridge_nonce: [u8; 32],
+    ) -> bool {
+        self.requests
+            .send(TrackedRequest {
+                tx_uuid,
+                tx_hash,
+                bridge_nonce: Some(bridge_nonce),
+            })
+            .is_ok()
     }
 
     pub async fn recv_message(&mut self) -> Option<Response> {
@@ -122,7 +161,7 @@ impl StatusFetcher {
 
 async fn task(
     mut this: StatusFetcher,
-    mut channel: UnboundedReceiver<Request>,
+    mut channel: UnboundedReceiver<TrackedRequest>,
     responses: UnboundedSender<Response>,
 ) {
     let mut attempts = 0;
@@ -160,10 +199,13 @@ async fn task(
 
 async fn task_inner(
     this: &mut StatusFetcher,
-    channel: &mut UnboundedReceiver<Request>,
+    channel: &mut UnboundedReceiver<TrackedRequest>,
     responses: &UnboundedSender<Response>,
 ) -> anyhow::Result<()> {
     let mut txs: FuturesUnordered<TxWatch> = FuturesUnordered::new();
+    let mut visibility_checks: FuturesUnordered<VisibilityCheck> = FuturesUnordered::new();
+    let mut reconciliations: FuturesUnordered<Reconciliation> = FuturesUnordered::new();
+
     loop {
         tokio::select! {
             message = channel.recv() => {
@@ -172,21 +214,13 @@ async fn task_inner(
                     return Ok(());
                 };
 
-                let Request { tx_uuid, tx_hash, .. } = request;
-
                 this.metrics.pending_tx_count.inc();
-
-                txs.push(watch_tx(
-                    this.eth_api.raw_provider().root().clone(),
-                    tx_uuid,
-                    tx_hash,
-                    this.confirmations,
-                ));
+                watch_with_api(&this.eth_api, &mut txs, request, this.confirmations);
             }
 
             Some(tx) = txs.next(), if !txs.is_empty() => {
                 match tx {
-                    Ok((uuid, receipt)) => {
+                    Ok((request, receipt)) => {
                         let tx_hash = receipt.transaction_hash;
                         let gas_used = receipt.gas_used;
 
@@ -201,46 +235,114 @@ async fn task_inner(
                             this.metrics.max_gas_used.set(gas_used);
                         }
 
-                        this.metrics.pending_tx_count.dec();
                         if receipt.status() {
-                            responses.send(Response::Success(uuid, tx_hash))?;
+                            this.metrics.pending_tx_count.dec();
+                            responses.send(Response::Success(request.tx_uuid, tx_hash))?;
                         } else {
                             this.metrics.total_failed_txs.inc();
-                            let error = format!("Ethereum transaction {tx_hash} reverted");
-                            log::error!("{error}");
-                            responses.send(Response::Failed(uuid, error))?;
+                            // A different submission can process the bridge message while this
+                            // transaction is pending. Reconcile against finalized bridge state;
+                            // an unprocessed message follows the bounded dropped-transaction retry.
+                            if request.bridge_nonce.is_some() {
+                                reconcile_reverted_receipt(
+                                    this.eth_api.clone(),
+                                    &mut reconciliations,
+                                    request,
+                                    Duration::ZERO,
+                                );
+                            } else {
+                                // Preserve the legacy two-argument API for callers that do not
+                                // have the bridge nonce; they still receive a bounded retry.
+                                this.metrics.pending_tx_count.dec();
+                                responses.send(reverted_receipt_response(request, false))?;
+                            }
                         }
                     }
-                    Err(TxWatchError::VisibilityCheck(uuid, tx_hash)) => {
-                        check_transaction_visibility(this, &mut txs, responses, uuid, tx_hash).await?;
-                    }
-                    Err(TxWatchError::Receipt(uuid, tx_hash, e))
-                        if is_timeout_error(&e) =>
-                    {
+                    Err(TxWatchError::VisibilityCheck(request)) => {
                         log::warn!(
-                            "Timed out while polling transaction {tx_hash}: {e}. Checking whether it is still visible"
+                            "Timed out while polling transaction {}. Checking whether it is still visible",
+                            request.tx_hash
                         );
-                        check_transaction_visibility(this, &mut txs, responses, uuid, tx_hash).await?;
+                        start_visibility_check(this.eth_api.clone(), &mut visibility_checks, request);
                     }
-                    Err(TxWatchError::Receipt(uuid, tx_hash, e))
-                        if rpc::is_recoverable_error_text(&e) =>
-                    {
-                        log::warn!("Recoverable error while polling transaction {tx_hash}: {e}. Reconnecting and continuing to watch");
-                        tokio::time::sleep(BASE_RETRY_DELAY).await;
-                        match this.eth_api.reconnect().await {
-                            Ok(eth_api) => this.eth_api = eth_api,
-                            Err(reconnect_error) => log::warn!(
-                                "Failed to reconnect while watching transaction {tx_hash}: {reconnect_error}"
+                    Err(TxWatchError::Receipt(request, error)) => {
+                        // PendingTransactionError describes watcher/transport infrastructure, not
+                        // EVM execution. Do not turn it into a terminal bridge-message failure.
+                        match classify_watcher_failure(&error) {
+                            WatcherFailure::ConfirmationTimeout => log::warn!(
+                                "Timed out while polling transaction {}: {error}. Checking whether it is still visible",
+                                request.tx_hash
+                            ),
+                            WatcherFailure::Infrastructure => log::warn!(
+                                "Transaction watcher infrastructure failed for {}: {error}. Checking visibility before continuing",
+                                request.tx_hash
                             ),
                         }
-                        rewatch(this, &mut txs, uuid, tx_hash);
+                        start_visibility_check(this.eth_api.clone(), &mut visibility_checks, request);
                     }
-                    Err(TxWatchError::Receipt(uuid, tx_hash, e)) => {
+                }
+            }
+
+            Some((request, visibility, eth_api)) = visibility_checks.next(), if !visibility_checks.is_empty() => {
+                match visibility {
+                    Visibility::Visible => {
+                        log::info!(
+                            "Transaction {} is still visible; continuing to watch",
+                            request.tx_hash
+                        );
+                        watch_with_api(&eth_api, &mut txs, request, this.confirmations);
+                    }
+                    Visibility::DefinitelyAbsent => {
                         this.metrics.pending_tx_count.dec();
                         this.metrics.total_failed_txs.inc();
-                        let error = format!("Failed to get transaction {tx_hash} status: {e}");
+                        let error = format!(
+                            "Ethereum transaction {} disappeared before receiving confirmations",
+                            request.tx_hash
+                        );
                         log::error!("{error}");
-                        responses.send(Response::Failed(uuid, error))?;
+                        responses.send(Response::Dropped(request.tx_uuid, error))?;
+                    }
+                    Visibility::Inconclusive => {
+                        log::warn!(
+                            "Transaction {} visibility remained inconclusive; continuing to watch without resubmitting",
+                            request.tx_hash
+                        );
+                        watch_with_api(&eth_api, &mut txs, request, this.confirmations);
+                    }
+                }
+            }
+
+            Some((request, processed, eth_api)) = reconciliations.next(), if !reconciliations.is_empty() => {
+                match processed {
+                    Ok(true) => {
+                        this.metrics.pending_tx_count.dec();
+                        log::info!(
+                            "Ethereum transaction {} reverted, but bridge message nonce {} is already processed",
+                            request.tx_hash,
+                            hex::encode(request.bridge_nonce.expect("reconciliation requires bridge nonce")),
+                        );
+                        responses.send(reverted_receipt_response(request, true))?;
+                    }
+                    Ok(false) => {
+                        this.metrics.pending_tx_count.dec();
+                        let response = reverted_receipt_response(request, false);
+                        if let Response::Dropped(_, ref error) = response {
+                            log::error!("{error}");
+                        }
+                        responses.send(response)?;
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "Failed to reconcile reverted transaction {} against bridge message nonce {}: {error}. Retrying",
+                            request.tx_hash,
+                            hex::encode(request.bridge_nonce.expect("reconciliation requires bridge nonce")),
+                        );
+                        reconcile_reverted_receipt(
+                            eth_api,
+                            &mut reconciliations,
+                            request,
+                            BASE_RETRY_DELAY,
+                        );
                     }
                 }
             }
@@ -248,105 +350,179 @@ async fn task_inner(
     }
 }
 
-fn rewatch(this: &StatusFetcher, txs: &mut FuturesUnordered<TxWatch>, uuid: Uuid, tx_hash: TxHash) {
+fn watch_with_api(
+    eth_api: &EthApi,
+    txs: &mut FuturesUnordered<TxWatch>,
+    request: TrackedRequest,
+    confirmations: u64,
+) {
     txs.push(watch_tx(
-        this.eth_api.raw_provider().root().clone(),
-        uuid,
-        tx_hash,
-        this.confirmations,
+        eth_api.raw_provider().root().clone(),
+        request,
+        confirmations,
     ));
 }
 
-async fn check_transaction_visibility(
-    this: &mut StatusFetcher,
-    txs: &mut FuturesUnordered<TxWatch>,
-    responses: &UnboundedSender<Response>,
-    uuid: Uuid,
-    tx_hash: TxHash,
-) -> anyhow::Result<()> {
-    let mut definitely_absent = true;
+fn start_visibility_check(
+    eth_api: EthApi,
+    checks: &mut FuturesUnordered<VisibilityCheck>,
+    request: TrackedRequest,
+) {
+    checks.push(check_transaction_visibility(eth_api, request));
+}
 
-    for attempt in 1..=TX_VISIBILITY_RECHECKS {
-        let transaction = this
-            .eth_api
-            .raw_provider()
-            .get_transaction_by_hash(tx_hash)
-            .await;
-        let receipt = this
-            .eth_api
-            .raw_provider()
-            .get_transaction_receipt(tx_hash)
-            .await;
+fn check_transaction_visibility(mut eth_api: EthApi, request: TrackedRequest) -> VisibilityCheck {
+    Box::pin(async move {
+        let mut definitely_absent = true;
 
-        match (transaction, receipt) {
-            (Ok(Some(_)), _) | (_, Ok(Some(_))) => {
-                log::info!("Transaction {tx_hash} is still visible; continuing to watch");
-                rewatch(this, txs, uuid, tx_hash);
-                return Ok(());
-            }
-            (Ok(None), Ok(None)) => {
-                log::warn!(
-                    "Transaction {tx_hash} was absent during visibility check {attempt}/{TX_VISIBILITY_RECHECKS}"
-                );
-                if attempt < TX_VISIBILITY_RECHECKS {
-                    match this.eth_api.reconnect().await {
-                        Ok(eth_api) => this.eth_api = eth_api,
-                        Err(reconnect_error) => log::warn!(
-                            "Failed to reconnect between visibility checks for transaction {tx_hash}: {reconnect_error}"
-                        ),
-                    }
+        for attempt in 1..=TX_VISIBILITY_RECHECKS {
+            let (transaction, receipt) = tokio::join!(
+                eth_api
+                    .raw_provider()
+                    .get_transaction_by_hash(request.tx_hash),
+                eth_api
+                    .raw_provider()
+                    .get_transaction_receipt(request.tx_hash),
+            );
+
+            match (transaction, receipt) {
+                (Ok(Some(_)), _) | (_, Ok(Some(_))) => {
+                    return (request, Visibility::Visible, eth_api);
+                }
+                (Ok(None), Ok(None)) => {
+                    log::warn!(
+                        "Transaction {} was absent during visibility check {attempt}/{TX_VISIBILITY_RECHECKS}",
+                        request.tx_hash
+                    );
+                }
+                (transaction, receipt) => {
+                    definitely_absent = false;
+                    log::warn!(
+                        "Transaction {} visibility check {attempt}/{TX_VISIBILITY_RECHECKS} was inconclusive: transaction={transaction:?}, receipt={receipt:?}",
+                        request.tx_hash
+                    );
                 }
             }
-            (transaction, receipt) => {
-                definitely_absent = false;
-                log::warn!(
-                    "Transaction {tx_hash} visibility check {attempt}/{TX_VISIBILITY_RECHECKS} was inconclusive: transaction={transaction:?}, receipt={receipt:?}"
-                );
-                match this.eth_api.reconnect().await {
-                    Ok(eth_api) => this.eth_api = eth_api,
-                    Err(reconnect_error) => log::warn!(
-                        "Failed to reconnect while checking transaction {tx_hash}: {reconnect_error}"
+
+            if attempt < TX_VISIBILITY_RECHECKS {
+                match eth_api.reconnect().await {
+                    Ok(reconnected) => eth_api = reconnected,
+                    Err(error) => log::warn!(
+                        "Failed to reconnect while checking transaction {}: {error}",
+                        request.tx_hash
                     ),
                 }
+                tokio::time::sleep(TX_VISIBILITY_RECHECK_DELAY).await;
             }
         }
 
-        if attempt < TX_VISIBILITY_RECHECKS {
-            tokio::time::sleep(TX_VISIBILITY_RECHECK_DELAY).await;
+        let visibility = if definitely_absent {
+            Visibility::DefinitelyAbsent
+        } else {
+            Visibility::Inconclusive
+        };
+        (request, visibility, eth_api)
+    })
+}
+
+fn reconcile_reverted_receipt(
+    mut eth_api: EthApi,
+    reconciliations: &mut FuturesUnordered<Reconciliation>,
+    request: TrackedRequest,
+    delay: Duration,
+) {
+    reconciliations.push(Box::pin(async move {
+        tokio::time::sleep(delay).await;
+        let bridge_nonce = request
+            .bridge_nonce
+            .expect("reconciliation requires bridge nonce");
+        let processed = eth_api
+            .is_message_processed(bridge_nonce)
+            .await
+            .map_err(|error| error.to_string());
+
+        if processed.is_err() {
+            match eth_api.reconnect().await {
+                Ok(reconnected) => eth_api = reconnected,
+                Err(error) => log::warn!(
+                    "Failed to reconnect after bridge-state reconciliation error for transaction {}: {error}",
+                    request.tx_hash
+                ),
+            }
         }
-    }
 
-    if definitely_absent {
-        this.metrics.pending_tx_count.dec();
-        this.metrics.total_failed_txs.inc();
-        let error =
-            format!("Ethereum transaction {tx_hash} disappeared before receiving confirmations");
-        log::error!("{error}");
-        responses.send(Response::Dropped(uuid, error))?;
+        (request, processed, eth_api)
+    }));
+}
+
+fn reverted_receipt_response(request: TrackedRequest, processed: bool) -> Response {
+    if processed {
+        Response::Success(request.tx_uuid, request.tx_hash)
     } else {
-        log::warn!(
-            "Transaction {tx_hash} visibility remained inconclusive; continuing to watch without resubmitting"
-        );
-        rewatch(this, txs, uuid, tx_hash);
+        Response::Dropped(
+            request.tx_uuid,
+            format!(
+                "Ethereum transaction {} reverted while the bridge message remained unprocessed",
+                request.tx_hash
+            ),
+        )
     }
-
-    Ok(())
 }
 
-fn is_timeout_error(error: &PendingTransactionError) -> bool {
-    let error = error.to_string().to_ascii_lowercase();
-    error.contains("timeout") || error.contains("timed out")
+fn classify_watcher_failure(error: &PendingTransactionError) -> WatcherFailure {
+    match error {
+        PendingTransactionError::TxWatcher(_) => WatcherFailure::ConfirmationTimeout,
+        PendingTransactionError::FailedToRegister
+        | PendingTransactionError::TransportError(_)
+        | PendingTransactionError::Recv(_) => WatcherFailure::Infrastructure,
+    }
 }
 
-fn watch_tx(provider: RootProvider, tx_uuid: Uuid, tx_hash: TxHash, confirmations: u64) -> TxWatch {
+fn watch_tx(provider: RootProvider, request: TrackedRequest, confirmations: u64) -> TxWatch {
     Box::pin(async move {
-        let pending = PendingTransactionBuilder::new(provider, tx_hash)
+        let pending = PendingTransactionBuilder::new(provider, request.tx_hash)
             .with_required_confirmations(confirmations);
 
         match tokio::time::timeout(TX_VISIBILITY_CHECK_INTERVAL, pending.get_receipt()).await {
-            Ok(Ok(receipt)) => Ok((tx_uuid, receipt)),
-            Ok(Err(error)) => Err(TxWatchError::Receipt(tx_uuid, tx_hash, error)),
-            Err(_) => Err(TxWatchError::VisibilityCheck(tx_uuid, tx_hash)),
+            Ok(Ok(receipt)) => Ok((request, receipt)),
+            Ok(Err(error)) => Err(TxWatchError::Receipt(request, error)),
+            Err(_) => Err(TxWatchError::VisibilityCheck(request)),
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::providers::WatchTxError;
+
+    #[test]
+    fn classifies_watcher_failures_without_treating_infrastructure_as_execution_failure() {
+        assert_eq!(
+            classify_watcher_failure(&PendingTransactionError::FailedToRegister),
+            WatcherFailure::Infrastructure
+        );
+        assert_eq!(
+            classify_watcher_failure(&PendingTransactionError::TxWatcher(WatchTxError::Timeout)),
+            WatcherFailure::ConfirmationTimeout
+        );
+    }
+
+    #[test]
+    fn reverted_receipt_is_success_or_bounded_retry_based_on_bridge_state() {
+        let request = TrackedRequest {
+            tx_uuid: Uuid::new_v4(),
+            tx_hash: TxHash::from([9; 32]),
+            bridge_nonce: Some([7; 32]),
+        };
+
+        assert!(matches!(
+            reverted_receipt_response(request, true),
+            Response::Success(uuid, hash) if uuid == request.tx_uuid && hash == request.tx_hash
+        ));
+        assert!(matches!(
+            reverted_receipt_response(request, false),
+            Response::Dropped(uuid, _) if uuid == request.tx_uuid
+        ));
+    }
 }

--- a/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
+++ b/relayer/src/message_relayer/common/ethereum/status_fetcher.rs
@@ -11,6 +11,7 @@ use prometheus::{
     core::{AtomicU64, GenericCounter, GenericGauge},
     IntCounter, IntGauge,
 };
+use std::time::Duration;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 use uuid::Uuid;
@@ -29,11 +30,20 @@ pub struct Request {
 
 pub enum Response {
     Success(Uuid, TxHash),
-    Failed(Uuid, PendingTransactionError),
+    Dropped(Uuid, String),
+    Failed(Uuid, String),
 }
 
-type TxWatchResult =
-    Result<(Uuid, alloy::rpc::types::TransactionReceipt), (Uuid, TxHash, PendingTransactionError)>;
+const TX_VISIBILITY_CHECK_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const TX_VISIBILITY_RECHECK_DELAY: Duration = Duration::from_secs(15);
+const TX_VISIBILITY_RECHECKS: usize = 3;
+
+enum TxWatchError {
+    Receipt(Uuid, TxHash, PendingTransactionError),
+    VisibilityCheck(Uuid, TxHash),
+}
+
+type TxWatchResult = Result<(Uuid, alloy::rpc::types::TransactionReceipt), TxWatchError>;
 type TxWatch = BoxFuture<'static, TxWatchResult>;
 
 pub struct StatusFetcherIo {
@@ -191,24 +201,46 @@ async fn task_inner(
                             this.metrics.max_gas_used.set(gas_used);
                         }
 
-
                         this.metrics.pending_tx_count.dec();
-                        responses.send(Response::Success(uuid, tx_hash))?;
+                        if receipt.status() {
+                            responses.send(Response::Success(uuid, tx_hash))?;
+                        } else {
+                            this.metrics.total_failed_txs.inc();
+                            let error = format!("Ethereum transaction {tx_hash} reverted");
+                            log::error!("{error}");
+                            responses.send(Response::Failed(uuid, error))?;
+                        }
                     }
-                    Err((uuid, tx_hash, e)) if rpc::is_recoverable_error_text(&e) => {
+                    Err(TxWatchError::VisibilityCheck(uuid, tx_hash)) => {
+                        check_transaction_visibility(this, &mut txs, responses, uuid, tx_hash).await?;
+                    }
+                    Err(TxWatchError::Receipt(uuid, tx_hash, e))
+                        if is_timeout_error(&e) =>
+                    {
+                        log::warn!(
+                            "Timed out while polling transaction {tx_hash}: {e}. Checking whether it is still visible"
+                        );
+                        check_transaction_visibility(this, &mut txs, responses, uuid, tx_hash).await?;
+                    }
+                    Err(TxWatchError::Receipt(uuid, tx_hash, e))
+                        if rpc::is_recoverable_error_text(&e) =>
+                    {
                         log::warn!("Recoverable error while polling transaction {tx_hash}: {e}. Reconnecting and continuing to watch");
-                        this.eth_api = this.eth_api.reconnect().await?;
-                        txs.push(watch_tx(
-                            this.eth_api.raw_provider().root().clone(),
-                            uuid,
-                            tx_hash,
-                            this.confirmations,
-                        ));
+                        tokio::time::sleep(BASE_RETRY_DELAY).await;
+                        match this.eth_api.reconnect().await {
+                            Ok(eth_api) => this.eth_api = eth_api,
+                            Err(reconnect_error) => log::warn!(
+                                "Failed to reconnect while watching transaction {tx_hash}: {reconnect_error}"
+                            ),
+                        }
+                        rewatch(this, &mut txs, uuid, tx_hash);
                     }
-                    Err((uuid, _tx_hash, e)) => {
+                    Err(TxWatchError::Receipt(uuid, tx_hash, e)) => {
+                        this.metrics.pending_tx_count.dec();
                         this.metrics.total_failed_txs.inc();
-                        log::error!("Failed to get transaction {uuid} status: {e}");
-                        responses.send(Response::Failed(uuid, e))?;
+                        let error = format!("Failed to get transaction {tx_hash} status: {e}");
+                        log::error!("{error}");
+                        responses.send(Response::Failed(uuid, error))?;
                     }
                 }
             }
@@ -216,16 +248,105 @@ async fn task_inner(
     }
 }
 
+fn rewatch(this: &StatusFetcher, txs: &mut FuturesUnordered<TxWatch>, uuid: Uuid, tx_hash: TxHash) {
+    txs.push(watch_tx(
+        this.eth_api.raw_provider().root().clone(),
+        uuid,
+        tx_hash,
+        this.confirmations,
+    ));
+}
+
+async fn check_transaction_visibility(
+    this: &mut StatusFetcher,
+    txs: &mut FuturesUnordered<TxWatch>,
+    responses: &UnboundedSender<Response>,
+    uuid: Uuid,
+    tx_hash: TxHash,
+) -> anyhow::Result<()> {
+    let mut definitely_absent = true;
+
+    for attempt in 1..=TX_VISIBILITY_RECHECKS {
+        let transaction = this
+            .eth_api
+            .raw_provider()
+            .get_transaction_by_hash(tx_hash)
+            .await;
+        let receipt = this
+            .eth_api
+            .raw_provider()
+            .get_transaction_receipt(tx_hash)
+            .await;
+
+        match (transaction, receipt) {
+            (Ok(Some(_)), _) | (_, Ok(Some(_))) => {
+                log::info!("Transaction {tx_hash} is still visible; continuing to watch");
+                rewatch(this, txs, uuid, tx_hash);
+                return Ok(());
+            }
+            (Ok(None), Ok(None)) => {
+                log::warn!(
+                    "Transaction {tx_hash} was absent during visibility check {attempt}/{TX_VISIBILITY_RECHECKS}"
+                );
+                if attempt < TX_VISIBILITY_RECHECKS {
+                    match this.eth_api.reconnect().await {
+                        Ok(eth_api) => this.eth_api = eth_api,
+                        Err(reconnect_error) => log::warn!(
+                            "Failed to reconnect between visibility checks for transaction {tx_hash}: {reconnect_error}"
+                        ),
+                    }
+                }
+            }
+            (transaction, receipt) => {
+                definitely_absent = false;
+                log::warn!(
+                    "Transaction {tx_hash} visibility check {attempt}/{TX_VISIBILITY_RECHECKS} was inconclusive: transaction={transaction:?}, receipt={receipt:?}"
+                );
+                match this.eth_api.reconnect().await {
+                    Ok(eth_api) => this.eth_api = eth_api,
+                    Err(reconnect_error) => log::warn!(
+                        "Failed to reconnect while checking transaction {tx_hash}: {reconnect_error}"
+                    ),
+                }
+            }
+        }
+
+        if attempt < TX_VISIBILITY_RECHECKS {
+            tokio::time::sleep(TX_VISIBILITY_RECHECK_DELAY).await;
+        }
+    }
+
+    if definitely_absent {
+        this.metrics.pending_tx_count.dec();
+        this.metrics.total_failed_txs.inc();
+        let error =
+            format!("Ethereum transaction {tx_hash} disappeared before receiving confirmations");
+        log::error!("{error}");
+        responses.send(Response::Dropped(uuid, error))?;
+    } else {
+        log::warn!(
+            "Transaction {tx_hash} visibility remained inconclusive; continuing to watch without resubmitting"
+        );
+        rewatch(this, txs, uuid, tx_hash);
+    }
+
+    Ok(())
+}
+
+fn is_timeout_error(error: &PendingTransactionError) -> bool {
+    let error = error.to_string().to_ascii_lowercase();
+    error.contains("timeout") || error.contains("timed out")
+}
+
 fn watch_tx(provider: RootProvider, tx_uuid: Uuid, tx_hash: TxHash, confirmations: u64) -> TxWatch {
     Box::pin(async move {
-        let pending = PendingTransactionBuilder::new(provider, tx_hash);
-        Ok((
-            tx_uuid,
-            pending
-                .with_required_confirmations(confirmations)
-                .get_receipt()
-                .await
-                .map_err(|e| (tx_uuid, tx_hash, e))?,
-        ))
+        let pending = PendingTransactionBuilder::new(provider, tx_hash)
+            .with_required_confirmations(confirmations);
+
+        match tokio::time::timeout(TX_VISIBILITY_CHECK_INTERVAL, pending.get_receipt()).await {
+            Ok(Ok(receipt)) => Ok((tx_uuid, receipt)),
+            Ok(Err(error)) => Err(TxWatchError::Receipt(tx_uuid, tx_hash, error)),
+            Err(_) => Err(TxWatchError::VisibilityCheck(tx_uuid, tx_hash)),
+        }
     })
 }

--- a/relayer/src/message_relayer/gear_to_eth/storage.rs
+++ b/relayer/src/message_relayer/gear_to_eth/storage.rs
@@ -427,6 +427,19 @@ impl Storage for JSONStorage {
             return Ok(());
         }
 
+        // Load failures first: legacy snapshots can contain both a UUID transaction
+        // file and the same UUID in `failed`. The failure record is authoritative,
+        // otherwise directory iteration order could resurrect a terminal transaction.
+        let failed_path = self.path.join("failed");
+        if failed_path.exists() {
+            let contents = tokio::fs::read_to_string(&failed_path)
+                .await
+                .context("Failed to read 'failed' transactions file")?;
+            let map: BTreeMap<Uuid, String> =
+                serde_json::from_str(&contents).context("Failed to parse 'failed' transactions")?;
+            tx_manager.failed.write().await.extend(map);
+        }
+
         let mut dir = tokio::fs::read_dir(&self.path).await?;
 
         while let Some(entry) = dir.next_entry().await? {
@@ -437,12 +450,8 @@ impl Storage for JSONStorage {
                 .is_file()
             {
                 if entry.file_name().to_str() == Some("failed") {
-                    let contents = tokio::fs::read_to_string(entry.path())
-                        .await
-                        .context("Failed to read 'failed' transactions file")?;
-                    let map: BTreeMap<Uuid, String> = serde_json::from_str(&contents)
-                        .context("Failed to parse 'failed' transactions")?;
-                    tx_manager.failed.write().await.extend(map);
+                    // Loaded before scanning transaction files.
+                    continue;
                 } else if entry.file_name().to_str() == Some("merkle_roots") {
                     let contents = tokio::fs::read_to_string(entry.path())
                         .await
@@ -467,6 +476,14 @@ impl Storage for JSONStorage {
                     *self.block_storage.blocks.write().await = map;
                 } else {
                     let tx = self.read_tx(entry.path(), entry.file_name()).await?;
+
+                    if tx_manager.failed.read().await.contains_key(&tx.uuid) {
+                        log::warn!(
+                            "Ignoring legacy transaction file {} because it is listed as failed",
+                            tx.uuid
+                        );
+                        continue;
+                    }
 
                     tx_manager.add_transaction(tx).await;
                 }
@@ -588,6 +605,41 @@ mod tests {
         assert_eq!(
             restored.failed.read().await.get(&uuid).map(String::as_str),
             Some("transaction dropped")
+        );
+
+        tokio::fs::remove_dir_all(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_does_not_resume_legacy_transaction_also_listed_as_failed() {
+        use crate::message_relayer::gear_to_eth::tx_manager::TxStatus;
+        use std::sync::Arc;
+
+        let path = std::env::temp_dir().join(format!(
+            "gear-bridge-relayer-legacy-failed-test-{}",
+            Uuid::new_v4()
+        ));
+        tokio::fs::create_dir_all(&path).await.unwrap();
+
+        let storage = Arc::new(JSONStorage::new(&path));
+        let tx = Transaction::new(msg_in_block(43, 8), TxStatus::WaitForMerkleRoot);
+        let uuid = tx.uuid;
+        storage.write_tx(&uuid, &tx).await.unwrap();
+        tokio::fs::write(
+            path.join("failed"),
+            serde_json::to_vec(&BTreeMap::from([(uuid, "legacy failure")])).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let restored = TransactionManager::new(storage.clone());
+        storage.load(&restored).await.unwrap();
+
+        assert!(restored.transactions.read().await.is_empty());
+        assert!(restored.completed.read().await.is_empty());
+        assert_eq!(
+            restored.failed.read().await.get(&uuid).map(String::as_str),
+            Some("legacy failure")
         );
 
         tokio::fs::remove_dir_all(path).await.unwrap();

--- a/relayer/src/message_relayer/gear_to_eth/storage.rs
+++ b/relayer/src/message_relayer/gear_to_eth/storage.rs
@@ -345,18 +345,16 @@ impl Storage for JSONStorage {
                 })?;
         }
 
-        let mut failed = BTreeMap::new();
-        let failed_map = tx_manager.failed.read().await;
+        let mut persisted_transactions = HashSet::new();
 
         for (tx_uuid, tx) in tx_manager.transactions.read().await.iter() {
             self.write_tx(tx_uuid, tx).await?;
-            if let Some(reason) = failed_map.get(tx_uuid) {
-                failed.insert(*tx_uuid, reason.clone());
-            }
+            persisted_transactions.insert(*tx_uuid);
         }
 
         for (tx_uuid, tx) in tx_manager.completed.read().await.iter() {
             self.write_tx(tx_uuid, tx).await?;
+            persisted_transactions.insert(*tx_uuid);
         }
 
         let mut failed_file = tokio::fs::OpenOptions::new()
@@ -366,7 +364,8 @@ impl Storage for JSONStorage {
             .open(self.path.join("failed"))
             .await?;
 
-        let str = serde_json::to_string(&failed)
+        let failed = tx_manager.failed.read().await;
+        let str = serde_json::to_string(&*failed)
             .with_context(|| "Failed to serialize failed transactions")?;
 
         failed_file
@@ -393,6 +392,32 @@ impl Storage for JSONStorage {
         merkle_file.flush().await?;
 
         self.block_storage.save(&self.path).await?;
+
+        // Remove transaction files that are no longer active or completed only
+        // after every current state file has been saved successfully. Without
+        // this cleanup, a failed transaction is resurrected on the next load.
+        let mut entries = tokio::fs::read_dir(&self.path).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            if !entry.file_type().await?.is_file() {
+                continue;
+            }
+
+            let Some(uuid) = entry
+                .file_name()
+                .to_str()
+                .and_then(|name| Uuid::from_str(name).ok())
+            else {
+                continue;
+            };
+
+            if !persisted_transactions.contains(&uuid) {
+                tokio::fs::remove_file(entry.path())
+                    .await
+                    .with_context(|| {
+                        format!("Failed to remove stale transaction file for {uuid}")
+                    })?;
+            }
+        }
 
         Ok(())
     }
@@ -529,5 +554,42 @@ mod tests {
 
         assert!(!storage.is_message_pending(block, n1).await);
         assert!(storage.is_message_pending(block, n2).await);
+    }
+
+    #[tokio::test]
+    async fn save_removes_stale_transaction_files_without_resurrecting_them() {
+        use crate::message_relayer::gear_to_eth::tx_manager::TxStatus;
+        use std::sync::Arc;
+
+        let path = std::env::temp_dir().join(format!(
+            "gear-bridge-relayer-storage-test-{}",
+            Uuid::new_v4()
+        ));
+        let storage = Arc::new(JSONStorage::new(&path));
+        let manager = TransactionManager::new(storage.clone());
+        let tx = Transaction::new(msg_in_block(42, 7), TxStatus::WaitForMerkleRoot);
+        let uuid = tx.uuid;
+
+        manager.add_transaction(tx).await;
+        storage.save(&manager).await.unwrap();
+        assert!(path.join(uuid.to_string()).is_file());
+
+        manager.transactions.write().await.remove(&uuid);
+        manager
+            .fail_transaction(uuid, "transaction dropped".to_string())
+            .await;
+        storage.save(&manager).await.unwrap();
+        assert!(!path.join(uuid.to_string()).exists());
+
+        let restored = TransactionManager::new(storage.clone());
+        storage.load(&restored).await.unwrap();
+        assert!(restored.transactions.read().await.is_empty());
+        assert!(restored.completed.read().await.is_empty());
+        assert_eq!(
+            restored.failed.read().await.get(&uuid).map(String::as_str),
+            Some("transaction dropped")
+        );
+
+        tokio::fs::remove_dir_all(path).await.unwrap();
     }
 }

--- a/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
+++ b/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
@@ -21,12 +21,16 @@ use crate::message_relayer::{
     gear_to_eth::storage::Storage,
 };
 
+const MAX_DROPPED_RETRIES: u32 = 3;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Transaction {
     pub uuid: Uuid,
     pub message: MessageInBlock,
     pub message_hash: [u8; 32],
     pub status: TxStatus,
+    #[serde(default)]
+    pub dropped_retries: u32,
 }
 
 impl Transaction {
@@ -37,6 +41,7 @@ impl Transaction {
             status,
             message_hash: message_hash(&message.message),
             message,
+            dropped_retries: 0,
         }
     }
 }
@@ -48,6 +53,11 @@ pub enum TxStatus {
     SendMessage(RelayedMerkleRoot, MerkleProof),
     WaitConfirmations(TxHash),
     Completed,
+}
+
+enum ExistingTransaction {
+    Completed,
+    Active(Box<Transaction>),
 }
 
 impl_metered_service!(
@@ -102,12 +112,20 @@ impl TransactionManager {
         self.metrics.failed_transactions.inc();
     }
 
+    async fn fail_active_transaction(&self, tx_uuid: Uuid, reason: String) -> Option<Transaction> {
+        let tx = self.transactions.write().await.remove(&tx_uuid);
+        if tx.is_some() {
+            self.fail_transaction(tx_uuid, reason).await;
+        }
+        tx
+    }
+
     pub async fn add_transaction(&self, tx: Transaction) {
         self.metrics.total_transactions.inc();
 
         match tx.status {
             TxStatus::Completed => {
-                self.completed.write().await.insert(tx.uuid, tx.clone());
+                self.completed.write().await.insert(tx.uuid, tx);
                 self.metrics.completed_transactions.inc();
             }
 
@@ -115,6 +133,40 @@ impl TransactionManager {
                 self.transactions.write().await.insert(tx.uuid, tx);
             }
         }
+    }
+
+    async fn complete_transaction(&self, uuid: Uuid) -> bool {
+        let tx = self.transactions.write().await.remove(&uuid);
+        let Some(mut tx) = tx else {
+            return false;
+        };
+
+        tx.status = TxStatus::Completed;
+        self.completed.write().await.insert(uuid, tx);
+        self.failed.write().await.remove(&uuid);
+        self.metrics.completed_transactions.inc();
+        true
+    }
+
+    async fn existing_transaction(&self, message_hash: [u8; 32]) -> Option<ExistingTransaction> {
+        if self
+            .completed
+            .read()
+            .await
+            .values()
+            .any(|tx| tx.message_hash == message_hash)
+        {
+            return Some(ExistingTransaction::Completed);
+        }
+
+        self.transactions
+            .read()
+            .await
+            .values()
+            .find(|tx| tx.message_hash == message_hash)
+            .cloned()
+            .map(Box::new)
+            .map(ExistingTransaction::Active)
     }
 
     pub async fn update_storage(&self) {
@@ -291,35 +343,31 @@ impl TransactionManager {
                 };
 
                 let hash = message_hash(&message.message);
-                {
-                    let completed = self.completed.read().await;
-                    if completed.values().any(|tx| tx.message_hash == hash) {
+                match self.existing_transaction(hash).await {
+                    Some(ExistingTransaction::Completed) => {
                         log::info!(
                             "Skipping completed message: nonce={}, block=#{}",
                             hex::encode(message.message.nonce_be),
                             message.block.0
                         );
-
                         return Ok(true);
                     }
+                    Some(ExistingTransaction::Active(tx)) => {
+                        log::info!(
+                            "Skipping active message: transaction={}, status={:?}, nonce={}, block=#{}",
+                            tx.uuid,
+                            tx.status,
+                            hex::encode(tx.message.message.nonce_be),
+                            tx.message.block.0,
+                        );
+                        return Ok(true);
+                    }
+                    None => {}
                 }
 
-                let tx_maybe = {
-                    let transactions = self.transactions.read().await;
-
-                    transactions.values().find(|tx| tx.message_hash == hash).cloned()
-                };
-
-                let (tx, is_new) = match tx_maybe {
-                    Some(tx) => (tx, false),
-                    None => {
-                        self.storage.block_storage().complete_transaction(&message).await;
-                        let tx = Transaction::new(message, TxStatus::WaitForMerkleRoot);
-                        self.add_transaction(tx.clone()).await;
-
-                        (tx, true)
-                    }
-                };
+                self.storage.block_storage().complete_transaction(&message).await;
+                let tx = Transaction::new(message, TxStatus::WaitForMerkleRoot);
+                self.add_transaction(tx.clone()).await;
 
                 let source = ActorId::from(tx.message.message.source);
                 let block_hash = tx.message.block_hash;
@@ -328,7 +376,7 @@ impl TransactionManager {
                 let uuid = tx.uuid;
 
                 log::info!(
-                    "Transaction (is new: {is_new}) {uuid}, nonce={} from source {source} at block #{} ({block_hash})",
+                    "New transaction {uuid}, nonce={} from source {source} at block #{} ({block_hash})",
                     hex::encode(tx.message.message.nonce_be),
                     block.0,
                 );
@@ -375,12 +423,29 @@ impl TransactionManager {
                     }
 
                     accumulator::Response::Overflowed(message) => {
-                        self.fail_transaction(message.tx_uuid, "Message overflowed".to_string()).await;
+                        if self
+                            .fail_active_transaction(
+                                message.tx_uuid,
+                                "Message overflowed".to_string(),
+                            )
+                            .await
+                            .is_none()
+                        {
+                            log::warn!(
+                                "Received overflow response for unknown transaction: {}",
+                                message.tx_uuid
+                            );
+                        }
                     }
 
                     accumulator::Response::Stuck { tx_uuid, .. } => {
-
-                        self.fail_transaction(tx_uuid, "Message stuck".to_string()).await;
+                        if self
+                            .fail_active_transaction(tx_uuid, "Message stuck".to_string())
+                            .await
+                            .is_none()
+                        {
+                            log::warn!("Received stuck response for unknown transaction: {tx_uuid}");
+                        }
                     }
                 }
             }
@@ -420,26 +485,41 @@ impl TransactionManager {
                 match message {
                     message_sender::Response::MessageAlreadyProcessed(tx_uuid) => {
                         log::info!(
-                            "Message already processed, skipping: tx_uuid = {tx_uuid}"
+                            "Message already processed, completing: tx_uuid = {tx_uuid}"
                         );
-                        if let Some(tx) = self.transactions.write().await.get_mut(&tx_uuid) {
-                            tx.status = TxStatus::Completed;
-                        } else {
+                        if !self.complete_transaction(tx_uuid).await {
                             log::warn!("Received message for unknown transaction: {tx_uuid}");
                         }
-
                     }
 
                     message_sender::Response::ProcessingStarted(tx_hash, tx_uuid) => {
-                        if let Some(tx) = self.transactions.write().await.get_mut(&tx_uuid) {
+                        let known = if let Some(tx) =
+                            self.transactions.write().await.get_mut(&tx_uuid)
+                        {
                             tx.status = TxStatus::WaitConfirmations(tx_hash);
+                            true
                         } else {
                             log::warn!("Received message for unknown transaction: {tx_uuid}");
-                        }
+                            false
+                        };
 
-                        if !status_fetcher.send_request(tx_uuid, tx_hash) {
+                        if known && !status_fetcher.send_request(tx_uuid, tx_hash) {
                             log::warn!("Status fetcher stopped accepting requests, exiting");
                             return Ok(false);
+                        }
+                    }
+
+                    message_sender::Response::Failed(tx_uuid, error) => {
+                        if let Some(tx) = self
+                            .fail_active_transaction(tx_uuid, error.clone())
+                            .await
+                        {
+                            let nonce = hex::encode(tx.message.message.nonce_be);
+                            log::error!(
+                                "Transaction {tx_uuid}, nonce={nonce} failed before broadcast: {error}"
+                            );
+                        } else {
+                            log::warn!("Received failure for unknown transaction: {tx_uuid}");
                         }
                     }
                 }
@@ -453,16 +533,7 @@ impl TransactionManager {
 
                 match status {
                     status_fetcher::Response::Success(uuid, tx_hash) => {
-                        if let Some(tx) = self.transactions.write().await.remove(&uuid) {
-                            let completed_tx = Transaction {
-                                uuid,
-                                message: tx.message,
-                                message_hash: tx.message_hash,
-                                status: TxStatus::Completed,
-                            };
-                            self.completed.write().await.insert(uuid, completed_tx);
-                            self.metrics.completed_transactions.inc();
-
+                        if self.complete_transaction(uuid).await {
                             log::info!(
                                 "Transaction {uuid} completed successfully: tx_hash = {tx_hash}"
                             );
@@ -471,11 +542,62 @@ impl TransactionManager {
                         }
                     }
 
-                    status_fetcher::Response::Failed(uuid, e) => {
-                        if let Some(tx) = self.transactions.write().await.remove(&uuid) {
-                            self.fail_transaction(uuid, e.to_string()).await;
+                    status_fetcher::Response::Dropped(uuid, error) => {
+                        let retry = {
+                            let mut transactions = self.transactions.write().await;
+                            transactions.get_mut(&uuid).map(|tx| {
+                                tx.dropped_retries = tx.dropped_retries.saturating_add(1);
+                                tx.status = TxStatus::WaitForMerkleRoot;
+                                (
+                                    tx.dropped_retries,
+                                    tx.message.authority_set_id,
+                                    tx.message.block,
+                                    tx.message.block_hash,
+                                    ActorId::from(tx.message.message.source),
+                                    hex::encode(tx.message.message.nonce_be),
+                                )
+                            })
+                        };
+
+                        if let Some((attempt, authority_set_id, block, block_hash, source, nonce)) =
+                            retry
+                        {
+                            if attempt > MAX_DROPPED_RETRIES {
+                                let reason = format!(
+                                    "Ethereum transaction repeatedly disappeared after {MAX_DROPPED_RETRIES} retries: {error}"
+                                );
+                                let _ = self.fail_active_transaction(uuid, reason.clone()).await;
+                                log::error!(
+                                    "Transaction {uuid}, nonce={nonce} failed terminally: {reason}"
+                                );
+                            } else {
+                                log::error!(
+                                    "Transaction {uuid}, nonce={nonce} was dropped: {error}. Retrying from merkle-root lookup ({attempt}/{MAX_DROPPED_RETRIES})"
+                                );
+                                if !accumulator.send_message(
+                                    uuid,
+                                    authority_set_id,
+                                    block,
+                                    block_hash,
+                                    source,
+                                ) {
+                                    log::warn!("Accumulator stopped accepting messages, exiting");
+                                    return Ok(false);
+                                }
+                            }
+                        } else {
+                            log::warn!("Received dropped response for unknown transaction: {uuid}");
+                        }
+                    }
+
+                    status_fetcher::Response::Failed(uuid, error) => {
+                        if let Some(tx) =
+                            self.fail_active_transaction(uuid, error.clone()).await
+                        {
                             let nonce = hex::encode(tx.message.message.nonce_be);
-                            log::error!("Transaction {uuid}, nonce={nonce} failed: {e}", );
+                            log::error!(
+                                "Transaction {uuid}, nonce={nonce} failed terminally: {error}"
+                            );
                         } else {
                             log::warn!("Received failure response for unknown transaction: {uuid}");
                         }
@@ -485,5 +607,148 @@ impl TransactionManager {
         }
 
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message_relayer::{
+        common::{AuthoritySetId, GearBlockNumber},
+        gear_to_eth::storage::NoStorage,
+    };
+    use gear_rpc_client::dto::Message;
+    use primitive_types::H256;
+
+    fn transaction() -> Transaction {
+        Transaction::new(
+            MessageInBlock {
+                message: Message {
+                    nonce_be: [7; 32],
+                    source: [1; 32],
+                    destination: [2; 20],
+                    payload: vec![3, 4],
+                },
+                block: GearBlockNumber(42),
+                block_hash: H256::from_low_u64_be(99),
+                authority_set_id: AuthoritySetId(5),
+            },
+            TxStatus::WaitForMerkleRoot,
+        )
+    }
+
+    #[tokio::test]
+    async fn complete_transaction_moves_active_transaction_to_completed() {
+        let manager = TransactionManager::new(Arc::new(NoStorage::new()));
+        let tx = transaction();
+        let uuid = tx.uuid;
+        let message_hash = tx.message_hash;
+
+        manager.add_transaction(tx).await;
+        manager
+            .failed
+            .write()
+            .await
+            .insert(uuid, "previous attempt failed".to_string());
+
+        assert!(manager.complete_transaction(uuid).await);
+        assert!(!manager.transactions.read().await.contains_key(&uuid));
+        assert!(!manager.failed.read().await.contains_key(&uuid));
+
+        let completed = manager.completed.read().await;
+        let completed_tx = completed.get(&uuid).unwrap();
+        assert_eq!(completed_tx.message_hash, message_hash);
+        assert!(matches!(completed_tx.status, TxStatus::Completed));
+        drop(completed);
+
+        assert!(!manager.complete_transaction(uuid).await);
+        assert_eq!(manager.metrics.completed_transactions.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn existing_transactions_are_classified_for_duplicate_suppression() {
+        let manager = TransactionManager::new(Arc::new(NoStorage::new()));
+        let tx = transaction();
+        let uuid = tx.uuid;
+        let message_hash = tx.message_hash;
+
+        manager.add_transaction(tx).await;
+        assert!(matches!(
+            manager.existing_transaction(message_hash).await,
+            Some(ExistingTransaction::Active(_))
+        ));
+
+        assert!(manager.complete_transaction(uuid).await);
+        assert!(matches!(
+            manager.existing_transaction(message_hash).await,
+            Some(ExistingTransaction::Completed)
+        ));
+        assert!(manager.existing_transaction([0; 32]).await.is_none());
+    }
+
+    #[test]
+    fn legacy_transaction_state_defaults_dropped_retry_count() {
+        let tx = transaction();
+        let mut value = serde_json::to_value(tx).unwrap();
+        value.as_object_mut().unwrap().remove("dropped_retries");
+
+        let restored: Transaction = serde_json::from_value(value).unwrap();
+        assert_eq!(restored.dropped_retries, 0);
+    }
+
+    #[tokio::test]
+    async fn terminal_failure_removes_active_transaction_for_explicit_retry() {
+        let manager = TransactionManager::new(Arc::new(NoStorage::new()));
+        let tx = transaction();
+        let uuid = tx.uuid;
+        let message_hash = tx.message_hash;
+        manager.add_transaction(tx).await;
+
+        assert!(manager
+            .fail_active_transaction(uuid, "terminal failure".to_string())
+            .await
+            .is_some());
+        assert!(manager.existing_transaction(message_hash).await.is_none());
+        assert_eq!(
+            manager.failed.read().await.get(&uuid).map(String::as_str),
+            Some("terminal failure")
+        );
+    }
+
+    #[tokio::test]
+    async fn every_active_status_suppresses_duplicate_submission() {
+        let root = RelayedMerkleRoot {
+            block: GearBlockNumber(43),
+            block_hash: H256::from_low_u64_be(100),
+            timestamp: 123,
+            authority_set_id: AuthoritySetId(6),
+            merkle_root: H256::from_low_u64_be(101),
+        };
+        let proof = MerkleProof {
+            root: [0; 32],
+            proof: vec![],
+            num_leaves: 1,
+            leaf_index: 0,
+        };
+        let statuses = [
+            TxStatus::WaitForMerkleRoot,
+            TxStatus::FetchMerkleRoot(root),
+            TxStatus::SendMessage(root, proof),
+            TxStatus::WaitConfirmations(TxHash::from([0; 32])),
+            TxStatus::Completed,
+        ];
+
+        for status in statuses {
+            let manager = TransactionManager::new(Arc::new(NoStorage::new()));
+            let mut tx = transaction();
+            tx.status = status;
+            let message_hash = tx.message_hash;
+            manager.transactions.write().await.insert(tx.uuid, tx);
+
+            assert!(matches!(
+                manager.existing_transaction(message_hash).await,
+                Some(ExistingTransaction::Active(_))
+            ));
+        }
     }
 }

--- a/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
+++ b/relayer/src/message_relayer/gear_to_eth/tx_manager.rs
@@ -256,7 +256,11 @@ impl TransactionManager {
                         hex::encode(tx.message.message.nonce_be),
                         tx_hash
                     );
-                    if !status_fetcher.send_request(tx.uuid, tx_hash) {
+                    if !status_fetcher.send_request_with_bridge_nonce(
+                        tx.uuid,
+                        tx_hash,
+                        tx.message.message.nonce_be,
+                    ) {
                         log::warn!("Status fetcher stopped accepting requests, exiting");
                         return Ok(false);
                     }
@@ -493,19 +497,21 @@ impl TransactionManager {
                     }
 
                     message_sender::Response::ProcessingStarted(tx_hash, tx_uuid) => {
-                        let known = if let Some(tx) =
+                        let bridge_nonce = if let Some(tx) =
                             self.transactions.write().await.get_mut(&tx_uuid)
                         {
                             tx.status = TxStatus::WaitConfirmations(tx_hash);
-                            true
+                            Some(tx.message.message.nonce_be)
                         } else {
                             log::warn!("Received message for unknown transaction: {tx_uuid}");
-                            false
+                            None
                         };
 
-                        if known && !status_fetcher.send_request(tx_uuid, tx_hash) {
-                            log::warn!("Status fetcher stopped accepting requests, exiting");
-                            return Ok(false);
+                        if let Some(bridge_nonce) = bridge_nonce {
+                            if !status_fetcher.send_request_with_bridge_nonce(tx_uuid, tx_hash, bridge_nonce) {
+                                log::warn!("Status fetcher stopped accepting requests, exiting");
+                                return Ok(false);
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Problem

A mainnet Gear-to-Ethereum transfer exposed a nonce-gap failure mode in the relayer:

- Alloy's cached nonce filler advanced its process-local nonce after submissions disappeared from the mempool.
- Repeated `/relay_messages` requests restarted an already-active transaction and created higher-nonce Ethereum transactions.
- The status/storage paths could treat reverted or disappeared transactions incorrectly and resurrect stale `WaitConfirmations` state after restart.

This left the fee-payer account expecting nonce 702 while later duplicate submissions were queued at nonces 705 and 706.

## Changes

- Replace cached nonce allocation with pending-aware `SimpleNonceManager`.
- Serialize Ethereum submissions per `(chain ID, fee-payer)` across clones and independently constructed `EthApi` clients in one process.
- Reserve and reuse the same explicit account nonce across ambiguous content-message send retries.
- Reconcile `nonce too low` against both bridge state and the latest mined account nonce before releasing a pinned nonce.
- Defer transient pause/challenge/emergency/root-delay errors without losing the request or head-of-line blocking governance messages.
- Suppress duplicate submissions for every active transaction status.
- Move `MessageAlreadyProcessed` transactions from active to completed state immediately.
- Treat watcher infrastructure errors as non-terminal and run visibility checks concurrently.
- Reconcile reverted receipts against `is_message_processed`; retry unprocessed messages through the persisted bounded-retry path.
- Require repeated transaction-and-receipt absence checks before declaring a transaction dropped.
- Bound and persist dropped/reverted transaction retry attempts.
- Remove terminal transactions from active state so explicit retries can proceed.
- Remove stale UUID transaction files, preserve failure diagnostics, and prevent legacy failed UUID files from being resumed during upgrade.
- Keep the existing status-fetcher API and transaction storage compatible.
- Document the one-submitting-process-per-fee-payer deployment requirement.

## Validation

- `cargo test -p relayer` — 67 passed, 14 ignored
- `cargo test -p ethereum-client` — passed
- `cargo clippy -p relayer --all-targets -- -D warnings` — passed
- `cargo clippy -p ethereum-client --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Follow-up hardening

A durable signed-raw-transaction outbox would additionally close the narrow crash window between transaction broadcast and receiving/persisting the RPC acknowledgement, and would provide stronger evidence before replacing a hash absent from configured RPC mempools. Cross-process nonce coordination is intentionally an operational invariant in this PR: replicas, manual commands, and external signer tools must not share the same fee-payer account concurrently.
