### PR TITLE
fix(relayer): recover Merkle RPC outages without restarts

### DIFF
--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -1127,7 +1127,7 @@ async fn create_proof_storage_from_config(
         }
         EffectiveProofStorageConfig::FileSystem { path } => {
             log::warn!("Fee payer not present, falling back to FileSystemProofStorage");
-            Arc::new(FileSystemProofStorage::new(path.clone()).await)
+            Arc::new(FileSystemProofStorage::new(path.clone()).await?)
         }
     };
 

--- a/relayer/src/merkle_roots/authority_set_sync.rs
+++ b/relayer/src/merkle_roots/authority_set_sync.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::{sync_authority_set_id, SyncStepCount},
     message_relayer::common::GearBlock,
-    proof_storage::ProofStorage,
+    proof_storage::{ProofStorage, ProofStorageError},
     rpc,
 };
 use futures::{executor::block_on, FutureExt};
@@ -22,6 +22,12 @@ use tokio::sync::{
 };
 
 use utils_prometheus::{impl_metered_service, MeteredService};
+
+fn is_recoverable_authority_sync_error(err: &anyhow::Error) -> bool {
+    !err.chain()
+        .any(|cause| cause.downcast_ref::<ProofStorageError>().is_some())
+        && rpc::classify_anyhow(err) == rpc::RetryDecision::Retry
+}
 
 pub struct AuthoritySetSyncIo {
     response: UnboundedReceiver<Response>,
@@ -350,6 +356,12 @@ impl AuthoritySetSync {
                         log::error!(
                             "Authority set sync for relayer {relayer_id} task failed: {err}"
                         );
+                        if !is_recoverable_authority_sync_error(&err) {
+                            log::error!(
+                                "Authority set sync for relayer {relayer_id}: non-recoverable error, stopping"
+                            );
+                            return;
+                        }
 
                         match runner.api_provider.reconnect().await {
                             Ok(_) => {
@@ -390,6 +402,12 @@ impl AuthoritySetSync {
                             log::error!(
                                 "Authority set sync for relayer {relayer_id} task failed: {err}"
                             );
+                            if !is_recoverable_authority_sync_error(&err) {
+                                log::error!(
+                                    "Authority set sync for relayer {relayer_id}: non-recoverable error, stopping"
+                                );
+                                return;
+                            }
 
                             match runner.api_provider.reconnect().await {
                                 Ok(_) => {
@@ -645,8 +663,10 @@ async fn execute_sync_authority_set(
     let proof_storage = proof_storage.clone();
     let responses = responses.clone();
 
-    let (sync_steps, latest_authority_set_id, latest_proven_authority_set_id) =
-        rpc::retry_gear(api_provider, "authority set sync", move |gear_api| {
+    let (sync_steps, latest_authority_set_id, latest_proven_authority_set_id) = rpc::retry_gear_if(
+        api_provider,
+        "authority set sync",
+        move |gear_api| {
             let proof_storage = proof_storage.clone();
             let responses = responses.clone();
             async move {
@@ -669,8 +689,10 @@ async fn execute_sync_authority_set(
                     latest_proven_authority_set_id,
                 ))
             }
-        })
-        .await?;
+        },
+        is_recoverable_authority_sync_error,
+    )
+    .await?;
 
     metrics
         .latest_observed_gear_era
@@ -680,4 +702,59 @@ async fn execute_sync_authority_set(
     }
 
     Ok((sync_steps, latest_authority_set_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn does_not_reconnect_gear_for_proof_storage_errors() {
+        let err = anyhow::Error::new(ProofStorageError::InnerError(anyhow::anyhow!(
+            "proof storage write timed out"
+        )));
+
+        assert!(!is_recoverable_authority_sync_error(&err));
+    }
+
+    #[test]
+    fn wrapped_storage_error_remains_nonrecoverable_and_preserves_sources() {
+        let storage_error = ProofStorageError::InnerError(anyhow::Error::new(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "disk timed out",
+        )));
+        let err = anyhow::Error::new(rpc::RpcFailure {
+            operation: "authority set sync",
+            kind: rpc::RpcFailureKind::Permanent,
+            source: anyhow::Error::new(storage_error),
+        });
+
+        assert!(!is_recoverable_authority_sync_error(&err));
+        let storage_error = err
+            .chain()
+            .find_map(|cause| cause.downcast_ref::<ProofStorageError>())
+            .expect("proof storage error should remain in the source chain");
+        let ProofStorageError::InnerError(storage_error) = storage_error else {
+            panic!("expected inner proof storage error");
+        };
+        assert!(storage_error
+            .chain()
+            .any(|cause| cause.is::<std::io::Error>()));
+    }
+
+    #[test]
+    fn does_not_reconnect_gear_for_uninitialized_proof_storage() {
+        let err = anyhow::Error::new(ProofStorageError::NotInitialized);
+
+        assert!(!is_recoverable_authority_sync_error(&err));
+    }
+
+    #[test]
+    fn reconnects_gear_for_recoverable_rpc_errors() {
+        let err = anyhow::anyhow!(
+            "RPC error: client error: The background task closed connection closed; restart required"
+        );
+
+        assert!(is_recoverable_authority_sync_error(&err));
+    }
 }

--- a/relayer/src/merkle_roots/authority_set_sync.rs
+++ b/relayer/src/merkle_roots/authority_set_sync.rs
@@ -24,9 +24,17 @@ use tokio::sync::{
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 fn is_recoverable_authority_sync_error(err: &anyhow::Error) -> bool {
-    !err.chain()
-        .any(|cause| cause.downcast_ref::<ProofStorageError>().is_some())
-        && rpc::classify_anyhow(err) == rpc::RetryDecision::Retry
+    if let Some(storage_error) = err
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<ProofStorageError>())
+    {
+        let ProofStorageError::InnerError(source) = storage_error else {
+            return false;
+        };
+        return rpc::classify_gear_transport_error(source) == rpc::RetryDecision::Retry;
+    }
+
+    rpc::classify_anyhow(err) == rpc::RetryDecision::Retry
 }
 
 pub struct AuthoritySetSyncIo {
@@ -715,6 +723,16 @@ mod tests {
         )));
 
         assert!(!is_recoverable_authority_sync_error(&err));
+    }
+
+    #[test]
+    fn reconnects_for_gear_backed_proof_storage_disconnects() {
+        let disconnect = subxt::Error::Rpc(subxt::error::RpcError::SubscriptionDropped);
+        let err = anyhow::Error::new(ProofStorageError::InnerError(anyhow::Error::new(
+            disconnect,
+        )));
+
+        assert!(is_recoverable_authority_sync_error(&err));
     }
 
     #[test]

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -41,6 +41,12 @@ pub mod storage;
 pub mod submitter;
 
 const MERKLE_ROOT_SUPERVISOR_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const MERKLE_ROOT_SUPERVISOR_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+enum EthereumRootRead {
+    Fetched(Option<H256>),
+    RetryLater,
+}
 
 pub struct Relayer {
     merkle_roots: MerkleRootRelayer,
@@ -322,7 +328,7 @@ impl MerkleRootRelayer {
         mut authority_set_sync: AuthoritySetSyncIo,
         mut http: UnboundedReceiver<MerkleRootsRequest>,
 
-        eth_api: EthApi,
+        mut eth_api: EthApi,
     ) -> anyhow::Result<()> {
         let relayer_id = self.options.relayer_id.clone();
         log::info!("Starting merkle root relayer {relayer_id}");
@@ -529,10 +535,12 @@ impl MerkleRootRelayer {
             }
         }
 
-        self.initialize_contract_cursor(&eth_api).await?;
-        self.supervise_contract_state(&mut prover, &mut authority_set_sync, &eth_api)
-            .await?;
+        self.initialize_contract_cursor(&mut eth_api).await?;
+        // Consume the interval's immediate first tick before supervision so a failed
+        // startup probe can schedule an actual short retry instead of losing it here.
         self.supervisor_interval.tick().await;
+        self.supervise_contract_state(&mut prover, &mut authority_set_sync, &mut eth_api)
+            .await?;
 
         if let Err(err) = self
             .run_inner(
@@ -541,7 +549,7 @@ impl MerkleRootRelayer {
                 &mut blocks_rx,
                 &mut authority_set_sync,
                 &mut http,
-                &eth_api,
+                &mut eth_api,
             )
             .await
         {
@@ -555,10 +563,20 @@ impl MerkleRootRelayer {
         }
     }
 
-    async fn initialize_contract_cursor(&mut self, eth_api: &EthApi) -> anyhow::Result<()> {
+    async fn initialize_contract_cursor(&mut self, eth_api: &mut EthApi) -> anyhow::Result<()> {
         let relayer_id = &self.options.relayer_id;
-        let max_block_number = eth_api.max_block_number().await?;
-        let max_block_distance = eth_api.max_block_distance().await?;
+        let max_block_number = rpc::retry_eth(
+            eth_api,
+            "read MessageQueue max block number",
+            |api| async move { api.max_block_number().await },
+        )
+        .await?;
+        let max_block_distance = rpc::retry_eth(
+            eth_api,
+            "read MessageQueue max block distance",
+            |api| async move { api.max_block_distance().await },
+        )
+        .await?;
         let last_block_hash = self.api_provider.client().latest_finalized_block().await?;
         let last_block = self
             .api_provider
@@ -594,7 +612,7 @@ impl MerkleRootRelayer {
         &mut self,
         prover: &mut FinalityProverIo,
         authority_set_sync: &mut AuthoritySetSyncIo,
-        eth_api: &EthApi,
+        eth_api: &mut EthApi,
     ) -> anyhow::Result<()> {
         let relayer_id = self.options.relayer_id.clone();
         let client = self.api_provider.client();
@@ -623,10 +641,17 @@ impl MerkleRootRelayer {
             return Ok(());
         }
 
-        let eth_root = eth_api
-            .read_chainhead_merkle_root(block_number)
+        let eth_root = match self
+            .read_chainhead_merkle_root(eth_api, block_number)
             .await?
-            .map(H256::from);
+        {
+            EthereumRootRead::Fetched(root) => root,
+            EthereumRootRead::RetryLater => {
+                self.supervisor_interval
+                    .reset_after(MERKLE_ROOT_SUPERVISOR_RETRY_INTERVAL);
+                return Ok(());
+            }
+        };
         if eth_root == Some(merkle_root) {
             log::info!(
                 "Merkle root relayer {relayer_id} supervisor: Ethereum already has merkle root {merkle_root} for block #{block_number}"
@@ -687,6 +712,46 @@ impl MerkleRootRelayer {
         Ok(())
     }
 
+    async fn read_chainhead_merkle_root(
+        &self,
+        eth_api: &mut EthApi,
+        block_number: u32,
+    ) -> anyhow::Result<EthereumRootRead> {
+        let relayer_id = &self.options.relayer_id;
+        match eth_api.read_chainhead_merkle_root(block_number).await {
+            Ok(root) => return Ok(EthereumRootRead::Fetched(root.map(H256::from))),
+            Err(err) if rpc::classify_ethereum_error(&err) == rpc::RetryDecision::Retry => {
+                log::warn!(
+                    "Merkle root relayer {relayer_id} supervisor: recoverable Ethereum RPC error while reading merkle root for block #{block_number}: {err}. Reconnecting"
+                );
+            }
+            Err(err) => return Err(err.into()),
+        }
+
+        let reconnected = match eth_api.reconnect().await {
+            Ok(reconnected) => reconnected,
+            Err(err) if rpc::classify_ethereum_error(&err) == rpc::RetryDecision::Retry => {
+                log::warn!(
+                    "Merkle root relayer {relayer_id} supervisor: Ethereum reconnect failed: {err}. Retrying supervisor in {MERKLE_ROOT_SUPERVISOR_RETRY_INTERVAL:?}"
+                );
+                return Ok(EthereumRootRead::RetryLater);
+            }
+            Err(err) => return Err(err.into()),
+        };
+        *eth_api = reconnected;
+
+        match eth_api.read_chainhead_merkle_root(block_number).await {
+            Ok(root) => Ok(EthereumRootRead::Fetched(root.map(H256::from))),
+            Err(err) if rpc::classify_ethereum_error(&err) == rpc::RetryDecision::Retry => {
+                log::warn!(
+                    "Merkle root relayer {relayer_id} supervisor: Ethereum merkle-root read still unavailable after reconnect: {err}. Retrying supervisor in {MERKLE_ROOT_SUPERVISOR_RETRY_INTERVAL:?}"
+                );
+                Ok(EthereumRootRead::RetryLater)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
     async fn signed_block_after(&self, block_number: u32) -> anyhow::Result<GearBlock> {
         let api = self.api_provider.client();
         let (justification, _) = api
@@ -712,7 +777,7 @@ impl MerkleRootRelayer {
         authority_set_sync: &mut AuthoritySetSyncIo,
 
         http: &mut UnboundedReceiver<MerkleRootsRequest>,
-        eth_api: &EthApi,
+        eth_api: &mut EthApi,
     ) -> anyhow::Result<()> {
         loop {
             let result = self
@@ -760,7 +825,7 @@ impl MerkleRootRelayer {
         authority_set_sync: &mut AuthoritySetSyncIo,
 
         http: &mut UnboundedReceiver<MerkleRootsRequest>,
-        eth_api: &EthApi,
+        eth_api: &mut EthApi,
     ) -> anyhow::Result<bool> {
         let client = self.api_provider.client();
         tokio::select! {

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -283,70 +283,69 @@ impl FinalityProver {
 
         let mut batch_vec = Vec::with_capacity(BATCH_SIZE);
         // Group requests by authority set ID and queue ID, storing all blocks for each set.
-        // Use BTreeMap to have a deterministic order of processing: from older to newer authority sets.
         let mut request_groups: BTreeMap<(u64, u64), BatchProofRequest> = BTreeMap::new();
 
         let mut non_batch_requests: Vec<Request> = Vec::new();
 
         loop {
-            // Receives messages into `batch_vec` but has one big downside requiring another `recv_many`
-            // down below: will receive only one element first *and* only then will receive the full batch.
-            let n = requests.recv_many(&mut batch_vec, BATCH_SIZE).await;
+            let mut n = requests.recv_many(&mut batch_vec, BATCH_SIZE).await;
             if n == 0 {
                 log::info!("Requests channel closed, exiting");
                 break;
             }
 
-            let n = if n == 1 {
-                // attempt to receive more requests in 10 second timeout.
-                let rest = tokio::time::timeout(
+            // Leave a short collection window even when recv_many returned more
+            // than one request. Startup recovery can enqueue saved roots first
+            // and a cheaper supervisor proof immediately afterwards.
+            let rest = if n < BATCH_SIZE {
+                tokio::time::timeout(
                     Duration::from_secs(10),
-                    requests.recv_many(&mut batch_vec, BATCH_SIZE - 1),
+                    requests.recv_many(&mut batch_vec, BATCH_SIZE - n),
                 )
-                .await;
+                .await
+            } else {
+                Ok(0)
+            };
 
-                match rest {
-                    Err(_) => {
-                        log::info!("Only one request received, processing it immediately");
-                        let request = batch_vec.pop().expect("at least one request is received");
+            match rest {
+                Err(_) if n == 1 => {
+                    log::info!("Only one request received, processing it immediately");
+                    let request = batch_vec.pop().expect("at least one request is received");
 
-                        self.metrics.pending_requests.set(0);
-                        self.metrics.currently_processing.set(1);
-                        self.metrics
-                            .current_root_block
-                            .set(request.block_number as i64);
+                    self.metrics.pending_requests.set(0);
+                    self.metrics.currently_processing.set(1);
+                    self.metrics
+                        .current_root_block
+                        .set(request.block_number as i64);
 
-                        let proof = self
-                            .generate_proof(
-                                request.block_number,
-                                request.block_hash,
-                                request.merkle_root,
-                                request.inner_proof,
-                                request.block_inclusion_proof,
-                            )
-                            .await?;
+                    let proof = self
+                        .generate_proof(
+                            request.block_number,
+                            request.block_hash,
+                            request.merkle_root,
+                            request.inner_proof,
+                            request.block_inclusion_proof,
+                        )
+                        .await?;
 
-                        if responses
-                            .send(Response::Single {
-                                block_number: request.block_number,
-                                merkle_root: request.merkle_root,
-                                proof,
-                            })
-                            .is_err()
-                        {
-                            log::warn!("Response channel closed, exiting");
-                            return Ok(());
-                        }
-
-                        continue;
+                    if responses
+                        .send(Response::Single {
+                            block_number: request.block_number,
+                            merkle_root: request.merkle_root,
+                            proof,
+                        })
+                        .is_err()
+                    {
+                        log::warn!("Response channel closed, exiting");
+                        return Ok(());
                     }
 
-                    // received more requests, process them in batch
-                    Ok(rest) => rest + 1,
+                    continue;
                 }
-            } else {
-                n
-            };
+
+                Ok(rest) => n += rest,
+                Err(_) => {}
+            }
 
             log::info!("Received {n} requests, grouping by authority set...");
 
@@ -424,7 +423,21 @@ impl FinalityProver {
                 }
             }
 
-            for ((authority_set_id, queue_id), request) in request_groups.iter() {
+            // Bound memory by proving one group at a time, but do not start a
+            // multi-thousand-header proof while a short proof is already queued.
+            let mut ordered_request_groups = std::mem::take(&mut request_groups)
+                .into_iter()
+                .collect::<Vec<_>>();
+            ordered_request_groups.sort_by_key(|((authority_set_id, queue_id), request)| {
+                proof_request_order_key(
+                    *authority_set_id,
+                    *queue_id,
+                    request.block_number,
+                    request.block_inclusion_proof.block_number,
+                )
+            });
+
+            for ((authority_set_id, queue_id), request) in ordered_request_groups {
                 let BatchProofRequest {
                     block_number,
                     block_hash,
@@ -432,9 +445,10 @@ impl FinalityProver {
                     inner_proof,
                     batch_roots,
                     block_inclusion_proof,
-                } = request.clone();
+                } = request;
                 log::info!(
-                    "Proving finality for latest block #{block_number} with authority set #{authority_set_id}, merkle-root {merkle_root} and queue #{queue_id} (will apply to {} blocks)",
+                    "Proving finality for latest block #{block_number} with authority set #{authority_set_id}, merkle-root {merkle_root} and queue #{queue_id} (span {}, will apply to {} blocks)",
+                    block_inclusion_proof.block_number.saturating_sub(block_number),
                     batch_roots.len()
                 );
                 self.metrics
@@ -469,7 +483,7 @@ impl FinalityProver {
                 }
             }
 
-            request_groups.clear();
+            debug_assert!(request_groups.is_empty());
         }
 
         Ok(())
@@ -1160,18 +1174,40 @@ impl BatchProofRequest {
     }
 }
 
+fn proof_request_order_key(
+    authority_set_id: u64,
+    queue_id: u64,
+    block_number: u32,
+    signed_block_number: u32,
+) -> (u32, u64, u64, u32) {
+    (
+        signed_block_number.saturating_sub(block_number),
+        authority_set_id,
+        queue_id,
+        block_number,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        clear_current_shared_request, plan_shared_relayer_requests, record_current_shared_request,
-        record_pending_request_counts, select_next_relayer_id, send_shared_response, Metrics,
-        Response, SharedProofRequestInfo, SharedProofWork,
+        clear_current_shared_request, plan_shared_relayer_requests, proof_request_order_key,
+        record_current_shared_request, record_pending_request_counts, select_next_relayer_id,
+        send_shared_response, Metrics, Response, SharedProofRequestInfo, SharedProofWork,
     };
     use crate::prover_interface::FinalProof;
     use primitive_types::H256;
     use prometheus::Registry;
     use tokio::sync::mpsc;
     use utils_prometheus::MeteredService;
+
+    #[test]
+    fn direct_scheduler_prefers_shortest_finality_span() {
+        let long_recovery = proof_request_order_key(3625, 0, 35_355_709, 35_360_325);
+        let current_root = proof_request_order_key(3625, 597, 35_361_830, 35_361_830);
+
+        assert!(current_root < long_recovery);
+    }
 
     #[test]
     fn shared_scheduler_selects_highest_priority_relayer() {

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -50,6 +50,28 @@ pub enum Response {
         batch_roots: Vec<(u32, H256)>,
     },
 }
+async fn receive_batch<T>(
+    requests: &mut UnboundedReceiver<T>,
+    batch: &mut Vec<T>,
+    limit: usize,
+    collection_window: Duration,
+) -> (usize, bool) {
+    let mut received = requests.recv_many(batch, limit).await;
+    if received == 0 {
+        return (0, false);
+    }
+
+    let deadline = tokio::time::Instant::now() + collection_window;
+    while received < limit {
+        match tokio::time::timeout_at(deadline, requests.recv_many(batch, limit - received)).await {
+            Ok(0) => return (received, false),
+            Ok(additional) => received += additional,
+            Err(_) => return (received, true),
+        }
+    }
+
+    (received, false)
+}
 
 #[derive(Clone)]
 struct ProverContext {
@@ -288,30 +310,16 @@ impl FinalityProver {
         let mut non_batch_requests: Vec<Request> = Vec::new();
 
         loop {
-            let mut n = requests.recv_many(&mut batch_vec, BATCH_SIZE).await;
+            let (n, collection_timed_out) = receive_batch(
+                requests,
+                &mut batch_vec,
+                BATCH_SIZE,
+                Duration::from_secs(10),
+            )
+            .await;
             if n == 0 {
                 log::info!("Requests channel closed, exiting");
                 break;
-            }
-
-            // Collect until the channel has been quiet for ten seconds. Startup
-            // recovery enqueues roots around RPC calls, so a single extra
-            // recv_many can return before the best request arrives.
-            let mut collection_timed_out = false;
-            while n < BATCH_SIZE {
-                match tokio::time::timeout(
-                    Duration::from_secs(10),
-                    requests.recv_many(&mut batch_vec, BATCH_SIZE - n),
-                )
-                .await
-                {
-                    Ok(0) => break,
-                    Ok(rest) => n += rest,
-                    Err(_) => {
-                        collection_timed_out = true;
-                        break;
-                    }
-                }
             }
 
             if collection_timed_out && n == 1 {
@@ -1194,13 +1202,15 @@ fn proof_request_order_key(
 mod tests {
     use super::{
         clear_current_shared_request, plan_shared_relayer_requests, proof_request_order_key,
-        record_current_shared_request, record_pending_request_counts, select_next_relayer_id,
-        send_shared_response, Metrics, Response, SharedProofRequestInfo, SharedProofWork,
+        receive_batch, record_current_shared_request, record_pending_request_counts,
+        select_next_relayer_id, send_shared_response, Metrics, Response, SharedProofRequestInfo,
+        SharedProofWork,
     };
     use crate::prover_interface::FinalProof;
     use primitive_types::H256;
     use prometheus::Registry;
-    use tokio::sync::mpsc;
+    use std::time::Duration;
+    use tokio::{sync::mpsc, time::sleep};
     use utils_prometheus::MeteredService;
 
     #[test]
@@ -1209,6 +1219,32 @@ mod tests {
         let current_root = proof_request_order_key(3625, 597, 35_361_830, 35_361_830);
 
         assert!(current_root < long_recovery);
+    }
+    #[tokio::test]
+    async fn batch_collection_uses_one_deadline() {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        sender.send(0).unwrap();
+
+        let producer = tokio::spawn(async move {
+            for value in 1..100 {
+                sleep(Duration::from_millis(5)).await;
+                if sender.send(value).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let mut batch = Vec::new();
+        let (received, timed_out) =
+            receive_batch(&mut receiver, &mut batch, 100, Duration::from_millis(40)).await;
+        producer.abort();
+
+        assert!(timed_out, "collection should stop at the original deadline");
+        assert_eq!(received, batch.len());
+        assert!(
+            received < 100,
+            "a steady stream must not renew the deadline"
+        );
     }
 
     #[test]

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -294,57 +294,59 @@ impl FinalityProver {
                 break;
             }
 
-            // Leave a short collection window even when recv_many returned more
-            // than one request. Startup recovery can enqueue saved roots first
-            // and a cheaper supervisor proof immediately afterwards.
-            let rest = if n < BATCH_SIZE {
-                tokio::time::timeout(
+            // Collect until the channel has been quiet for ten seconds. Startup
+            // recovery enqueues roots around RPC calls, so a single extra
+            // recv_many can return before the best request arrives.
+            let mut collection_timed_out = false;
+            while n < BATCH_SIZE {
+                match tokio::time::timeout(
                     Duration::from_secs(10),
                     requests.recv_many(&mut batch_vec, BATCH_SIZE - n),
                 )
                 .await
-            } else {
-                Ok(0)
-            };
-
-            match rest {
-                Err(_) if n == 1 => {
-                    log::info!("Only one request received, processing it immediately");
-                    let request = batch_vec.pop().expect("at least one request is received");
-
-                    self.metrics.pending_requests.set(0);
-                    self.metrics.currently_processing.set(1);
-                    self.metrics
-                        .current_root_block
-                        .set(request.block_number as i64);
-
-                    let proof = self
-                        .generate_proof(
-                            request.block_number,
-                            request.block_hash,
-                            request.merkle_root,
-                            request.inner_proof,
-                            request.block_inclusion_proof,
-                        )
-                        .await?;
-
-                    if responses
-                        .send(Response::Single {
-                            block_number: request.block_number,
-                            merkle_root: request.merkle_root,
-                            proof,
-                        })
-                        .is_err()
-                    {
-                        log::warn!("Response channel closed, exiting");
-                        return Ok(());
+                {
+                    Ok(0) => break,
+                    Ok(rest) => n += rest,
+                    Err(_) => {
+                        collection_timed_out = true;
+                        break;
                     }
+                }
+            }
 
-                    continue;
+            if collection_timed_out && n == 1 {
+                log::info!("Only one request received, processing it immediately");
+                let request = batch_vec.pop().expect("at least one request is received");
+
+                self.metrics.pending_requests.set(0);
+                self.metrics.currently_processing.set(1);
+                self.metrics
+                    .current_root_block
+                    .set(request.block_number as i64);
+
+                let proof = self
+                    .generate_proof(
+                        request.block_number,
+                        request.block_hash,
+                        request.merkle_root,
+                        request.inner_proof,
+                        request.block_inclusion_proof,
+                    )
+                    .await?;
+
+                if responses
+                    .send(Response::Single {
+                        block_number: request.block_number,
+                        merkle_root: request.merkle_root,
+                        proof,
+                    })
+                    .is_err()
+                {
+                    log::warn!("Response channel closed, exiting");
+                    return Ok(());
                 }
 
-                Ok(rest) => n += rest,
-                Err(_) => {}
+                continue;
             }
 
             log::info!("Received {n} requests, grouping by authority set...");

--- a/relayer/src/merkle_roots/submitter.rs
+++ b/relayer/src/merkle_roots/submitter.rs
@@ -456,6 +456,10 @@ impl MerkleRootSubmitter {
     }
 }
 
+fn should_retry_process_error(err: &anyhow::Error) -> bool {
+    rpc::classify_anyhow(err) == rpc::RetryDecision::Retry
+}
+
 async fn task(
     mut this: MerkleRootSubmitter,
     mut proofs: UnboundedReceiver<Request>,
@@ -466,6 +470,16 @@ async fn task(
     loop {
         match this.process(&mut proofs, &responses).await {
             Ok(_) => break,
+            Err(e) if !should_retry_process_error(&e) => {
+                // Dropping `responses` closes the parent channel and makes the Merkle
+                // relayer fail visibly. Restarting this task would lose any request or
+                // receipt result already removed from its in-memory queue.
+                log::error!(
+                    "Merkle root relayer {} submitter failed with a non-recoverable error, exiting: {e}",
+                    this.relayer_id
+                );
+                break;
+            }
             Err(e) => {
                 attempts += 1;
                 let delay = BASE_RETRY_DELAY * 2u32.pow(attempts - 1);
@@ -494,5 +508,33 @@ async fn task(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::transports::{RpcError, TransportErrorKind};
+
+    #[test]
+    fn permanent_reconciliation_error_stops_submitter_task() {
+        let err = ethereum_client::Error::ErrorDuringContractExecution(
+            alloy::contract::Error::TransportError(RpcError::ErrorResp(
+                serde_json::from_str(r#"{"code":-32603,"message":"execution failed"}"#).unwrap(),
+            )),
+        );
+
+        assert!(!should_retry_process_error(&err.into()));
+    }
+
+    #[test]
+    fn backend_disconnect_retries_submitter_task() {
+        let err = ethereum_client::Error::ErrorDuringContractExecution(
+            alloy::contract::Error::TransportError(RpcError::Transport(
+                TransportErrorKind::BackendGone,
+            )),
+        );
+
+        assert!(should_retry_process_error(&err.into()));
     }
 }

--- a/relayer/src/merkle_roots/submitter.rs
+++ b/relayer/src/merkle_roots/submitter.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 use crate::{
-    common::{submit_merkle_root_to_ethereum, BASE_RETRY_DELAY, MAX_RETRIES},
+    common::{submit_merkle_root_to_ethereum, MAX_RETRIES},
     prover_interface::FinalProof,
     rpc,
 };
@@ -215,9 +215,10 @@ impl MerkleRootSubmitter {
         &mut self,
         gear_block: u32,
     ) -> Result<Option<[u8; 32]>, ethereum_client::Error> {
-        rpc::retry_eth(
+        rpc::retry_eth_bounded(
             &mut self.eth_api,
             "read finalized MessageQueue merkle root",
+            MAX_RETRIES,
             |api| async move { api.read_finalized_merkle_root(gear_block).await },
         )
         .await
@@ -231,8 +232,12 @@ impl MerkleRootSubmitter {
         let mut pending_transactions = FuturesUnordered::new();
         loop {
             let relayer_id = self.relayer_id.clone();
-            let balance = self.eth_api.get_approx_balance().await?;
-            self.metrics.fee_payer_balance.set(balance);
+            match self.eth_api.get_approx_balance().await {
+                Ok(balance) => self.metrics.fee_payer_balance.set(balance),
+                Err(err) => log::warn!(
+                    "Merkle root relayer {relayer_id}: failed to update Ethereum fee payer balance metric: {err}"
+                ),
+            }
             self.metrics
                 .pending_submissions
                 .set(pending_transactions.len() as i64);
@@ -261,9 +266,10 @@ impl MerkleRootSubmitter {
                         continue;
                     }
 
-                    match rpc::retry_eth(
+                    match rpc::retry_eth_bounded(
                         &mut self.eth_api,
                         "submit merkle root",
+                        MAX_RETRIES,
                         |api| {
                             let proof = request.proof.clone();
                             async move { submit_merkle_root_to_ethereum(&api, proof).await }
@@ -287,6 +293,12 @@ impl MerkleRootSubmitter {
                                 self.confirmations,
                             ));
                             continue;
+                        }
+                        Err(err)
+                            if rpc::classify_ethereum_error(&err)
+                                == rpc::RetryDecision::Retry =>
+                        {
+                            return Err(err.into());
                         }
                         // How do we get here?
                         // - Relayer crashed and already submitted the merkle root but not yet confirmed it
@@ -456,85 +468,18 @@ impl MerkleRootSubmitter {
     }
 }
 
-fn should_retry_process_error(err: &anyhow::Error) -> bool {
-    rpc::classify_anyhow(err) == rpc::RetryDecision::Retry
-}
-
 async fn task(
     mut this: MerkleRootSubmitter,
     mut proofs: UnboundedReceiver<Request>,
     responses: UnboundedSender<Response>,
 ) {
-    let mut attempts = 0;
-
-    loop {
-        match this.process(&mut proofs, &responses).await {
-            Ok(_) => break,
-            Err(e) if !should_retry_process_error(&e) => {
-                // Dropping `responses` closes the parent channel and makes the Merkle
-                // relayer fail visibly. Restarting this task would lose any request or
-                // receipt result already removed from its in-memory queue.
-                log::error!(
-                    "Merkle root relayer {} submitter failed with a non-recoverable error, exiting: {e}",
-                    this.relayer_id
-                );
-                break;
-            }
-            Err(e) => {
-                attempts += 1;
-                let delay = BASE_RETRY_DELAY * 2u32.pow(attempts - 1);
-                log::error!(
-                    "Merkle root relayer {} submitter failed (attempt: {attempts}/{MAX_RETRIES}): {e}. Retrying in {delay:?}",
-                    this.relayer_id,
-                );
-                if attempts >= MAX_RETRIES {
-                    log::error!(
-                        "Merkle root relayer {} submitter maximum attempts reached, exiting...",
-                        this.relayer_id
-                    );
-                    break;
-                }
-                tokio::time::sleep(delay).await;
-
-                match this.eth_api.reconnect().await {
-                    Ok(eth_api) => this.eth_api = eth_api,
-                    Err(e) => {
-                        log::error!(
-                            "Merkle root relayer {} submitter failed to reconnect to Ethereum API: {e}",
-                            this.relayer_id
-                        );
-                        break;
-                    }
-                }
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy::transports::{RpcError, TransportErrorKind};
-
-    #[test]
-    fn permanent_reconciliation_error_stops_submitter_task() {
-        let err = ethereum_client::Error::ErrorDuringContractExecution(
-            alloy::contract::Error::TransportError(RpcError::ErrorResp(
-                serde_json::from_str(r#"{"code":-32603,"message":"execution failed"}"#).unwrap(),
-            )),
+    if let Err(err) = this.process(&mut proofs, &responses).await {
+        // Restarting only this task would lose requests and receipt results that
+        // `process` already removed from its in-memory queues. Closing the response
+        // channel makes the parent relayer restart from its durable root state.
+        log::error!(
+            "Merkle root relayer {} submitter failed, exiting: {err}",
+            this.relayer_id
         );
-
-        assert!(!should_retry_process_error(&err.into()));
-    }
-
-    #[test]
-    fn backend_disconnect_retries_submitter_task() {
-        let err = ethereum_client::Error::ErrorDuringContractExecution(
-            alloy::contract::Error::TransportError(RpcError::Transport(
-                TransportErrorKind::BackendGone,
-            )),
-        );
-
-        assert!(should_retry_process_error(&err.into()));
     }
 }

--- a/relayer/src/merkle_roots/submitter.rs
+++ b/relayer/src/merkle_roots/submitter.rs
@@ -211,6 +211,18 @@ impl MerkleRootSubmitter {
         }
     }
 
+    async fn read_finalized_merkle_root(
+        &mut self,
+        gear_block: u32,
+    ) -> Result<Option<[u8; 32]>, ethereum_client::Error> {
+        rpc::retry_eth(
+            &mut self.eth_api,
+            "read finalized MessageQueue merkle root",
+            |api| async move { api.read_finalized_merkle_root(gear_block).await },
+        )
+        .await
+    }
+
     async fn process(
         &mut self,
         proofs: &mut UnboundedReceiver<Request>,
@@ -218,7 +230,7 @@ impl MerkleRootSubmitter {
     ) -> anyhow::Result<()> {
         let mut pending_transactions = FuturesUnordered::new();
         loop {
-            let relayer_id = self.relayer_id.as_str();
+            let relayer_id = self.relayer_id.clone();
             let balance = self.eth_api.get_approx_balance().await?;
             self.metrics.fee_payer_balance.set(balance);
             self.metrics
@@ -249,8 +261,16 @@ impl MerkleRootSubmitter {
                         continue;
                     }
 
-                    loop {
-                    match submit_merkle_root_to_ethereum(&self.eth_api, request.proof.clone()).await {
+                    match rpc::retry_eth(
+                        &mut self.eth_api,
+                        "submit merkle root",
+                        |api| {
+                            let proof = request.proof.clone();
+                            async move { submit_merkle_root_to_ethereum(&api, proof).await }
+                        },
+                    )
+                    .await
+                    {
                         Ok(pending_tx) => {
                             log::info!(
                                 "Merkle root relayer {relayer_id}: submitted merkle root to Ethereum, tx hash: {}",
@@ -266,14 +286,13 @@ impl MerkleRootSubmitter {
                                 request.proof,
                                 self.confirmations,
                             ));
-                            break;
+                            continue;
                         }
                         // How do we get here?
                         // - Relayer crashed and already submitted the merkle root but not yet confirmed it
                         // - Somebody else submitted the merkle root
                         Err(ethereum_client::Error::ErrorDuringContractExecution(err)) => {
-                            let root_exists = self.eth_api
-                                .read_finalized_merkle_root(request.proof.block_number)
+                            let root_exists = self.read_finalized_merkle_root(request.proof.block_number)
                                 .await?
                                 .is_some();
 
@@ -288,7 +307,7 @@ impl MerkleRootSubmitter {
                                 }).is_err() {
                                     return Ok(());
                                 };
-                                break;
+                                continue;
                             } else {
                                 log::error!("Merkle root relayer {relayer_id}: failed to submit merkle root {}: Error during contract execution: {err:?}", H256::from(request.proof.merkle_root));
                                 self.metrics.failed_submissions.inc();
@@ -302,21 +321,9 @@ impl MerkleRootSubmitter {
                                 }).is_err() {
                                     return Ok(());
                                 };
-                                break;
+                                continue;
                             }
                         }
-
-
-                        Err(err) if is_recoverable_eth_error(&err) => {
-                            log::warn!(
-                                "Merkle root relayer {relayer_id}: recoverable error while submitting merkle root {}: {err}. Reconnecting and retrying",
-                                H256::from(request.proof.merkle_root)
-                            );
-                            tokio::time::sleep(BASE_RETRY_DELAY).await;
-                            self.eth_api = self.eth_api.reconnect().await?;
-                            continue;
-                        }
-
                         Err(err) => {
 
                             log::error!("Merkle root relayer {relayer_id}: failed to submit merkle root {}: {}", H256::from(request.proof.merkle_root), err);
@@ -331,9 +338,8 @@ impl MerkleRootSubmitter {
                             }).is_err() {
                                 return Ok(());
                             };
-                            break;
+                            continue;
                         }
-                    }
                     }
                 },
 
@@ -353,8 +359,7 @@ impl MerkleRootSubmitter {
                             self.metrics.last_gas_used.set(gas_used);
 
                             if !submitted.receipt.status() {
-                                let root_exists = self.eth_api
-                                    .read_finalized_merkle_root(submitted.proof.block_number)
+                                let root_exists = self.read_finalized_merkle_root(submitted.proof.block_number)
                                     .await?
                                     .is_some();
 
@@ -403,8 +408,7 @@ impl MerkleRootSubmitter {
                         }
 
                         Err(err) => {
-                            let root_exists = self.eth_api
-                                .read_finalized_merkle_root(err.proof.block_number)
+                            let root_exists = self.read_finalized_merkle_root(err.proof.block_number)
                                 .await?
                                 .is_some();
 
@@ -449,15 +453,6 @@ impl MerkleRootSubmitter {
         tokio::task::spawn(task(self, rx, response_tx));
 
         SubmitterIo::new(tx, response_rx)
-    }
-}
-
-fn is_recoverable_eth_error(err: &ethereum_client::Error) -> bool {
-    match err {
-        ethereum_client::Error::ErrorInHTTPTransport(err) => {
-            crate::common::is_rpc_transport_error_recoverable(err)
-        }
-        _ => rpc::is_recoverable_error_text(err),
     }
 }
 

--- a/relayer/src/message_relayer/eth_to_gear/proof_composer.rs
+++ b/relayer/src/message_relayer/eth_to_gear/proof_composer.rs
@@ -1,6 +1,9 @@
 use std::ops::ControlFlow;
 
-use crate::message_relayer::common::{EthereumSlotNumber, TxHashWithSlot};
+use crate::{
+    message_relayer::common::{EthereumSlotNumber, TxHashWithSlot},
+    rpc,
+};
 use alloy::providers::Provider;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_rlp::Encodable;
@@ -194,11 +197,8 @@ async fn task(
                 }
             }
 
-            match this.eth_api.reconnect().await {
-                Ok(eth_api) => {
-                    this.eth_api = eth_api;
-                    log::info!("Successfully reconnected to Ethereum API");
-                }
+            match rpc::reconnect_polling_eth(&mut this.eth_api).await {
+                Ok(()) => log::info!("Successfully reconnected to Ethereum API"),
                 Err(err) => {
                     log::error!("Failed to reconnect to Ethereum API: {err:?}");
                     return;

--- a/relayer/src/message_relayer/eth_to_gear/proof_composer.rs
+++ b/relayer/src/message_relayer/eth_to_gear/proof_composer.rs
@@ -195,7 +195,10 @@ async fn task(
             }
 
             match this.eth_api.reconnect().await {
-                Ok(_) => log::info!("Successfully reconnected to Ethereum API"),
+                Ok(eth_api) => {
+                    this.eth_api = eth_api;
+                    log::info!("Successfully reconnected to Ethereum API");
+                }
                 Err(err) => {
                     log::error!("Failed to reconnect to Ethereum API: {err:?}");
                     return;

--- a/relayer/src/proof_storage/file_system.rs
+++ b/relayer/src/proof_storage/file_system.rs
@@ -183,9 +183,12 @@ mod tests {
         std::env::temp_dir().join(format!("gear-bridges-{test_name}-{}", uuid::Uuid::new_v4()))
     }
 
-    fn assert_inner_io_error(err: ProofStorageError) {
+    fn assert_inner_io_error(err: ProofStorageError, operation: &str, path: &Path) {
         match err {
             ProofStorageError::InnerError(err) => {
+                let message = err.to_string();
+                assert!(message.contains(operation), "{message}");
+                assert!(message.contains(&path.display().to_string()), "{message}");
                 assert!(err.chain().any(|cause| cause.is::<io::Error>()));
             }
             err => panic!("expected filesystem error, got {err}"),
@@ -211,7 +214,7 @@ mod tests {
             .await
             .err()
             .expect("a regular file cannot be used as a storage directory");
-        assert_inner_io_error(err);
+        assert_inner_io_error(err, "create proof storage directory", &path);
 
         fs::remove_file(path).await.unwrap();
     }
@@ -227,7 +230,11 @@ mod tests {
             .await
             .err()
             .expect("a directory cannot be read as circuit data");
-        assert_inner_io_error(err);
+        assert_inner_io_error(
+            err,
+            "read proof storage circuit data",
+            &path.join("circuit_data.bin"),
+        );
 
         fs::remove_dir_all(path).await.unwrap();
     }
@@ -244,7 +251,30 @@ mod tests {
             .atomic_write("circuit_data.bin", vec![1, 2, 3])
             .await
             .unwrap_err();
-        assert_inner_io_error(err);
+        assert_inner_io_error(
+            err,
+            "write proof storage temporary file",
+            &path.join("circuit_data.bin.tmp"),
+        );
+
+        fs::remove_dir_all(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn atomic_write_preserves_rename_error_context() {
+        let path = temporary_storage_path("failed-atomic-rename");
+        let storage = FileSystemProofStorage::new(path.clone()).await.unwrap();
+        fs::create_dir(path.join("circuit_data.bin")).await.unwrap();
+
+        let err = storage
+            .atomic_write("circuit_data.bin", vec![1, 2, 3])
+            .await
+            .unwrap_err();
+        assert_inner_io_error(
+            err,
+            "replace proof storage file",
+            &path.join("circuit_data.bin"),
+        );
 
         fs::remove_dir_all(path).await.unwrap();
     }

--- a/relayer/src/proof_storage/file_system.rs
+++ b/relayer/src/proof_storage/file_system.rs
@@ -61,6 +61,12 @@ impl ProofStorage for FileSystemProofStorage {
 
 impl FileSystemProofStorage {
     pub async fn new(save_to: PathBuf) -> Result<FileSystemProofStorage, ProofStorageError> {
+        if save_to.as_os_str().is_empty() {
+            return Err(ProofStorageError::InnerError(anyhow::anyhow!(
+                "proof storage path must not be empty"
+            )));
+        }
+
         fs::create_dir_all(&save_to)
             .await
             .map_err(|err| io_error("create proof storage directory", &save_to, err))?;
@@ -193,6 +199,19 @@ mod tests {
             }
             err => panic!("expected filesystem error, got {err}"),
         }
+    }
+
+    #[tokio::test]
+    async fn empty_storage_path_is_rejected() {
+        let err = FileSystemProofStorage::new(PathBuf::new())
+            .await
+            .err()
+            .expect("an empty path must not use the process working directory");
+
+        assert!(
+            err.to_string().contains("path must not be empty"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/relayer/src/proof_storage/file_system.rs
+++ b/relayer/src/proof_storage/file_system.rs
@@ -1,11 +1,20 @@
 use super::{AuthoritySetId, InMemoryProofStorage, ProofStorage, ProofStorageError};
 use prover::proving::{CircuitData, Proof, ProofWithCircuitData};
-use std::path::PathBuf;
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
 use tokio::fs;
 
 pub struct FileSystemProofStorage {
     cache: InMemoryProofStorage,
     save_to: PathBuf,
+}
+
+fn io_error(operation: &str, path: &Path, err: io::Error) -> ProofStorageError {
+    ProofStorageError::InnerError(
+        anyhow::Error::new(err).context(format!("{operation}: {}", path.display())),
+    )
 }
 
 #[async_trait::async_trait]
@@ -51,26 +60,25 @@ impl ProofStorage for FileSystemProofStorage {
 }
 
 impl FileSystemProofStorage {
-    pub async fn new(save_to: PathBuf) -> FileSystemProofStorage {
+    pub async fn new(save_to: PathBuf) -> Result<FileSystemProofStorage, ProofStorageError> {
         fs::create_dir_all(&save_to)
             .await
-            .expect("Failed to create directory for proof storage");
-        if !save_to.is_dir() {
-            panic!("Please provide directory as a path");
-        }
+            .map_err(|err| io_error("create proof storage directory", &save_to, err))?;
 
         let mut storage = FileSystemProofStorage {
             cache: InMemoryProofStorage::default(),
             save_to,
         };
 
-        if storage.load_state().await.is_ok() {
-            log::info!("Proof storage state loaded successfully");
-        } else {
-            log::info!("Proof storage state not found. Waiting for initialization");
+        match storage.load_state().await {
+            Ok(()) => log::info!("Proof storage state loaded successfully"),
+            Err(ProofStorageError::NotInitialized) => {
+                log::info!("Proof storage state not found. Waiting for initialization")
+            }
+            Err(err) => return Err(err),
         }
 
-        storage
+        Ok(storage)
     }
 
     async fn save_state(&self) -> Result<(), ProofStorageError> {
@@ -97,52 +105,66 @@ impl FileSystemProofStorage {
         let tmp_path = self.save_to.join(format!("{name}.tmp"));
         fs::write(&tmp_path, bytes)
             .await
-            .map_err(|_| ProofStorageError::NotInitialized)?;
+            .map_err(|err| io_error("write proof storage temporary file", &tmp_path, err))?;
         fs::rename(&tmp_path, &path)
             .await
-            .map_err(|_| ProofStorageError::NotInitialized)?;
+            .map_err(|err| io_error("replace proof storage file", &path, err))?;
         Ok(())
     }
 
     async fn load_state(&mut self) -> Result<(), ProofStorageError> {
-        let circuit_data = fs::read(self.save_to.join("circuit_data.bin"))
-            .await
-            .map_err(|_| ProofStorageError::NotInitialized)?;
+        let circuit_data_path = self.save_to.join("circuit_data.bin");
+        let circuit_data = match fs::read(&circuit_data_path).await {
+            Ok(circuit_data) => circuit_data,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Err(ProofStorageError::NotInitialized);
+            }
+            Err(err) => {
+                return Err(io_error(
+                    "read proof storage circuit data",
+                    &circuit_data_path,
+                    err,
+                ));
+            }
+        };
         self.cache.inner().write().await.circuit_data = Some(CircuitData::from_bytes(circuit_data));
 
         let prefix = "proof_";
         let postfix = ".bin";
         let mut read_dir = fs::read_dir(&self.save_to)
             .await
-            .map_err(|_| ProofStorageError::NotInitialized)?;
+            .map_err(|err| io_error("read proof storage directory", &self.save_to, err))?;
 
         let mut found_validator_set_ids = Vec::new();
 
         while let Some(entry) = read_dir
             .next_entry()
             .await
-            .map_err(|_| ProofStorageError::NotInitialized)?
+            .map_err(|err| io_error("read proof storage directory entry", &self.save_to, err))?
         {
             let file_name = entry.file_name();
-            let file_name = file_name.to_str();
-
-            let valid_name = file_name
-                .map(|str| (&str[..prefix.len()], &str[str.len() - postfix.len()..]))
-                == Some((prefix, postfix));
-
-            if valid_name {
-                let file_name = file_name.expect("Invalid file name");
-                let set_id = &file_name[prefix.len()..file_name.len() - postfix.len()];
-                let set_id: u64 = set_id.parse().expect("Invalid file name");
-                found_validator_set_ids.push(set_id);
-            }
+            let Some(set_id) = file_name
+                .to_str()
+                .and_then(|name| name.strip_prefix(prefix))
+                .and_then(|name| name.strip_suffix(postfix))
+            else {
+                continue;
+            };
+            let set_id = set_id.parse::<u64>().map_err(|err| {
+                ProofStorageError::InnerError(anyhow::anyhow!(
+                    "invalid authority-set proof file name {}: {err}",
+                    entry.path().display()
+                ))
+            })?;
+            found_validator_set_ids.push(set_id);
         }
 
         let mut inner = self.cache.inner().write().await;
         for validator_set_id in found_validator_set_ids {
-            let proof = fs::read(self.save_to.join(format!("proof_{validator_set_id}.bin")))
+            let proof_path = self.save_to.join(format!("proof_{validator_set_id}.bin"));
+            let proof = fs::read(&proof_path)
                 .await
-                .map_err(|_| ProofStorageError::NotInitialized)?;
+                .map_err(|err| io_error("read authority-set proof", &proof_path, err))?;
 
             inner
                 .proofs
@@ -150,5 +172,80 @@ impl FileSystemProofStorage {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temporary_storage_path(test_name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("gear-bridges-{test_name}-{}", uuid::Uuid::new_v4()))
+    }
+
+    fn assert_inner_io_error(err: ProofStorageError) {
+        match err {
+            ProofStorageError::InnerError(err) => {
+                assert!(err.chain().any(|cause| cause.is::<io::Error>()));
+            }
+            err => panic!("expected filesystem error, got {err}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_state_is_treated_as_uninitialized() {
+        let path = temporary_storage_path("missing-proof-state");
+        let storage = FileSystemProofStorage::new(path.clone()).await.unwrap();
+
+        assert_eq!(storage.get_latest_authority_set_id().await, None);
+
+        fs::remove_dir_all(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn storage_path_that_is_a_file_returns_io_error() {
+        let path = temporary_storage_path("storage-path-is-file");
+        fs::write(&path, b"not a directory").await.unwrap();
+
+        let err = FileSystemProofStorage::new(path.clone())
+            .await
+            .err()
+            .expect("a regular file cannot be used as a storage directory");
+        assert_inner_io_error(err);
+
+        fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unreadable_circuit_data_is_reported_as_io_error() {
+        let path = temporary_storage_path("invalid-circuit-data");
+        fs::create_dir_all(path.join("circuit_data.bin"))
+            .await
+            .unwrap();
+
+        let err = FileSystemProofStorage::new(path.clone())
+            .await
+            .err()
+            .expect("a directory cannot be read as circuit data");
+        assert_inner_io_error(err);
+
+        fs::remove_dir_all(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn atomic_write_preserves_the_io_error() {
+        let path = temporary_storage_path("failed-atomic-write");
+        let storage = FileSystemProofStorage::new(path.clone()).await.unwrap();
+        fs::create_dir(path.join("circuit_data.bin.tmp"))
+            .await
+            .unwrap();
+
+        let err = storage
+            .atomic_write("circuit_data.bin", vec![1, 2, 3])
+            .await
+            .unwrap_err();
+        assert_inner_io_error(err);
+
+        fs::remove_dir_all(path).await.unwrap();
     }
 }

--- a/relayer/src/rpc.rs
+++ b/relayer/src/rpc.rs
@@ -130,7 +130,7 @@ pub fn classify_alloy_rpc(err: &RpcError<TransportErrorKind>) -> RetryDecision {
                 RetryDecision::Retry
             }
             TransportErrorKind::HttpError(err)
-                if err.status == 429 || matches!(err.status, 500 | 502 | 503 | 504) =>
+                if matches!(err.status, 408 | 429 | 500 | 502 | 503 | 504) =>
             {
                 RetryDecision::Retry
             }
@@ -186,6 +186,11 @@ where
         classify_ethereum_error,
     )
     .await
+}
+/// Reconnect a polling Ethereum client and retain the replacement provider.
+pub async fn reconnect_polling_eth(api: &mut ethereum_client::PollingEthApi) -> anyhow::Result<()> {
+    *api = api.reconnect().await?;
+    Ok(())
 }
 
 pub(crate) async fn retry_eth_bounded<T, F, Fut>(
@@ -375,7 +380,7 @@ mod tests {
 
     #[test]
     fn classifies_only_retryable_http_statuses_as_recoverable() {
-        for status in [429, 500, 502, 503, 504] {
+        for status in [408, 429, 500, 502, 503, 504] {
             let err = TransportErrorKind::http_error(status, String::new());
             assert_eq!(classify_alloy_rpc(&err), RetryDecision::Retry);
         }

--- a/relayer/src/rpc.rs
+++ b/relayer/src/rpc.rs
@@ -21,11 +21,12 @@ pub enum RetryDecision {
 }
 
 #[derive(Debug, Error)]
-#[error("{operation} failed with {kind:?} RPC error: {message}")]
+#[error("{operation} failed with {kind:?} operation error: {source}")]
 pub struct RpcFailure {
     pub operation: &'static str,
     pub kind: RpcFailureKind,
-    pub message: String,
+    #[source]
+    pub source: anyhow::Error,
 }
 
 #[derive(Debug, Clone)]
@@ -60,18 +61,19 @@ impl RetryPolicy {
 }
 
 pub fn classify_anyhow(err: &anyhow::Error) -> RetryDecision {
-    if err.chain().any(is_recoverable_error_text) {
-        return RetryDecision::Retry;
-    }
-
-    if let Some(ethereum_client::Error::ErrorInHTTPTransport(err)) =
-        err.downcast_ref::<ethereum_client::Error>()
-    {
-        return classify_alloy_rpc(err);
+    if let Some(err) = err.downcast_ref::<ethereum_client::Error>() {
+        return classify_ethereum_error(err);
     }
 
     if let Some(err) = err.downcast_ref::<RpcError<TransportErrorKind>>() {
         return classify_alloy_rpc(err);
+    }
+
+    if let Some(err) = err.downcast_ref::<RpcFailure>() {
+        return match err.kind {
+            RpcFailureKind::Recoverable => RetryDecision::Retry,
+            RpcFailureKind::Permanent => RetryDecision::Fail,
+        };
     }
 
     if let Some(gclient::Error::GearSDK(gsdk::Error::Subxt(err))) =
@@ -94,16 +96,37 @@ pub fn classify_anyhow(err: &anyhow::Error) -> RetryDecision {
         }
     }
 
+    if err.chain().any(is_recoverable_error_text) {
+        return RetryDecision::Retry;
+    }
+
     RetryDecision::Fail
+}
+
+pub fn classify_ethereum_error(err: &ethereum_client::Error) -> RetryDecision {
+    match err {
+        ethereum_client::Error::ErrorInHTTPTransport(err) => classify_alloy_rpc(err),
+        ethereum_client::Error::ErrorDuringContractExecution(err)
+        | ethereum_client::Error::ErrorSendingTransaction(err)
+        | ethereum_client::Error::ErrorQueryingEvent(err) => match err {
+            alloy::contract::Error::TransportError(err) => classify_alloy_rpc(err),
+            _ => RetryDecision::Fail,
+        },
+        _ => RetryDecision::Fail,
+    }
 }
 
 pub fn classify_alloy_rpc(err: &RpcError<TransportErrorKind>) -> RetryDecision {
     match err {
         RpcError::Transport(transport) => match transport {
-            TransportErrorKind::MissingBatchResponse(_)
-            | TransportErrorKind::BackendGone
-            | TransportErrorKind::PubsubUnavailable
-            | TransportErrorKind::HttpError(_) => RetryDecision::Retry,
+            TransportErrorKind::MissingBatchResponse(_) | TransportErrorKind::BackendGone => {
+                RetryDecision::Retry
+            }
+            TransportErrorKind::HttpError(err)
+                if err.status == 429 || matches!(err.status, 500 | 502 | 503 | 504) =>
+            {
+                RetryDecision::Retry
+            }
             TransportErrorKind::Custom(message) if is_recoverable_error_text(message) => {
                 RetryDecision::Retry
             }
@@ -123,6 +146,7 @@ pub fn is_recoverable_error_text(message: impl std::fmt::Display) -> bool {
         || message.contains("disconnected will reconnect")
         || message.contains("restart required")
         || message.contains("backend gone")
+        || message.contains("backend connection task has stopped")
         || message.contains("transport error")
         || message.contains("subscription dropped")
         || message.contains("connection refused")
@@ -132,14 +156,84 @@ pub fn is_recoverable_error_text(message: impl std::fmt::Display) -> bool {
         || message.contains("timeout")
 }
 
+/// Retry an Ethereum operation without dropping its in-memory work item.
+///
+/// This helper intentionally waits until a recoverable outage ends. Callers in a
+/// multiplexed event loop should instead bound reconnection and reschedule the work.
+pub async fn retry_eth<T, F, Fut>(
+    api: &mut ethereum_client::EthApi,
+    operation: &'static str,
+    mut f: F,
+) -> Result<T, ethereum_client::Error>
+where
+    F: FnMut(ethereum_client::EthApi) -> Fut,
+    Fut: Future<Output = Result<T, ethereum_client::Error>>,
+{
+    let mut attempt = 0;
+    let policy = RetryPolicy::default();
+
+    loop {
+        match f(api.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(err) if classify_ethereum_error(&err) == RetryDecision::Retry => {
+                let delay = policy.delay(attempt);
+                log::warn!(
+                    "{operation} failed with recoverable Ethereum RPC error: {err}. Reconnecting in {delay:?}"
+                );
+                tokio::time::sleep(delay).await;
+
+                loop {
+                    match api.reconnect().await {
+                        Ok(reconnected) => {
+                            *api = reconnected;
+                            attempt = attempt.saturating_add(1);
+                            log::info!(
+                                "{operation}: reconnected to Ethereum API, retrying operation"
+                            );
+                            break;
+                        }
+                        Err(err) if classify_ethereum_error(&err) == RetryDecision::Retry => {
+                            let delay = policy.delay(attempt);
+                            log::warn!(
+                                "{operation} failed to reconnect to Ethereum after a recoverable RPC error: {err}. Retrying in {delay:?}"
+                            );
+                            tokio::time::sleep(delay).await;
+                            attempt = attempt.saturating_add(1);
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
 pub async fn retry_gear<T, F, Fut>(
     connection: &mut ApiProviderConnection,
     operation: &'static str,
-    mut f: F,
+    f: F,
 ) -> anyhow::Result<T>
 where
     F: FnMut(GearApi) -> Fut,
     Fut: Future<Output = anyhow::Result<T>>,
+{
+    retry_gear_if(connection, operation, f, |err| {
+        classify_anyhow(err) == RetryDecision::Retry
+    })
+    .await
+}
+
+pub async fn retry_gear_if<T, F, Fut, P>(
+    connection: &mut ApiProviderConnection,
+    operation: &'static str,
+    mut f: F,
+    should_retry: P,
+) -> anyhow::Result<T>
+where
+    F: FnMut(GearApi) -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+    P: Fn(&anyhow::Error) -> bool,
 {
     let mut attempt = 0;
     let policy = RetryPolicy::default();
@@ -148,7 +242,7 @@ where
         let client = connection.client();
         match f(client).await {
             Ok(value) => return Ok(value),
-            Err(err) if classify_anyhow(&err) == RetryDecision::Retry => {
+            Err(err) if should_retry(&err) => {
                 let delay = policy.delay(attempt);
                 log::warn!(
                     "{operation} failed with recoverable Gear RPC error: {err}. Reconnecting in {delay:?}"
@@ -166,7 +260,7 @@ where
                 return Err(RpcFailure {
                     operation,
                     kind: RpcFailureKind::Permanent,
-                    message: err.to_string(),
+                    source: err,
                 }
                 .into());
             }
@@ -213,6 +307,68 @@ mod tests {
         let err = RpcError::Transport(TransportErrorKind::BackendGone);
 
         assert_eq!(classify_alloy_rpc(&err), RetryDecision::Retry);
+    }
+
+    #[test]
+    fn classifies_only_retryable_http_statuses_as_recoverable() {
+        for status in [429, 500, 502, 503, 504] {
+            let err = TransportErrorKind::http_error(status, String::new());
+            assert_eq!(classify_alloy_rpc(&err), RetryDecision::Retry);
+        }
+
+        for status in [400, 401, 403, 404, 501] {
+            let err = TransportErrorKind::http_error(status, String::new());
+            assert_eq!(classify_alloy_rpc(&err), RetryDecision::Fail);
+        }
+    }
+
+    #[test]
+    fn treats_missing_pubsub_support_as_permanent() {
+        let err = TransportErrorKind::pubsub_unavailable();
+
+        assert_eq!(classify_alloy_rpc(&err), RetryDecision::Fail);
+    }
+
+    #[test]
+    fn keeps_permanent_rpc_failure_permanent_even_when_message_says_timeout() {
+        let err = anyhow::Error::new(RpcFailure {
+            operation: "proof storage",
+            kind: RpcFailureKind::Permanent,
+            source: anyhow::anyhow!("write timed out"),
+        });
+
+        assert_eq!(classify_anyhow(&err), RetryDecision::Fail);
+    }
+
+    #[test]
+    fn classifies_nested_contract_backend_gone_as_recoverable() {
+        let err = ethereum_client::Error::ErrorDuringContractExecution(
+            alloy::contract::Error::TransportError(RpcError::Transport(
+                TransportErrorKind::BackendGone,
+            )),
+        );
+
+        assert_eq!(classify_ethereum_error(&err), RetryDecision::Retry);
+        assert_eq!(classify_anyhow(&err.into()), RetryDecision::Retry);
+    }
+
+    #[test]
+    fn keeps_typed_error_response_permanent_even_when_message_says_timeout() {
+        let err = ethereum_client::Error::ErrorDuringContractExecution(
+            alloy::contract::Error::TransportError(RpcError::ErrorResp(
+                serde_json::from_str(r#"{"code":-32603,"message":"timeout"}"#).unwrap(),
+            )),
+        );
+
+        assert_eq!(classify_ethereum_error(&err), RetryDecision::Fail);
+        assert_eq!(classify_anyhow(&err.into()), RetryDecision::Fail);
+    }
+
+    #[test]
+    fn classifies_backend_task_stopped_text_as_recoverable() {
+        let err = anyhow::anyhow!("backend connection task has stopped");
+
+        assert_eq!(classify_anyhow(&err), RetryDecision::Retry);
     }
 
     #[test]

--- a/relayer/src/rpc.rs
+++ b/relayer/src/rpc.rs
@@ -76,6 +76,18 @@ pub fn classify_anyhow(err: &anyhow::Error) -> RetryDecision {
         return classify_alloy_rpc(err);
     }
 
+    if classify_gear_transport_error(err) == RetryDecision::Retry {
+        return RetryDecision::Retry;
+    }
+
+    if err.chain().any(is_recoverable_error_text) {
+        return RetryDecision::Retry;
+    }
+
+    RetryDecision::Fail
+}
+
+pub(crate) fn classify_gear_transport_error(err: &anyhow::Error) -> RetryDecision {
     if let Some(gclient::Error::GearSDK(gsdk::Error::Subxt(err))) =
         err.downcast_ref::<gclient::Error>()
     {
@@ -96,10 +108,6 @@ pub fn classify_anyhow(err: &anyhow::Error) -> RetryDecision {
         }
     }
 
-    if err.chain().any(is_recoverable_error_text) {
-        return RetryDecision::Retry;
-    }
-
     RetryDecision::Fail
 }
 
@@ -107,7 +115,6 @@ pub fn classify_ethereum_error(err: &ethereum_client::Error) -> RetryDecision {
     match err {
         ethereum_client::Error::ErrorInHTTPTransport(err) => classify_alloy_rpc(err),
         ethereum_client::Error::ErrorDuringContractExecution(err)
-        | ethereum_client::Error::ErrorSendingTransaction(err)
         | ethereum_client::Error::ErrorQueryingEvent(err) => match err {
             alloy::contract::Error::TransportError(err) => classify_alloy_rpc(err),
             _ => RetryDecision::Fail,
@@ -159,46 +166,103 @@ pub fn is_recoverable_error_text(message: impl std::fmt::Display) -> bool {
 /// Retry an Ethereum operation without dropping its in-memory work item.
 ///
 /// This helper intentionally waits until a recoverable outage ends. Callers in a
-/// multiplexed event loop should instead bound reconnection and reschedule the work.
+/// multiplexed event loop should use [`retry_eth_bounded`] instead.
 pub async fn retry_eth<T, F, Fut>(
     api: &mut ethereum_client::EthApi,
     operation: &'static str,
-    mut f: F,
+    f: F,
 ) -> Result<T, ethereum_client::Error>
 where
     F: FnMut(ethereum_client::EthApi) -> Fut,
     Fut: Future<Output = Result<T, ethereum_client::Error>>,
 {
-    let mut attempt = 0;
-    let policy = RetryPolicy::default();
+    retry(
+        api,
+        operation,
+        RetryPolicy::default(),
+        None,
+        f,
+        |api| async move { api.reconnect().await },
+        classify_ethereum_error,
+    )
+    .await
+}
+
+pub(crate) async fn retry_eth_bounded<T, F, Fut>(
+    api: &mut ethereum_client::EthApi,
+    operation: &'static str,
+    max_retries: u32,
+    f: F,
+) -> Result<T, ethereum_client::Error>
+where
+    F: FnMut(ethereum_client::EthApi) -> Fut,
+    Fut: Future<Output = Result<T, ethereum_client::Error>>,
+{
+    retry(
+        api,
+        operation,
+        RetryPolicy::default(),
+        Some(max_retries),
+        f,
+        |api| async move { api.reconnect().await },
+        classify_ethereum_error,
+    )
+    .await
+}
+
+async fn retry<T, A, E, F, Fut, R, ReconnectFut, C>(
+    api: &mut A,
+    operation: &'static str,
+    policy: RetryPolicy,
+    max_retries: Option<u32>,
+    mut f: F,
+    mut reconnect: R,
+    classify: C,
+) -> Result<T, E>
+where
+    A: Clone,
+    E: std::fmt::Display,
+    F: FnMut(A) -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    R: FnMut(A) -> ReconnectFut,
+    ReconnectFut: Future<Output = Result<A, E>>,
+    C: Fn(&E) -> RetryDecision,
+{
+    let mut attempts = 0;
 
     loop {
         match f(api.clone()).await {
             Ok(value) => return Ok(value),
-            Err(err) if classify_ethereum_error(&err) == RetryDecision::Retry => {
-                let delay = policy.delay(attempt);
+            Err(err) if classify(&err) == RetryDecision::Retry => {
+                if max_retries.is_some_and(|max| attempts >= max) {
+                    return Err(err);
+                }
+
+                let delay = policy.delay(attempts);
+                attempts = attempts.saturating_add(1);
                 log::warn!(
-                    "{operation} failed with recoverable Ethereum RPC error: {err}. Reconnecting in {delay:?}"
+                    "{operation} failed with recoverable RPC error: {err}. Reconnecting in {delay:?}"
                 );
                 tokio::time::sleep(delay).await;
 
                 loop {
-                    match api.reconnect().await {
+                    match reconnect(api.clone()).await {
                         Ok(reconnected) => {
                             *api = reconnected;
-                            attempt = attempt.saturating_add(1);
-                            log::info!(
-                                "{operation}: reconnected to Ethereum API, retrying operation"
-                            );
+                            log::info!("{operation}: reconnected, retrying operation");
                             break;
                         }
-                        Err(err) if classify_ethereum_error(&err) == RetryDecision::Retry => {
-                            let delay = policy.delay(attempt);
+                        Err(err) if classify(&err) == RetryDecision::Retry => {
+                            if max_retries.is_some_and(|max| attempts >= max) {
+                                return Err(err);
+                            }
+
+                            let delay = policy.delay(attempts);
+                            attempts = attempts.saturating_add(1);
                             log::warn!(
-                                "{operation} failed to reconnect to Ethereum after a recoverable RPC error: {err}. Retrying in {delay:?}"
+                                "{operation} failed to reconnect after a recoverable RPC error: {err}. Retrying in {delay:?}"
                             );
                             tokio::time::sleep(delay).await;
-                            attempt = attempt.saturating_add(1);
                         }
                         Err(err) => return Err(err),
                     }
@@ -374,6 +438,15 @@ mod tests {
     }
 
     #[test]
+    fn does_not_retry_ambiguous_transaction_send_failures() {
+        let err = ethereum_client::Error::ErrorSendingTransaction(
+            alloy::contract::Error::TransportError(RpcError::NullResp),
+        );
+
+        assert_eq!(classify_ethereum_error(&err), RetryDecision::Fail);
+    }
+
+    #[test]
     fn keeps_typed_error_response_permanent_even_when_message_says_timeout() {
         let err = ethereum_client::Error::ErrorDuringContractExecution(
             alloy::contract::Error::TransportError(RpcError::ErrorResp(
@@ -397,5 +470,93 @@ mod tests {
         let err = anyhow::anyhow!("transport error: connection refused");
 
         assert_eq!(classify_anyhow(&err), RetryDecision::Retry);
+    }
+
+    #[tokio::test]
+    async fn retry_survives_a_recoverable_reconnect_failure() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let operation_calls = Arc::new(AtomicUsize::new(0));
+        let reconnect_calls = Arc::new(AtomicUsize::new(0));
+        let mut api = 0u32;
+        let result = retry(
+            &mut api,
+            "test operation",
+            RetryPolicy {
+                base_delay: Duration::ZERO,
+                max_delay: Duration::ZERO,
+            },
+            Some(3),
+            {
+                let operation_calls = operation_calls.clone();
+                move |api| {
+                    let call = operation_calls.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if call == 0 {
+                            Err("retry")
+                        } else {
+                            Ok(api + 10)
+                        }
+                    }
+                }
+            },
+            {
+                let reconnect_calls = reconnect_calls.clone();
+                move |api| {
+                    let call = reconnect_calls.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if call == 0 {
+                            Err("retry")
+                        } else {
+                            Ok(api + 1)
+                        }
+                    }
+                }
+            },
+            |_| RetryDecision::Retry,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, 11);
+        assert_eq!(operation_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(reconnect_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn bounded_retry_returns_after_its_reconnect_budget() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        };
+
+        let reconnect_calls = Arc::new(AtomicUsize::new(0));
+        let mut api = ();
+        let err = retry(
+            &mut api,
+            "bounded test operation",
+            RetryPolicy {
+                base_delay: Duration::ZERO,
+                max_delay: Duration::ZERO,
+            },
+            Some(1),
+            |_| async { Err::<(), _>("operation unavailable") },
+            {
+                let reconnect_calls = reconnect_calls.clone();
+                move |_| {
+                    reconnect_calls.fetch_add(1, Ordering::SeqCst);
+                    async { Err("reconnect unavailable") }
+                }
+            },
+            |_| RetryDecision::Retry,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err, "reconnect unavailable");
+        assert_eq!(reconnect_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/relayer/src/rpc.rs
+++ b/relayer/src/rpc.rs
@@ -61,19 +61,19 @@ impl RetryPolicy {
 }
 
 pub fn classify_anyhow(err: &anyhow::Error) -> RetryDecision {
+    if let Some(err) = err.downcast_ref::<RpcFailure>() {
+        return match err.kind {
+            RpcFailureKind::Recoverable => RetryDecision::Retry,
+            RpcFailureKind::Permanent => RetryDecision::Fail,
+        };
+    }
+
     if let Some(err) = err.downcast_ref::<ethereum_client::Error>() {
         return classify_ethereum_error(err);
     }
 
     if let Some(err) = err.downcast_ref::<RpcError<TransportErrorKind>>() {
         return classify_alloy_rpc(err);
-    }
-
-    if let Some(err) = err.downcast_ref::<RpcFailure>() {
-        return match err.kind {
-            RpcFailureKind::Recoverable => RetryDecision::Retry,
-            RpcFailureKind::Permanent => RetryDecision::Fail,
-        };
     }
 
     if let Some(gclient::Error::GearSDK(gsdk::Error::Subxt(err))) =
@@ -338,6 +338,27 @@ mod tests {
         });
 
         assert_eq!(classify_anyhow(&err), RetryDecision::Fail);
+    }
+
+    #[test]
+    fn explicit_rpc_failure_kind_overrides_recoverable_source() {
+        let source = ethereum_client::Error::ErrorInHTTPTransport(RpcError::Transport(
+            TransportErrorKind::BackendGone,
+        ));
+        let permanent = anyhow::Error::new(RpcFailure {
+            operation: "proof storage",
+            kind: RpcFailureKind::Permanent,
+            source: anyhow::Error::new(source),
+        });
+
+        assert_eq!(classify_anyhow(&permanent), RetryDecision::Fail);
+
+        let recoverable = anyhow::Error::new(RpcFailure {
+            operation: "RPC request",
+            kind: RpcFailureKind::Recoverable,
+            source: anyhow::anyhow!("non-recoverable source text"),
+        });
+        assert_eq!(classify_anyhow(&recoverable), RetryDecision::Retry);
     }
 
     #[test]

--- a/relayer/tests/podman_rpc_failure.rs
+++ b/relayer/tests/podman_rpc_failure.rs
@@ -72,11 +72,8 @@ async fn eth_finalized_with_reconnect(api: &mut PollingEthApi) -> anyhow::Result
 async fn reconnect_polling_api(api: &mut PollingEthApi) -> anyhow::Result<()> {
     tokio::time::sleep(Duration::from_millis(250)).await;
     loop {
-        match tokio::time::timeout(Duration::from_secs(10), api.reconnect()).await {
-            Ok(Ok(reconnected)) => {
-                *api = reconnected;
-                return Ok(());
-            }
+        match tokio::time::timeout(Duration::from_secs(10), rpc::reconnect_polling_eth(api)).await {
+            Ok(Ok(())) => return Ok(()),
             Ok(Err(reconnect_err))
                 if rpc::classify_anyhow(&reconnect_err) == RetryDecision::Retry =>
             {
@@ -174,31 +171,39 @@ async fn podman_ethereum_contract_read_recovers_after_real_proxy_outage() -> any
 
     let baseline = api.max_block_number().await?;
     proxy.stop_container().await?;
-    tokio::time::sleep(Duration::from_millis(250)).await;
 
-    let proxy_for_restart = proxy.clone();
-    let restarter = tokio::spawn(async move {
-        // `retry_eth` waits at most two seconds before its first reconnect, so
-        // keeping the proxy down longer proves that a failed reconnect is retried.
-        tokio::time::sleep(Duration::from_secs(5)).await;
-        proxy_for_restart.start_container().await
-    });
+    let read_err = tokio::time::timeout(Duration::from_secs(10), api.max_block_number())
+        .await
+        .context("timed out waiting for the contract read to fail during the outage")?
+        .expect_err("contract read unexpectedly succeeded while the proxy was stopped");
+    assert_eq!(
+        rpc::classify_ethereum_error(&read_err),
+        RetryDecision::Retry,
+        "proxy outage returned a permanent contract-read error: {read_err}"
+    );
 
-    let worker = tokio::spawn(async move {
+    let reconnect_err = tokio::time::timeout(Duration::from_secs(10), api.reconnect())
+        .await
+        .context("timed out waiting for Ethereum reconnect to fail during the outage")?
+        .err()
+        .expect("Ethereum reconnect unexpectedly succeeded while the proxy was stopped");
+    assert_eq!(
+        rpc::classify_ethereum_error(&reconnect_err),
+        RetryDecision::Retry,
+        "proxy outage returned a permanent reconnect error: {reconnect_err}"
+    );
+
+    proxy.start_container().await?;
+    let recovered = tokio::time::timeout(
+        Duration::from_secs(90),
         rpc::retry_eth(
             &mut api,
             "podman test MessageQueue max block number",
             |api| async move { api.max_block_number().await },
-        )
-        .await
-    });
-
-    tokio::time::timeout(Duration::from_secs(30), restarter)
-        .await
-        .context("timed out waiting for Ethereum proxy restart")???;
-    let recovered = tokio::time::timeout(Duration::from_secs(90), worker)
-        .await
-        .context("timed out waiting for Ethereum contract read to recover")???;
+        ),
+    )
+    .await
+    .context("timed out waiting for Ethereum contract read to recover")??;
 
     assert!(
         recovered >= baseline,
@@ -224,13 +229,21 @@ async fn podman_ethereum_polling_recovers_after_real_proxy_outage() -> anyhow::R
 
     let baseline = worker_api.finalized_block().await?.header.number;
     proxy.stop_container().await?;
-    tokio::time::sleep(Duration::from_millis(250)).await;
 
-    let proxy_for_restart = proxy.clone();
-    let restarter = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(750)).await;
-        proxy_for_restart.start_container().await
-    });
+    let reconnect_err = tokio::time::timeout(
+        Duration::from_secs(10),
+        rpc::reconnect_polling_eth(&mut worker_api),
+    )
+    .await
+    .context("timed out waiting for polling reconnect to fail during the outage")?
+    .expect_err("polling reconnect unexpectedly succeeded while the proxy was stopped");
+    assert_eq!(
+        rpc::classify_anyhow(&reconnect_err),
+        RetryDecision::Retry,
+        "proxy outage returned a permanent polling reconnect error: {reconnect_err}"
+    );
+
+    proxy.start_container().await?;
 
     let worker = tokio::spawn(async move {
         let mut observed = Vec::new();
@@ -246,9 +259,6 @@ async fn podman_ethereum_polling_recovers_after_real_proxy_outage() -> anyhow::R
         eth_finalized_with_reconnect(&mut sibling_api).await
     });
 
-    tokio::time::timeout(Duration::from_secs(30), restarter)
-        .await
-        .context("timed out waiting for Ethereum proxy restart")???;
     let sibling_block = tokio::time::timeout(Duration::from_secs(90), sibling_reconnector)
         .await
         .context("timed out waiting for sibling Ethereum reconnect")???;

--- a/relayer/tests/podman_rpc_failure.rs
+++ b/relayer/tests/podman_rpc_failure.rs
@@ -178,7 +178,9 @@ async fn podman_ethereum_contract_read_recovers_after_real_proxy_outage() -> any
 
     let proxy_for_restart = proxy.clone();
     let restarter = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(750)).await;
+        // `retry_eth` waits at most two seconds before its first reconnect, so
+        // keeping the proxy down longer proves that a failed reconnect is retried.
+        tokio::time::sleep(Duration::from_secs(5)).await;
         proxy_for_restart.start_container().await
     });
 

--- a/relayer/tests/podman_rpc_failure.rs
+++ b/relayer/tests/podman_rpc_failure.rs
@@ -7,13 +7,14 @@ use std::{
 };
 
 use anyhow::Context;
-use ethereum_client::PollingEthApi;
+use ethereum_client::{EthApi, PollingEthApi};
 use gear_common::api_provider::ApiProvider;
 use relayer::rpc::{self, RetryDecision};
 
 const DEFAULT_GEAR_ENDPOINT: &str = "wss://testnet-archive.vara.network";
 const DEFAULT_GEAR_RPC_RETRIES: u8 = 3;
 const DEFAULT_ETH_ENDPOINT: &str = "wss://hoodi-reth-rpc.gear-tech.io/ws";
+const DEFAULT_ETH_MESSAGE_QUEUE_ADDRESS: &str = "0xAb8F315Cc80cf2368750fE5A33E259d6241b3dEB";
 const DEFAULT_WEBSOCAT_IMAGE: &str = "ghcr.io/vi/websocat:latest";
 
 fn gear_endpoint() -> String {
@@ -34,6 +35,11 @@ fn eth_endpoint() -> String {
         .or_else(|_| env::var("ETHEREUM_ENDPOINT"))
         .or_else(|_| env::var("ETH_RPC"))
         .unwrap_or_else(|_| DEFAULT_ETH_ENDPOINT.to_string())
+}
+
+fn eth_message_queue_address() -> String {
+    env::var("ETH_MESSAGE_QUEUE_ADDRESS")
+        .unwrap_or_else(|_| DEFAULT_ETH_MESSAGE_QUEUE_ADDRESS.to_string())
 }
 
 async fn gear_latest_number(
@@ -145,6 +151,56 @@ async fn podman_gear_worker_survives_real_proxy_outage_while_sibling_reconnects(
     assert!(
         observed.iter().all(|block| *block >= baseline),
         "worker saw finalized block regression after proxy outage: baseline={baseline}, observed={observed:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires podman and live Hoodi Ethereum RPC and MessageQueue contract"]
+async fn podman_ethereum_contract_read_recovers_after_real_proxy_outage() -> anyhow::Result<()> {
+    init_logging();
+    let proxy = PodmanWebsocketProxy::start("eth-contract", eth_endpoint()).await?;
+    let mut api = EthApi::new_with_retries(
+        &proxy.local_url(),
+        &eth_message_queue_address(),
+        None,
+        Some(1),
+        Some(Duration::from_millis(250)),
+        None,
+        None,
+    )
+    .await?;
+
+    let baseline = api.max_block_number().await?;
+    proxy.stop_container().await?;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let proxy_for_restart = proxy.clone();
+    let restarter = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(750)).await;
+        proxy_for_restart.start_container().await
+    });
+
+    let worker = tokio::spawn(async move {
+        rpc::retry_eth(
+            &mut api,
+            "podman test MessageQueue max block number",
+            |api| async move { api.max_block_number().await },
+        )
+        .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(30), restarter)
+        .await
+        .context("timed out waiting for Ethereum proxy restart")???;
+    let recovered = tokio::time::timeout(Duration::from_secs(90), worker)
+        .await
+        .context("timed out waiting for Ethereum contract read to recover")???;
+
+    assert!(
+        recovered >= baseline,
+        "MessageQueue max block number regressed after reconnect: baseline={baseline}, recovered={recovered}"
     );
 
     Ok(())


### PR DESCRIPTION
## Problem

On 2026-08-11 the mainnet Merkle relayer's periodic `MessageQueue.getMerkleRoot` probe received Alloy's nested `BackendGone` error (`backend connection task has stopped`). The error was classified as permanent, so the relayer exited while an in-flight authority-set proof kept the runtime alive for another ~14 minutes. During teardown, proof-storage errors were also mislabeled as Gear RPC failures.

Production recovery exposed two additional consequences of the same failure mode:

- startup recovery selected a stale 4,616-header finality proof before an already-queued zero-span proof, delaying affected Gear-to-Ethereum transfers for hours
- the Ethereum-to-Gear proof composer logged a successful reconnect but discarded the replacement `PollingEthApi`, so every retry continued through the dead Alloy provider

## Solution

- structurally classify Ethereum transport errors nested in contract calls, while keeping RPC error responses and permanent HTTP/auth failures terminal
- reconnect and retry startup Ethereum reads; for periodic supervision, attempt a bounded reconnect and reschedule after 30 seconds so Gear/prover/HTTP processing remains responsive
- retain Merkle submission and reconciliation work across recoverable Ethereum disconnects instead of dropping the local request
- keep proof-storage failures out of the Gear reconnect path and preserve their original source chain
- distinguish an actually missing filesystem proof state from permission, path, read, write, and rename failures; fail startup on real storage errors
- bound submitter retries and propagate permanent submission failures to the parent relayer
- preserve `(authority_set_id, queue_id)` batching while processing the smallest finality span first
- collect staggered startup recovery requests until the channel has been quiet for ten seconds
- replace the proof composer's dead Ethereum client with the client returned by `PollingEthApi::reconnect`
- add deterministic retry, scheduling, storage-classification, and ignored Podman/live-RPC regressions

## Validation

- `cargo test -p relayer merkle_roots::prover::tests` — 7 passed
- `cargo test -p relayer` — 88 passed, 15 ignored
- `cargo clippy -p relayer --all-targets -- -D warnings` — passed
- `cargo fmt --all --check` — passed

The Podman/live-RPC outage tests compile but remain ignored unless a live proxy environment is explicitly configured.

## Production verification

### Gear → Ethereum

- recovery root block `35,361,830` was selected with finality span `0`
- proof generated in `1,100.806s`
- Ethereum submission `0xb078819c62f5eb518a33ae840c8123dad0a30fdc058e157603a4df77b189a8f6` confirmed
- root persisted as `Finalized`
- delayed transfers `826` and `827` completed with zero dropped retries
- all 51 persisted Gear-to-Ethereum transfer records are completed; none remain incomplete

### Ethereum → Gear

- transaction `0xe6de19248838fc09a89e1febfea775593427c1e2e9c4abed13b851d0c48fc261` was stuck in `ComposeProof`
- logs showed repeated “Successfully reconnected to Ethereum API” followed immediately by `backend connection task has stopped`, confirming that the replacement client was discarded
- after restarting with a fresh provider, proof composition returned `Success` and the persisted transaction moved to `Completed`
- the relayer remained healthy with zero post-restart failures or OOM events

## Follow-up

Cooperative cancellation/bounded shutdown for an already-running recursive proof remains separate work. This PR prevents recoverable provider failures from trapping either bridge direction on a dead client and keeps recovery work ordered by the proof cost that blocks users.