### PR TITLE
fix(relayer): reconcile Merkle roots by polling

### DIFF
--- a/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/mod.rs
@@ -255,7 +255,7 @@ async fn run_inner(
 
                 let mut merkle_roots = this.merkle_roots.write().await;
                 match merkle_roots.add(merkle_root) {
-                    Ok(Added::Ok | Added::Overwritten(_)) => {}
+                    Ok(Added::Ok | Added::Overwritten(_) | Added::IgnoredOlder) => {}
 
                     Ok(Added::Removed(merkle_root_old)) => {
                         log::warn!("Removing merkle root = {merkle_root_old:?}");

--- a/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
+++ b/relayer/src/message_relayer/common/ethereum/accumulator/utils.rs
@@ -135,6 +135,8 @@ pub enum Added {
     Removed(RelayedMerkleRoot),
     /// The provided root overwrites existing one with the same authority set id.
     Overwritten(GearBlockNumber),
+    /// The provided root is older than every retained root and is ignored.
+    IgnoredOlder,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -260,10 +262,9 @@ impl MerkleRoots {
 
         let (result, i) = if self.0.len() < self.0.capacity() {
             (None, i)
+        } else if i >= self.0.len() {
+            return Ok(Added::IgnoredOlder);
         } else {
-            // adjust insertion index
-            let i = if i >= self.0.len() { i - 1 } else { i };
-
             (self.0.pop(), i)
         };
 
@@ -499,6 +500,20 @@ mod tests {
                 0
             )
             .is_none());
+
+        // An older backfilled root must not evict any of the retained recent roots.
+        let retained_roots = merkle_roots.0.clone();
+        let retained_oldest = *retained_roots.last().unwrap();
+        let older_backfilled_root = RelayedMerkleRoot {
+            block: GearBlockNumber(retained_oldest.block.0.saturating_sub(1)),
+            authority_set_id: AuthoritySetId(retained_oldest.authority_set_id.0.saturating_sub(1)),
+            ..retained_oldest
+        };
+        assert!(matches!(
+            merkle_roots.add(older_backfilled_root),
+            Ok(Added::IgnoredOlder)
+        ));
+        assert_eq!(merkle_roots.0, retained_roots);
 
         // attempt to add a newer merkle root should displace the oldest one
         let root_expected_removed = *merkle_roots.get(merkle_roots.len() - 1).unwrap();

--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -1,16 +1,20 @@
 use crate::message_relayer::common::{AuthoritySetId, GearBlockNumber, RelayedMerkleRoot};
-use alloy::{
-    providers::{PendingTransactionBuilder, Provider},
-    sol_types::SolEvent,
-};
-use ethereum_client::{abi::IMessageQueue::MerkleRoot, EthApi};
-use futures::StreamExt;
+use anyhow::Context;
+use ethereum_client::{EthApi, MerkleRootEntry};
 use gear_common::api_provider::ApiProviderConnection;
 use gear_rpc_client::GearApi;
 use primitive_types::H256;
-use prometheus::IntGauge;
+use prometheus::{IntCounter, IntGauge};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc::UnboundedSender;
 use utils_prometheus::{impl_metered_service, MeteredService};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(15);
+const RECONNECT_DELAY: Duration = Duration::from_secs(30);
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const QUERY_CHUNK_SIZE: u64 = 2_000;
+const STARTUP_HISTORY_BLOCKS: u64 = 100_000;
+const REORG_LOOKBACK_BLOCKS: u64 = 64;
 
 pub struct MerkleRootExtractor {
     eth_api: EthApi,
@@ -32,7 +36,27 @@ impl_metered_service! {
         latest_merkle_root_for_block: IntGauge = IntGauge::new(
             "merkle_root_extractor_latest_merkle_root_for_block",
             "Latest gear block present in found merkle roots",
-        )
+        ),
+        last_scanned_eth_block: IntGauge = IntGauge::new(
+            "merkle_root_extractor_last_scanned_eth_block",
+            "Latest Ethereum block successfully scanned for merkle roots",
+        ),
+        scan_lag_blocks: IntGauge = IntGauge::new(
+            "merkle_root_extractor_scan_lag_blocks",
+            "Confirmed Ethereum blocks not yet scanned for merkle roots",
+        ),
+        last_success_timestamp: IntGauge = IntGauge::new(
+            "merkle_root_extractor_last_success_timestamp",
+            "Unix timestamp of the latest successful merkle root reconciliation",
+        ),
+        reconnects_total: IntCounter = IntCounter::new(
+            "merkle_root_extractor_reconnects_total",
+            "Total successful Ethereum API reconnects by the merkle root extractor",
+        ),
+        scan_failures_total: IntCounter = IntCounter::new(
+            "merkle_root_extractor_scan_failures_total",
+            "Total failed merkle root reconciliation attempts",
+        ),
     }
 }
 
@@ -64,36 +88,99 @@ impl MerkleRootExtractor {
     async fn fetch_hash_auth_id(
         &mut self,
         block_number_gear: u32,
-    ) -> Option<(H256, AuthoritySetId)> {
-        loop {
-            let gear_api = self.api_provider.client();
+    ) -> anyhow::Result<(H256, AuthoritySetId)> {
+        let gear_api = self.api_provider.client();
 
-            match self::fetch_hash_auth_id(&gear_api, block_number_gear).await {
-                Ok(result) => return Some(result),
-
-                Err(e) => {
-                    log::error!(r#"Merkle root extractor failed to fetch block_hash: "{e:?}""#);
-                    log::trace!(
-                        r#"e.downcast_ref::<gsdk::Error>(): "{:?}""#,
-                        e.downcast_ref::<gsdk::Error>()
-                    );
-                    log::trace!(
-                        r#"e.downcast_ref::<subxt::Error>(): "{:?}""#,
-                        e.downcast_ref::<subxt::Error>()
-                    );
-                    for cause in e.chain() {
-                        log::trace!(r#"cause: "{cause:?}""#);
-                    }
+        match self::fetch_hash_auth_id(&gear_api, block_number_gear).await {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                log::error!(
+                    r#"Merkle root extractor failed to fetch Gear block metadata: "{err:?}""#
+                );
+                for cause in err.chain() {
+                    log::trace!(r#"cause: "{cause:?}""#);
                 }
-            }
 
-            if let Err(e) = self.api_provider.reconnect().await {
-                log::error!(r#"Merkle root extractor unable to reconnect: "{e}""#);
-                return None;
-            }
+                self.api_provider
+                    .reconnect()
+                    .await
+                    .context("Merkle root extractor unable to reconnect to Gear API")?;
 
-            log::debug!("API provider reconnected");
+                Err(err).context("Failed to fetch Gear block metadata; retrying the scan range")
+            }
         }
+    }
+
+    async fn scan_range(&mut self, range: ScanRange) -> anyhow::Result<()> {
+        let roots = tokio::time::timeout(
+            RPC_TIMEOUT,
+            self.eth_api
+                .fetch_merkle_roots_in_range(range.from, range.to),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Timed out fetching merkle roots from Ethereum blocks #{}..=#{}",
+                range.from, range.to
+            )
+        })??;
+
+        let roots_len = roots.len();
+        for (root, eth_block) in roots {
+            let eth_block = eth_block.with_context(|| {
+                format!(
+                    "Merkle root for Gear block #{} has no Ethereum block number",
+                    root.block_number
+                )
+            })?;
+            self.process_root(root, eth_block).await?;
+        }
+
+        log::trace!(
+            "Successfully scanned Ethereum blocks #{}..=#{} and found {roots_len} merkle root entry(ies)",
+            range.from,
+            range.to,
+        );
+        Ok(())
+    }
+
+    async fn process_root(&mut self, root: MerkleRootEntry, eth_block: u64) -> anyhow::Result<()> {
+        let block_timestamp =
+            tokio::time::timeout(RPC_TIMEOUT, self.eth_api.get_block_timestamp(eth_block))
+                .await
+                .with_context(|| {
+                    format!("Timed out fetching timestamp for Ethereum block #{eth_block}")
+                })??;
+
+        let block_number_gear = u32::try_from(root.block_number).with_context(|| {
+            format!(
+                "Merkle root Gear block number does not fit into u32: {}",
+                root.block_number
+            )
+        })?;
+
+        let latest_root_block = self.metrics.latest_merkle_root_for_block.get();
+        self.metrics
+            .latest_merkle_root_for_block
+            .set(latest_root_block.max(i64::from(block_number_gear)));
+
+        let (block_hash, authority_set_id) = self.fetch_hash_auth_id(block_number_gear).await?;
+
+        log::info!(
+            "Found merkle root {:?} at Ethereum block #{eth_block} with timestamp {block_timestamp} ({} confirmation(s)), for era #{authority_set_id}",
+            (root.block_number, root.merkle_root),
+            self.confirmations,
+        );
+
+        self.sender
+            .send(RelayedMerkleRoot {
+                block: GearBlockNumber(block_number_gear),
+                block_hash,
+                authority_set_id,
+                merkle_root: root.merkle_root,
+                timestamp: block_timestamp,
+            })
+            .context("Merkle root receiver channel closed")
     }
 }
 
@@ -109,115 +196,283 @@ async fn fetch_hash_auth_id(
 }
 
 async fn task(mut this: MerkleRootExtractor) {
+    let mut scan_state = ScanState::default();
+
     loop {
-        let Err(err) = task_inner(&mut this).await else {
-            log::info!("Exiting");
+        let Err(err) = task_inner(&mut this, &mut scan_state).await else {
+            log::info!("Merkle root extractor exiting");
             break;
         };
 
+        this.metrics.scan_failures_total.inc();
         log::error!(r#"Merkle root extractor failed: "{err:?}""#);
+
+        if this.sender.is_closed() {
+            log::info!("Merkle root receiver channel closed, exiting");
+            break;
+        }
 
         loop {
             match this.eth_api.reconnect().await {
                 Ok(eth_api) => {
                     this.eth_api = eth_api;
+                    this.metrics.reconnects_total.inc();
                     break;
                 }
                 Err(err) => {
                     log::error!(r#"Failed to reconnect to Ethereum: "{err}". Retrying..."#);
-                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    tokio::time::sleep(RECONNECT_DELAY).await;
                 }
             }
         }
     }
 }
 
-async fn task_inner(this: &mut MerkleRootExtractor) -> anyhow::Result<()> {
-    let subscription = this.eth_api.subscribe_logs().await?;
-
-    let mut stream = subscription.into_result_stream();
-    // check periodically that the connection to ApiProvider is alive
-    let mut interval = tokio::time::interval(std::time::Duration::from_secs(15));
+async fn task_inner(
+    this: &mut MerkleRootExtractor,
+    scan_state: &mut ScanState,
+) -> anyhow::Result<()> {
+    let mut interval = tokio::time::interval(POLL_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
-        tokio::select! {
-            _ = interval.tick() => {
-                if !this.api_provider.is_alive() {
-                    return Err(anyhow::anyhow!("ApiProvider connection is dead"));
-                }
-            }
+        interval.tick().await;
 
-            log = stream.next() => {
-                let log = match log {
-                    Some(Ok(log)) => log,
-                    Some(Err(e)) => {
-                        return Err(anyhow::anyhow!("Failed to get first log from stream: {e:?}"));
-                    }
-                    None => {
-                        return Err(anyhow::anyhow!("Log stream closed"));
-                    }
-                };
-
-                log::debug!("Get log = {log:?}");
-
-                let (Some(tx_hash), Some(block_number)) = (log.transaction_hash, log.block_number) else {
-                    log::error!("Unable to get tx_hash and block_number for log = {log:?}. Skipping");
-                    continue;
-                };
-
-                if log.removed {
-                    log::debug!("Blocks reorganization, log = {log:?}. Skipping");
-                    continue;
-                }
-
-                let root = match MerkleRoot::decode_log_data(log.data()) {
-                    Ok(root) => root,
-                    Err(e) => {
-                        log::error!("Failed to decode log = {log:?}: {e:?}. Skipping");
-                        continue;
-                    }
-                };
-
-                let pending =
-                    PendingTransactionBuilder::new(this.eth_api.raw_provider().root().clone(), tx_hash);
-                pending
-                    .with_required_confirmations(this.confirmations)
-                    .watch()
-                    .await?;
-
-                let block_timestamp = this.eth_api.get_block_timestamp(block_number).await?;
-
-                log::info!(
-                    "Found merkle root {:?} at Ethereum block #{block_number} with timestamp {block_timestamp} ({} confirmation(s))",
-                    (root.blockNumber, root.merkleRoot),
-                    this.confirmations,
-                );
-
-                let block_number_gear: u32 = root.blockNumber.to();
-                this.metrics
-                    .latest_merkle_root_for_block
-                    .set(block_number_gear as i64);
-
-                let Some((block_hash, authority_set_id)) = this.fetch_hash_auth_id(block_number_gear).await else {
-                    return Ok(());
-                };
-
-                log::info!(
-                    "Merkle root {:?} is for era #{authority_set_id}",
-                    (root.blockNumber, root.merkleRoot),
-                );
-
-                if let Err(e) = this.sender.send(RelayedMerkleRoot {
-                    block: GearBlockNumber(block_number_gear),
-                    block_hash,
-                    authority_set_id,
-                    merkle_root: root.merkleRoot.0.into(),
-                    timestamp: block_timestamp,
-                }) {
-                    log::error!(r#"Sender channel closed: "{e:?}"."#);
-                    return Ok(());
-                }
-            }
+        if !this.api_provider.is_alive() {
+            this.api_provider
+                .reconnect()
+                .await
+                .context("Merkle root extractor unable to reconnect to Gear API")?;
         }
+
+        scan_once(this, scan_state).await?;
+    }
+}
+
+async fn scan_once(
+    this: &mut MerkleRootExtractor,
+    scan_state: &mut ScanState,
+) -> anyhow::Result<()> {
+    let latest = tokio::time::timeout(RPC_TIMEOUT, this.eth_api.latest_block_number())
+        .await
+        .context("Timed out fetching latest Ethereum block number")??;
+    let confirmed = confirmed_head(latest, this.confirmations);
+
+    scan_state.initialize(confirmed);
+    update_scan_lag(&this.metrics, scan_state, confirmed);
+
+    while let Some(range) = scan_state.next_forward(confirmed) {
+        let result = this.scan_range(range).await;
+        scan_state.finish(range, result)?;
+
+        this.metrics
+            .last_scanned_eth_block
+            .set(u64_to_i64(range.to));
+        update_scan_lag(&this.metrics, scan_state, confirmed);
+    }
+
+    // Re-scan a short overlap because `confirmed` need not be finalized and a reorg may
+    // replace an Ethereum block after its first successful scan.
+    let range = scan_state.reconciliation_range(confirmed);
+    this.scan_range(range).await?;
+
+    // Backfill one historical chunk per poll after current confirmed blocks are caught up.
+    if let Some(range) = scan_state.next_backfill() {
+        let result = this.scan_range(range).await;
+        scan_state.finish(range, result)?;
+    }
+
+    this.metrics
+        .last_success_timestamp
+        .set(u64_to_i64(unix_timestamp()));
+
+    Ok(())
+}
+
+fn confirmed_head(latest: u64, confirmations: u64) -> u64 {
+    latest.saturating_sub(confirmations.saturating_sub(1))
+}
+
+fn update_scan_lag(metrics: &Metrics, scan_state: &ScanState, confirmed: u64) {
+    let last_scanned = scan_state
+        .forward_next
+        .and_then(|next| next.checked_sub(1))
+        .unwrap_or_default();
+    metrics
+        .scan_lag_blocks
+        .set(u64_to_i64(confirmed.saturating_sub(last_scanned)));
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn u64_to_i64(value: u64) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScanKind {
+    Forward,
+    Backfill,
+    Reconciliation,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ScanRange {
+    kind: ScanKind,
+    from: u64,
+    to: u64,
+}
+
+#[derive(Debug, Default)]
+struct ScanState {
+    initialized: bool,
+    forward_next: Option<u64>,
+    backfill_floor: u64,
+    backfill_next: Option<u64>,
+}
+
+impl ScanState {
+    fn initialize(&mut self, confirmed: u64) {
+        if self.initialized {
+            return;
+        }
+
+        let forward_from = confirmed.saturating_sub(QUERY_CHUNK_SIZE - 1);
+        self.forward_next = Some(forward_from);
+        self.backfill_floor = confirmed.saturating_sub(STARTUP_HISTORY_BLOCKS - 1);
+        self.backfill_next = forward_from
+            .checked_sub(1)
+            .filter(|to| *to >= self.backfill_floor);
+        self.initialized = true;
+    }
+
+    fn next_forward(&self, confirmed: u64) -> Option<ScanRange> {
+        let from = self.forward_next?;
+        if from > confirmed {
+            return None;
+        }
+
+        Some(ScanRange {
+            kind: ScanKind::Forward,
+            from,
+            to: confirmed.min(from.saturating_add(QUERY_CHUNK_SIZE - 1)),
+        })
+    }
+
+    fn reconciliation_range(&self, confirmed: u64) -> ScanRange {
+        ScanRange {
+            kind: ScanKind::Reconciliation,
+            from: confirmed.saturating_sub(REORG_LOOKBACK_BLOCKS - 1),
+            to: confirmed,
+        }
+    }
+
+    fn next_backfill(&self) -> Option<ScanRange> {
+        let to = self.backfill_next?;
+        Some(ScanRange {
+            kind: ScanKind::Backfill,
+            from: self
+                .backfill_floor
+                .max(to.saturating_sub(QUERY_CHUNK_SIZE - 1)),
+            to,
+        })
+    }
+
+    fn finish(&mut self, range: ScanRange, result: anyhow::Result<()>) -> anyhow::Result<()> {
+        result?;
+
+        match range.kind {
+            ScanKind::Forward => {
+                debug_assert_eq!(self.forward_next, Some(range.from));
+                self.forward_next = range.to.checked_add(1);
+            }
+            ScanKind::Backfill => {
+                debug_assert_eq!(self.backfill_next, Some(range.to));
+                self.backfill_next = if range.from <= self.backfill_floor {
+                    None
+                } else {
+                    range.from.checked_sub(1)
+                };
+            }
+            ScanKind::Reconciliation => {}
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confirmation_horizon_includes_the_event_block_as_first_confirmation() {
+        assert_eq!(confirmed_head(100, 0), 100);
+        assert_eq!(confirmed_head(100, 1), 100);
+        assert_eq!(confirmed_head(100, 2), 99);
+        assert_eq!(confirmed_head(100, 12), 89);
+    }
+
+    #[test]
+    fn scans_recent_blocks_before_backfilling_history() {
+        let mut state = ScanState::default();
+        state.initialize(10_000);
+
+        let recent = state.next_forward(10_000).unwrap();
+        assert_eq!((recent.from, recent.to), (8_001, 10_000));
+        state.finish(recent, Ok(())).unwrap();
+        assert!(state.next_forward(10_000).is_none());
+
+        let backfill = state.next_backfill().unwrap();
+        assert_eq!((backfill.from, backfill.to), (6_001, 8_000));
+
+        let reconciliation = state.reconciliation_range(10_000);
+        assert_eq!((reconciliation.from, reconciliation.to), (9_937, 10_000));
+    }
+
+    #[test]
+    fn failed_forward_scan_does_not_advance_cursor() {
+        let mut state = ScanState::default();
+        state.initialize(10_000);
+        let range = state.next_forward(10_000).unwrap();
+
+        assert!(state
+            .finish(range, Err(anyhow::anyhow!("provider unavailable")))
+            .is_err());
+        assert_eq!(state.next_forward(10_000), Some(range));
+    }
+
+    #[test]
+    fn failed_backfill_scan_does_not_advance_cursor() {
+        let mut state = ScanState::default();
+        state.initialize(10_000);
+        let recent = state.next_forward(10_000).unwrap();
+        state.finish(recent, Ok(())).unwrap();
+        let range = state.next_backfill().unwrap();
+
+        assert!(state
+            .finish(range, Err(anyhow::anyhow!("provider unavailable")))
+            .is_err());
+        assert_eq!(state.next_backfill(), Some(range));
+    }
+
+    #[test]
+    fn forward_scan_resumes_from_first_unscanned_block() {
+        let mut state = ScanState::default();
+        state.initialize(10_000);
+        let initial = state.next_forward(10_000).unwrap();
+        state.finish(initial, Ok(())).unwrap();
+
+        let resumed = state.next_forward(12_500).unwrap();
+        assert_eq!((resumed.from, resumed.to), (10_001, 12_000));
+        state.finish(resumed, Ok(())).unwrap();
+
+        let tail = state.next_forward(12_500).unwrap();
+        assert_eq!((tail.from, tail.to), (12_001, 12_500));
     }
 }

--- a/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
+++ b/relayer/src/message_relayer/common/ethereum/merkle_root_extractor.rs
@@ -1,4 +1,7 @@
-use crate::message_relayer::common::{AuthoritySetId, GearBlockNumber, RelayedMerkleRoot};
+use crate::{
+    message_relayer::common::{AuthoritySetId, GearBlockNumber, RelayedMerkleRoot},
+    rpc,
+};
 use anyhow::Context;
 use ethereum_client::{EthApi, MerkleRootEntry};
 use gear_common::api_provider::ApiProviderConnection;
@@ -6,6 +9,7 @@ use gear_rpc_client::GearApi;
 use primitive_types::H256;
 use prometheus::{IntCounter, IntGauge};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 use utils_prometheus::{impl_metered_service, MeteredService};
 
@@ -15,6 +19,13 @@ const RPC_TIMEOUT: Duration = Duration::from_secs(30);
 const QUERY_CHUNK_SIZE: u64 = 2_000;
 const STARTUP_HISTORY_BLOCKS: u64 = 100_000;
 const REORG_LOOKBACK_BLOCKS: u64 = 64;
+
+#[derive(Debug, Error)]
+#[error("Gear operation failed: {source}")]
+struct GearOperationError {
+    #[source]
+    source: anyhow::Error,
+}
 
 pub struct MerkleRootExtractor {
     eth_api: EthApi,
@@ -89,26 +100,15 @@ impl MerkleRootExtractor {
         &mut self,
         block_number_gear: u32,
     ) -> anyhow::Result<(H256, AuthoritySetId)> {
-        let gear_api = self.api_provider.client();
-
-        match self::fetch_hash_auth_id(&gear_api, block_number_gear).await {
-            Ok(result) => Ok(result),
-            Err(err) => {
-                log::error!(
-                    r#"Merkle root extractor failed to fetch Gear block metadata: "{err:?}""#
-                );
-                for cause in err.chain() {
-                    log::trace!(r#"cause: "{cause:?}""#);
-                }
-
-                self.api_provider
-                    .reconnect()
-                    .await
-                    .context("Merkle root extractor unable to reconnect to Gear API")?;
-
-                Err(err).context("Failed to fetch Gear block metadata; retrying the scan range")
-            }
-        }
+        rpc::retry_gear(
+            &mut self.api_provider,
+            "fetch merkle root Gear block metadata",
+            move |gear_api| async move {
+                self::fetch_hash_auth_id(&gear_api, block_number_gear).await
+            },
+        )
+        .await
+        .map_err(|source| GearOperationError { source }.into())
     }
 
     async fn scan_range(&mut self, range: ScanRange) -> anyhow::Result<()> {
@@ -197,11 +197,15 @@ async fn fetch_hash_auth_id(
 
 async fn task(mut this: MerkleRootExtractor) {
     let mut scan_state = ScanState::default();
+    // Keep the interval across failures so a retained range cannot be replayed in a tight loop.
+    let mut interval = tokio::time::interval(POLL_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
+        interval.tick().await;
+
         let Err(err) = task_inner(&mut this, &mut scan_state).await else {
-            log::info!("Merkle root extractor exiting");
-            break;
+            continue;
         };
 
         this.metrics.scan_failures_total.inc();
@@ -210,6 +214,10 @@ async fn task(mut this: MerkleRootExtractor) {
         if this.sender.is_closed() {
             log::info!("Merkle root receiver channel closed, exiting");
             break;
+        }
+
+        if !should_reconnect_ethereum(&err) {
+            continue;
         }
 
         loop {
@@ -232,21 +240,19 @@ async fn task_inner(
     this: &mut MerkleRootExtractor,
     scan_state: &mut ScanState,
 ) -> anyhow::Result<()> {
-    let mut interval = tokio::time::interval(POLL_INTERVAL);
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-    loop {
-        interval.tick().await;
-
-        if !this.api_provider.is_alive() {
-            this.api_provider
-                .reconnect()
-                .await
-                .context("Merkle root extractor unable to reconnect to Gear API")?;
-        }
-
-        scan_once(this, scan_state).await?;
+    if !this.api_provider.is_alive() {
+        this.api_provider
+            .reconnect()
+            .await
+            .map_err(|source| GearOperationError { source })?;
     }
+
+    scan_once(this, scan_state).await
+}
+
+fn should_reconnect_ethereum(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<GearOperationError>().is_none()
+        && rpc::classify_anyhow(err) == rpc::RetryDecision::Retry
 }
 
 async fn scan_once(
@@ -409,6 +415,18 @@ impl ScanState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gear_failures_do_not_reconnect_ethereum() {
+        let err = anyhow::Error::new(GearOperationError {
+            source: anyhow::anyhow!("backend connection task has stopped"),
+        });
+
+        assert!(!should_reconnect_ethereum(&err));
+        assert!(should_reconnect_ethereum(&anyhow::anyhow!(
+            "backend connection task has stopped"
+        )));
+    }
 
     #[test]
     fn confirmation_horizon_includes_the_event_block_as_first_confirmation() {

--- a/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
+++ b/relayer/src/message_relayer/gear_to_eth/paid_token_transfers.rs
@@ -1,24 +1,20 @@
-use crate::{
-    common::BlockRange,
-    message_relayer::{
-        common::{
-            ethereum::{
-                accumulator::Accumulator, merkle_root_extractor::MerkleRootExtractor,
-                message_sender::MessageSender, status_fetcher::StatusFetcher,
-            },
-            gear::{
-                block_listener::BlockListener as GearBlockListener,
-                merkle_proof_fetcher::MerkleProofFetcher,
-                message_data_extractor::MessageDataExtractor,
-                message_paid_event_extractor::MessagePaidEventExtractor,
-                message_queued_event_extractor::MessageQueuedEventExtractor,
-            },
-            paid_messages_filter::PaidMessagesFilter,
-            web_request::Message,
-            AuthoritySetId, GearBlockNumber, MessageInBlock, RelayedMerkleRoot,
+use crate::message_relayer::{
+    common::{
+        ethereum::{
+            accumulator::Accumulator, merkle_root_extractor::MerkleRootExtractor,
+            message_sender::MessageSender, status_fetcher::StatusFetcher,
         },
-        gear_to_eth::{storage::JSONStorage, tx_manager::TransactionManager},
+        gear::{
+            block_listener::BlockListener as GearBlockListener,
+            merkle_proof_fetcher::MerkleProofFetcher, message_data_extractor::MessageDataExtractor,
+            message_paid_event_extractor::MessagePaidEventExtractor,
+            message_queued_event_extractor::MessageQueuedEventExtractor,
+        },
+        paid_messages_filter::PaidMessagesFilter,
+        web_request::Message,
+        MessageInBlock,
     },
+    gear_to_eth::{storage::JSONStorage, tx_manager::TransactionManager},
 };
 use anyhow::Result as AnyResult;
 use ethereum_client::EthApi;
@@ -27,10 +23,7 @@ use gear_common::api_provider::ApiProviderConnection;
 use primitive_types::H256;
 use sails_rs::ActorId;
 use std::{collections::HashSet, iter, path::Path, sync::Arc};
-use tokio::{
-    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
-    task, time,
-};
+use tokio::sync::mpsc::{self, UnboundedReceiver};
 use utils_prometheus::MeteredService;
 
 pub struct Relayer {
@@ -122,12 +115,6 @@ impl Relayer {
             eth_api.clone(),
         );
 
-        task::spawn(self::fetch_merkle_roots(
-            eth_api,
-            api_provider,
-            roots_sender,
-        ));
-
         Ok(Self {
             gear_block_listener,
 
@@ -177,80 +164,4 @@ impl Relayer {
             )
             .await
     }
-}
-
-async fn fetch_merkle_roots(
-    eth_api: EthApi,
-    api_provider: ApiProviderConnection,
-    sender: UnboundedSender<RelayedMerkleRoot>,
-) {
-    if let Err(e) = fetch_merkle_roots_inner(eth_api, api_provider, sender).await {
-        log::error!("Task fetch_merkle_roots failed: {e:?}");
-    }
-}
-
-async fn fetch_merkle_roots_inner(
-    eth_api: EthApi,
-    api_provider: ApiProviderConnection,
-    sender: UnboundedSender<RelayedMerkleRoot>,
-) -> AnyResult<()> {
-    const COUNT: u64 = 2_000;
-    const COUNT_STEP: u64 = 50;
-
-    let block_finalized = eth_api.finalized_block_number().await?;
-    let block_latest = eth_api.latest_block_number().await?;
-    let gear_api = api_provider.client();
-
-    for i in 0..COUNT_STEP {
-        let block_range = crate::common::create_range(
-            (block_finalized - (i + 1) * COUNT).into(),
-            block_finalized - i * COUNT,
-        );
-
-        fetch_merkle_roots_in_range(&eth_api, &gear_api, &sender, i, block_range).await?;
-
-        time::sleep(time::Duration::from_secs(5)).await;
-    }
-
-    // to that moment block_latest should have the required number of confirmations
-    let block_range = crate::common::create_range((block_finalized + 1).into(), block_latest);
-
-    fetch_merkle_roots_in_range(&eth_api, &gear_api, &sender, COUNT_STEP, block_range).await
-}
-
-async fn fetch_merkle_roots_in_range(
-    eth_api: &EthApi,
-    gear_api: &gear_rpc_client::GearApi,
-    sender: &UnboundedSender<RelayedMerkleRoot>,
-    i: u64,
-    block_range: BlockRange,
-) -> AnyResult<()> {
-    let merkle_roots = eth_api
-        .fetch_merkle_roots_in_range(block_range.from, block_range.to)
-        .await?;
-
-    let len = merkle_roots.len();
-    log::trace!("Found {len} entry(ies) with merkle roots (i = {i})");
-    for (root, _block_number_eth) in merkle_roots
-        .into_iter()
-        .filter_map(|(root, block)| block.map(|block| (root, block)))
-    {
-        let timestamp = eth_api.get_block_timestamp(_block_number_eth).await?;
-        let block_hash = gear_api
-            .block_number_to_hash(root.block_number as u32)
-            .await?;
-        let authority_set_id = gear_api.signed_by_authority_set_id(block_hash).await?;
-
-        sender.send(RelayedMerkleRoot {
-            block: GearBlockNumber(root.block_number as u32),
-            block_hash,
-            authority_set_id: AuthoritySetId(authority_set_id),
-            merkle_root: root.merkle_root,
-            timestamp,
-        })?;
-    }
-
-    log::trace!("Successfuly sent {len} merkle root entry(ies) (i = {i})");
-
-    Ok(())
 }


### PR DESCRIPTION
## Problem

The Merkle root extractor depends on a long-lived Ethereum log subscription. Recoverable provider outages can silently stop root delivery, leaving Gear-to-Ethereum transfers waiting indefinitely.

## Changes

- Replace the subscription with bounded, cursor-based Ethereum block polling.
- Scan recent confirmed blocks first, then backfill 100,000 blocks in 2,000-block chunks.
- Reconcile a 64-block overlap to tolerate reorgs.
- Retain scan cursors across failures and retry on a stable 15-second cadence.
- Keep Gear RPC recovery on the Gear connection; reconnect Ethereum only for recoverable Ethereum failures.
- Ignore historical roots older than the accumulator's retained window instead of evicting usable recent roots.
- Add extractor progress/failure metrics and regression tests.

## Verification

- `cargo fmt --all --check`
- `cargo test -p relayer` — 96 passed, 15 ignored
- `cargo clippy -p relayer --all-targets -- -D warnings` — 0 errors
- `git diff --check`

Follow-up to #843.