### PR TITLE
fix(relayer): recover stalled merkle root submissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "bridging-payment"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bridging-payment-app",
  "sails-idl-gen",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "bridging-payment-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "gstd",
  "parity-scale-codec",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "bridging-payment-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bridging-payment-app",
  "mockall 0.12.1",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "checkpoint-light-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "checkpoint-light-client-app",
  "sails-idl-gen",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "checkpoint-light-client-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "checkpoint-light-client-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "checkpoint-light-client-app",
  "checkpoint-light-client-io",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "checkpoint-light-client-io"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ark-bls12-381",
  "ark-scale",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "checkpoints-tool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "ark-serialize 0.4.2",
@@ -2793,7 +2793,7 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cli-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4050,7 +4050,7 @@ checksum = "1b241177c7107d9829286c2ffdc5eee98d992d6356f3515e7f412f988b1a72fd"
 
 [[package]]
 name = "eth-events-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "alloy-rlp",
  "checkpoint-light-client-client",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "eth-events-deneb"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "eth-events-deneb-app",
  "sails-idl-gen",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "eth-events-deneb-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "eth-events-common",
  "ethereum-common",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "eth-events-deneb-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "eth-events-deneb-app",
  "ethereum-common",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "eth-events-electra"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "eth-events-electra-app",
  "sails-idl-gen",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "eth-events-electra-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "eth-events-common",
  "ethereum-common",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "eth-events-electra-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "eth-events-electra-app",
  "ethereum-common",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ahash 0.7.8",
  "alloy",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "ethereum_beacon_client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "ark-serialize 0.4.2",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "gear-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "gclient",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "gear-rpc-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "gear_proof_storage"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "gear-wasm-builder",
  "gstd",
@@ -5437,7 +5437,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "governance-tool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "alloy",
  "clap",
@@ -5843,7 +5843,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "historical-proxy"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "historical-proxy",
  "historical-proxy-app",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "historical-proxy-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "eth-events-common",
  "eth-events-deneb",
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "historical-proxy-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "historical-proxy-app",
  "mockall 0.12.1",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "js-test"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "alloy",
  "dotenv",
@@ -7904,7 +7904,7 @@ dependencies = [
 
 [[package]]
 name = "mock-contract"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "checkpoint-light-client-client",
  "gear-wasm-builder",
@@ -8962,7 +8962,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ping"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "parity-scale-codec",
  "sails-rs",
@@ -9022,7 +9022,7 @@ dependencies = [
 
 [[package]]
 name = "plonky2_blake2b256"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "plonky2_ed25519"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -9100,7 +9100,7 @@ dependencies = [
 
 [[package]]
 name = "plonky2_sha512"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "itertools 0.10.5",
@@ -9640,7 +9640,7 @@ dependencies = [
 
 [[package]]
 name = "prover"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -10184,7 +10184,7 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "relayer"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-web",
  "alloy",
@@ -10211,7 +10211,7 @@ dependencies = [
  "ethereum_beacon_client",
  "futures",
  "gclient",
- "gear-common 1.2.0",
+ "gear-common 1.2.1",
  "gear-core",
  "gear-rpc-client",
  "gear_proof_storage",
@@ -11940,7 +11940,7 @@ dependencies = [
 
 [[package]]
 name = "signed-block-id-tool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -13789,7 +13789,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13816,7 +13816,7 @@ dependencies = [
  "ethereum_beacon_client",
  "futures",
  "gclient",
- "gear-common 1.2.0",
+ "gear-common 1.2.1",
  "gear-core",
  "gstd",
  "gtest",
@@ -14727,7 +14727,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils-prometheus"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "prometheus",
@@ -14766,7 +14766,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vft"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "sails-idl-gen",
  "sails-rs",
@@ -14775,7 +14775,7 @@ dependencies = [
 
 [[package]]
 name = "vft-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "awesome-sails-services",
  "sails-rs",
@@ -14784,7 +14784,7 @@ dependencies = [
 
 [[package]]
 name = "vft-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mockall 0.12.1",
  "sails-client-gen",
@@ -14795,7 +14795,7 @@ dependencies = [
 
 [[package]]
 name = "vft-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "awesome-sails",
  "awesome-sails-services",
@@ -14804,7 +14804,7 @@ dependencies = [
 
 [[package]]
 name = "vft-manager"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "sails-idl-gen",
  "sails-rs",
@@ -14813,7 +14813,7 @@ dependencies = [
 
 [[package]]
 name = "vft-manager-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
@@ -14832,7 +14832,7 @@ dependencies = [
 
 [[package]]
 name = "vft-manager-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mockall 0.12.1",
  "sails-client-gen",
@@ -14843,14 +14843,14 @@ dependencies = [
 
 [[package]]
 name = "vft-manager-tool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "clap",
  "cli-utils",
  "dotenv",
  "gclient",
- "gear-common 1.2.0",
+ "gear-common 1.2.1",
  "gear-core",
  "gsdk",
  "hex",
@@ -14864,13 +14864,13 @@ dependencies = [
 
 [[package]]
 name = "vft-tool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap",
  "cli-utils",
  "dotenv",
  "gclient",
- "gear-common 1.2.0",
+ "gear-common 1.2.1",
  "gear-core",
  "gsdk",
  "hex",
@@ -14886,7 +14886,7 @@ dependencies = [
 
 [[package]]
 name = "vft-vara"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "sails-idl-gen",
  "sails-rs",
@@ -14895,7 +14895,7 @@ dependencies = [
 
 [[package]]
 name = "vft-vara-app"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "awesome-sails-services",
  "sails-rs",
@@ -14904,7 +14904,7 @@ dependencies = [
 
 [[package]]
 name = "vft-vara-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mockall 0.12.1",
  "sails-client-gen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 
 [workspace.dependencies]

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -108,7 +108,7 @@ Once the inner authority-set proof is available, the root is recorded as Generat
 - whether the request may be batched;
 - the relayer-specific context needed to reconnect to Gear and invoke the prover.
 
-Normal, paid-priority, and supervisor work is batchable and may use an authenticated cumulative root at a later GRANDPA-signed target. Non-batched generation is reserved for authenticated exact-block HTTP requests and forced health anchors.
+Normal and paid-priority work is batchable; supervisor work may also use an authenticated cumulative root at a GRANDPA-signed target. Non-batched generation is reserved for forced health anchors and authenticated exact-block HTTP requests, which remain priority work and retain the requested block/root metadata.
 
 ### 4. Compose and generate the proof
 
@@ -131,12 +131,11 @@ The root relayer keeps a pending batch with timestamps and message-nonce counts.
 - spike_timeout flushes an ordinary batch after its timeout.
 - priority_spike_timeout flushes a batch containing a priority request sooner.
 - A bridging_payment_address enables priority handling for recognized priority-payment events.
-- critical_threshold compares Gear timestamps from the latest signed block and the last Ethereum-confirmed root. When the configured duration elapses, it schedules a forced health anchor; authority_set_change remains an alternative trigger around an authority-set transition.
-- An authenticated /get_merkle_root_proof request is handled as a priority, non-batched request and retains the requested block and root metadata.
+- critical_threshold compares Gear timestamps from the latest finalized block and the last Ethereum-confirmed root. When the configured duration elapses, it schedules a forced health anchor; authority_set_change instead triggers at an authority-set transition.
 
-A supervisor tick periodically compares the latest Gear queue root with finalized Ethereum state. When Ethereum has no matching root and the configured time threshold has elapsed, it schedules a forced health anchor, using an intermediate signed anchor when MessageQueue's maximum block-distance window requires one. Signed-anchor work is deduplicated while in flight; authenticated exact-block requests remain separate.
+A supervisor tick periodically compares the latest Gear queue root with finalized Ethereum state. When Ethereum has no matching root and the configured time threshold has elapsed, it schedules a forced health anchor at the latest signed block within MessageQueue's maximum block-distance window. Persisted proof work is dispatched after this startup check. Signed-anchor work is deduplicated while in flight; authenticated exact-block requests remain separate.
 
-The prover gives non-batched requests priority over ordinary batches. Batches are grouped by authority-set id and queue id, and responses are sent back through the channel associated with the originating request.
+The prover gives non-batched requests priority over ordinary batches and orders them by finality-proof span before block number. Batches are grouped by authority-set id and queue id, and responses are sent back through the channel associated with the originating request.
 
 ## Ethereum-to-Gear core
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -75,7 +75,7 @@ The expensive proof work is isolated behind channels so block listening, schedul
 3. Produces and stores the raw block-inclusion/finality material in MerkleRootStorage.
 4. Broadcasts the block to the root relayer and authority-set synchronizer.
 
-The listener has a large broadcast capacity because proving and era synchronization can lag behind block production. It replays unprocessed state at startup, detects gaps in live justifications, and replays missing ranges. On recoverable provider errors it reconnects and starts replay from the last finalized cursor.
+The listener has a large broadcast capacity because proving and era synchronization can lag behind block production. It replays unprocessed state at startup and, when a live GRANDPA justification skips block numbers, replays the missing range serially before broadcasting the current block. On recoverable provider errors it reconnects and starts replay from the last finalized cursor.
 
 The block storage is a source of recovery, not just a cache. A consumer that falls behind can be restarted from the persisted block set. A broadcast lag warning is therefore different from a proof being lost; operators should inspect persisted state before deleting anything.
 
@@ -108,7 +108,7 @@ Once the inner authority-set proof is available, the root is recorded as Generat
 - whether the request may be batched;
 - the relayer-specific context needed to reconnect to Gear and invoke the prover.
 
-Normal block traffic is batchable. Non-batched requests are used for catch-up, critical-threshold recovery, supervisor checks, and authenticated HTTP requests that need a specific proof quickly.
+Normal, paid-priority, and supervisor work is batchable and may use an authenticated cumulative root at a later GRANDPA-signed target. Non-batched generation is reserved for authenticated exact-block HTTP requests and forced health anchors.
 
 ### 4. Compose and generate the proof
 
@@ -131,10 +131,10 @@ The root relayer keeps a pending batch with timestamps and message-nonce counts.
 - spike_timeout flushes an ordinary batch after its timeout.
 - priority_spike_timeout flushes a batch containing a priority request sooner.
 - A bridging_payment_address enables priority handling for recognized priority-payment events.
-- critical_threshold forces a non-batched proof when the last confirmed root is too far behind. authority_set_change is an alternative trigger that forces a proof around an authority-set transition.
-- An authenticated /get_merkle_root_proof request is handled as a priority, non-batched request and may use a fresh justified block while the requested block is being caught up.
+- critical_threshold compares Gear timestamps from the latest signed block and the last Ethereum-confirmed root. When the configured duration elapses, it schedules a forced health anchor; authority_set_change remains an alternative trigger around an authority-set transition.
+- An authenticated /get_merkle_root_proof request is handled as a priority, non-batched request and retains the requested block and root metadata.
 
-A supervisor tick periodically reads the latest Gear queue root and the corresponding Ethereum root. If Ethereum has no matching root, or a configured critical threshold is reached, it schedules a recovery proof. It deduplicates a root while the same proof is in flight.
+A supervisor tick periodically compares the latest Gear queue root with finalized Ethereum state. When Ethereum has no matching root and the configured time threshold has elapsed, it schedules a forced health anchor, using an intermediate signed anchor when MessageQueue's maximum block-distance window requires one. Signed-anchor work is deduplicated while in flight; authenticated exact-block requests remain separate.
 
 The prover gives non-batched requests priority over ordinary batches. Batches are grouped by authority-set id and queue id, and responses are sent back through the channel associated with the originating request.
 

--- a/docs/merkle-roots.md
+++ b/docs/merkle-roots.md
@@ -101,15 +101,13 @@ Normal roots are placed in a batch. The batch is flushed when:
 
 The spike_window limits how far back timestamps are counted. A bridging-payment event associated with the configured payment address marks the relevant root as priority.
 
-A non-batched proof is used for:
+For normal, paid-priority, and supervisor work, the relayer prefers the cumulative queue root at the GRANDPA-signed target already carried by the block inclusion proof. Before using cumulative coverage, it verifies the source and target queue ID/root pairs with Vara storage proofs tied to their block headers. It uses the target only when it is not older than the source block and the authenticated authority-set ID and queue ID still match. Otherwise it keeps the exact source root. This normally reduces final proof composition to the signed target instead of replaying every header from the source event.
 
-- startup/catch-up recovery;
-- a critical block-distance threshold;
-- an authority-set-change threshold;
-- an authenticated HTTP request for a particular block;
-- the periodic supervisor's mismatch check.
+Batched source roots remain in a proving state until Ethereum confirms the selected anchor. Only then are the older roots marked covered; the anchor proof is never exposed as an exact proof for an older block.
 
-The configuration parser accepts a human duration for critical_threshold, but the current effective options convert a timeout to a block-distance using seconds divided by three; the runtime compares that value against finalized Gear block numbers. Treat the setting as a deployment policy and verify it against the exact binary version before changing it.
+Non-batched generation is reserved for authenticated exact-block HTTP requests and forced health anchors. Exact requests retain the requested block/root metadata even when normal transfer processing would use a later cumulative anchor.
+
+The configuration parser carries `critical_threshold` as a duration. The supervisor compares actual Gear timestamp values for the latest signed block and the last Ethereum-confirmed root; queued or proving work does not advance that confirmation cursor.
 
 The startup_sync_strategy setting accepts critical-threshold, skip, or blocks, and the blocks list is validated to be present only for the blocks strategy. The option is carried into the root-relayer configuration; confirm the behavior of the deployed revision when using a non-default strategy.
 
@@ -121,9 +119,9 @@ The root relayer periodically reads:
 - the root recorded by Ethereum's MessageQueue for the same Gear block;
 - local submission state.
 
-If Ethereum has no matching root, or the critical threshold is reached, the supervisor schedules a forced proof. If Ethereum already has the expected root, local storage is marked submitted/confirmed. If local state says a root was submitted but Ethereum does not show it in finalized state, the root remains eligible for recovery.
+If Ethereum has no matching root and the time threshold is reached, the supervisor schedules a forced proof. If the signed target would exceed MessageQueue's maximum block-distance window, the scheduler first selects an intermediate GRANDPA-signed anchor at or below the contract limit. The source block remains unprocessed until a confirmed anchor actually covers it.
 
-The supervisor deduplicates a root while the same hash is already in GenerateProof or SubmitProof. It clears that deduplication marker after the submitter reports success or failure.
+If Ethereum already has the expected root, local storage is reconciled with finalized submission state. Active signed-anchor work is deduplicated, while authenticated exact-block requests remain separate so batching cannot return mismatched proof metadata.
 
 ## Ethereum submission semantics
 
@@ -136,6 +134,8 @@ The submitter calls MessageQueue.submitMerkleRoot with the Gear block number, ro
 5. emits a MerkleRoot event.
 
 The contract documents that anyone may submit a valid root; the configured fee payer is the process's transaction sender, not a trust assumption for proof validity. MessageQueue can reject submissions during challenge/emergency-stop conditions, and a conflicting root can enable the emergency stop path. Operators must treat such rejections as protocol incidents, not as generic RPC retries.
+
+The local submitted marker is tentative while a transaction is in flight. A transaction is reported as submitted only after its receipt succeeds and finalized Ethereum contract state contains the expected root; restart recovery rechecks persisted markers against the same finalized view before confirming or resubmitting them.
 
 Once a root is stored, MessageQueue.processMessage still enforces the applicable delay and verifies an individual binary Merkle proof for the message. A root being Finalized in the relayer does not by itself complete a token transfer.
 
@@ -163,6 +163,8 @@ The root's serialized proof is not the only required artifact. Recovery may also
 ## Process isolation
 
 Run separate process instances when relayers need different networks, signers, storage, or restart policies. Give each instance its own HTTP address, root-storage file, proof-storage directory, transaction-storage directory, and metrics identity. Sharing mutable state between two processes can cause duplicate work or make recovery ambiguous.
+
+If a relayer component channel closes or a submission fails, the command exits non-zero before the Tokio runtime waits for blocking prover tasks. The process supervisor must restart the container; startup recovery reloads durable proving/submission state.
 
 ## HTTP proof API
 

--- a/docs/merkle-roots.md
+++ b/docs/merkle-roots.md
@@ -119,7 +119,7 @@ The root relayer periodically reads:
 - the root recorded by Ethereum's MessageQueue for the same Gear block;
 - local submission state.
 
-If Ethereum has no matching root and the time threshold is reached, the supervisor schedules a forced proof. If the signed target would exceed MessageQueue's maximum block-distance window, the scheduler first selects an intermediate GRANDPA-signed anchor at or below the contract limit. The source block remains unprocessed until a confirmed anchor actually covers it.
+If Ethereum has no matching root and the time threshold is reached, the supervisor schedules a forced proof at the latest finalized signed target, capped by MessageQueue's maximum block-distance window. Persisted GenerateProof work is restored only after this startup check, and shorter finality spans are processed first so a stale long proof cannot block recovery. The source block remains unprocessed until a confirmed anchor actually covers it.
 
 If Ethereum already has the expected root, local storage is reconciled with finalized submission state. Active signed-anchor work is deduplicated, while authenticated exact-block requests remain separate so batching cannot return mismatched proof metadata.
 
@@ -141,7 +141,7 @@ Once a root is stored, MessageQueue.processMessage still enforces the applicable
 
 ## Persistent format and atomic writes
 
-The root storage path is a JSON file configured as storage.block_storage. It contains a version, unprocessed block records, Ethereum submission states, and a roots map whose keys encode the Gear block number and root hash.
+The root storage path is a JSON file configured as storage.block_storage. It contains every unresolved block record, the latest 100 block records for replay context, Ethereum submission states, and a roots map whose keys encode the Gear block number and root hash.
 
 Writes use:
 

--- a/ethereum/client/src/lib.rs
+++ b/ethereum/client/src/lib.rs
@@ -443,6 +443,12 @@ impl EthApi {
     pub async fn max_block_number(&self) -> Result<u32, Error> {
         self.contracts.max_block_number().await
     }
+    /// Returns MessageQueue's maximum Gear block from finalized Ethereum state.
+    pub async fn finalized_max_block_number(&self) -> Result<u32, Error> {
+        self.contracts
+            .max_block_number_at(BlockNumberOrTag::Finalized)
+            .await
+    }
 
     /// Returns the maximum block distance allowed between `max_block_number`
     /// and the block number being submitted as part of a merkle-root submission
@@ -660,6 +666,15 @@ impl Contracts {
     pub async fn max_block_number(&self) -> Result<u32, Error> {
         self.message_queue_instance
             .maxBlockNumber()
+            .call()
+            .await
+            .map(|num| num.to())
+            .map_err(Error::ErrorDuringContractExecution)
+    }
+    pub async fn max_block_number_at(&self, block_tag: BlockNumberOrTag) -> Result<u32, Error> {
+        self.message_queue_instance
+            .maxBlockNumber()
+            .block(BlockId::Number(block_tag))
             .call()
             .await
             .map(|num| num.to())

--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -52,6 +52,16 @@ struct StorageTrieInclusionProof {
 
 pub type GearHeader = sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>;
 
+fn validate_block_header_hash(expected: H256, encoded_header: &[u8]) -> AnyResult<()> {
+    let actual = H256::from(Blake2Hasher::hash(encoded_header).0);
+    if actual != expected {
+        return Err(anyhow!(
+            "Block header hash mismatch: expected {expected}, got {actual}"
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Clone)]
 pub struct GearApi {
     pub api: gsdk::Api,
@@ -370,7 +380,10 @@ impl GearApi {
             Some(justification) => justification,
             None => self.get_justification(block).await?,
         };
-        let required_authority_set_id = self.signed_by_authority_set_id(block).await?;
+        let target_block: H256 = justification.commit.target_hash.0.into();
+        let required_authority_set_id = self
+            .fetch_authenticated_signed_by_authority_set_id(target_block)
+            .await?;
         let validator_set = self.fetch_authority_set(required_authority_set_id).await?;
 
         let pre_commits: Vec<_> = justification
@@ -533,8 +546,10 @@ impl GearApi {
     ) -> AnyResult<StorageInclusionProof> {
         let storage_inclusion_proof = self.fetch_storage_inclusion_proof(block, address).await?;
 
-        let block = (*self.api).blocks().at(block).await?;
+        let expected_block_hash = block;
+        let block = (*self.api).blocks().at(expected_block_hash).await?;
         let encoded_header = block.header().encode();
+        validate_block_header_hash(expected_block_hash, &encoded_header)?;
 
         // Assume that encoded_header have the folowing structure:
         // - previous block hash    (32 bytes)
@@ -608,10 +623,13 @@ impl GearApi {
             _,
             _,
         >(&storage_proof, state_root.0.into(), storage_keys.iter())
-        .unwrap_or_else(|err| panic!("Failed to generate trie proof for {address:?}: {err}"));
+        .map_err(|err| anyhow!("Failed to generate trie proof for {address:?}: {err}"))?;
 
-        let leaf = proof.pop().expect("At least one node in trie proof");
-        let leaf = TrieCodec::decode(&leaf).expect("Failed to decode last node in trie proof");
+        let leaf = proof
+            .pop()
+            .ok_or_else(|| anyhow!("Storage trie proof is empty"))?;
+        let leaf = TrieCodec::decode(&leaf)
+            .map_err(|err| anyhow!("Failed to decode last node in trie proof: {err:?}"))?;
         let encoded_leaf = if let Node::Leaf(nibbles, value) = leaf {
             if !matches!(value, Value::Inline(b) if b.is_empty()) {
                 return Err(anyhow!(
@@ -620,51 +638,50 @@ impl GearApi {
             }
 
             let storage_data_hash = Blake2Hasher::hash(&storage_data).0;
-
             let value = match storage_data.len() {
-                32 => Value::Inline(&storage_data),
-                l if l > 32 => Value::Node(&storage_data_hash),
-                _ => panic!("Unsupported leaf data length"),
+                0..=32 => Value::Inline(&storage_data),
+                _ => Value::Node(&storage_data_hash),
             };
 
             TrieCodec::leaf_node(nibbles.right_iter(), nibbles.len(), value)
         } else {
-            panic!("The last node in proof is expected to be leaf");
+            return Err(anyhow!("The last node in proof is expected to be a leaf"));
         };
 
         let mut current_hash = Blake2Hasher::hash(&encoded_leaf).0;
         let mut branch_nodes = Vec::with_capacity(proof.len());
         for node_data in proof.iter().rev() {
-            let node = TrieCodec::decode(node_data).expect("Correctly encoded node");
+            let node = TrieCodec::decode(node_data)
+                .map_err(|err| anyhow!("Failed to decode trie branch node: {err:?}"))?;
             if let Node::NibbledBranch(nibbles, children, value) = node {
-                // There will be only one NodeHandle::Inline(&[]) children and this
-                // children will lead to the target leaf.
                 let mut target_child_nibble = None;
-                let children: Vec<Option<ChildReference<H256>>> = children
-                    .into_iter()
-                    .enumerate()
-                    .map(|(child_nibble, mut child)| {
-                        if matches!(child, Some(NodeHandle::Inline(&[]))) {
-                            assert!(target_child_nibble.is_none());
-                            target_child_nibble = Some(child_nibble as u8);
-                            child = Some(NodeHandle::Hash(&current_hash));
+                let mut child_references: Vec<Option<ChildReference<H256>>> =
+                    Vec::with_capacity(16);
+                for (child_nibble, mut child) in children.into_iter().enumerate() {
+                    if matches!(child, Some(NodeHandle::Inline(&[]))) {
+                        if target_child_nibble.is_some() {
+                            return Err(anyhow!(
+                                "Trie branch contains multiple inline target children"
+                            ));
                         }
+                        target_child_nibble = Some(child_nibble as u8);
+                        child = Some(NodeHandle::Hash(&current_hash));
+                    }
 
-                        child.map(|child| {
-                            child
-                                .try_into()
-                                .expect("Failed to convert NodeHandle to ChildReference")
-                        })
-                    })
-                    .collect();
+                    child_references.push(match child {
+                        Some(child) => Some(child.try_into().map_err(|_| {
+                            anyhow!("Failed to convert trie node handle to child reference")
+                        })?),
+                        None => None,
+                    });
+                }
 
                 let target_child_nibble = target_child_nibble
-                    .expect("At least one child should be NodeHandle::Inline([])");
-
+                    .ok_or_else(|| anyhow!("Trie branch has no inline target child"))?;
                 let encoded_node = TrieCodec::branch_node_nibbled(
                     nibbles.right_iter(),
                     nibbles.len(),
-                    children.into_iter().map(|x| {
+                    child_references.into_iter().map(|x| {
                         x.map(|x| match x {
                             ChildReference::Hash(hash) => ChildReference::Hash(hash.0.into()),
                             ChildReference::Inline(hash, data) => {
@@ -676,13 +693,14 @@ impl GearApi {
                 );
 
                 current_hash = Blake2Hasher::hash(&encoded_node).0;
-
                 branch_nodes.push(BranchNodeData {
                     data: encoded_node,
                     target_child: target_child_nibble,
                 });
             } else {
-                panic!("All remaining nodes are expected to be nibbled branches");
+                return Err(anyhow!(
+                    "All remaining trie proof nodes must be nibbled branches"
+                ));
             };
         }
 
@@ -754,6 +772,56 @@ impl GearApi {
         };
 
         Ok((queue_id, merkle_root))
+    }
+    /// Fetches queue metadata with storage proofs tied to the requested block header.
+    pub async fn fetch_authenticated_queue_merkle_root(
+        &self,
+        block: H256,
+    ) -> AnyResult<(u64, H256)> {
+        let merkle_root_proof = self.fetch_sent_message_inclusion_proof(block).await?;
+        let merkle_root = H256::decode(&mut merkle_root_proof.stored_data.as_slice())
+            .context("Failed to decode authenticated queue merkle root")?;
+
+        let queue_id_address = gsdk::gear::storage().gear_eth_bridge().queue_id();
+        let queue_id_proof = self
+            .fetch_block_inclusion_proof(block, &queue_id_address.to_root_bytes())
+            .await?;
+        let queue_id = u64::decode(&mut queue_id_proof.stored_data.as_slice())
+            .context("Failed to decode authenticated queue id")?;
+
+        Ok((queue_id, merkle_root))
+    }
+
+    /// Fetches the authority-set ID that signed `block` from storage proofs tied to
+    /// the requested block and its authenticated parent header.
+    pub async fn fetch_authenticated_signed_by_authority_set_id(
+        &self,
+        block: H256,
+    ) -> AnyResult<u64> {
+        let address = gsdk::gear::storage().grandpa().current_set_id();
+        let proof = self
+            .fetch_block_inclusion_proof(block, &address.to_root_bytes())
+            .await?;
+        let stored_set_id = u64::decode(&mut proof.stored_data.as_slice())
+            .context("Failed to decode authenticated authority set id")?;
+        let header = GearHeader::decode(&mut proof.block_header.as_slice())
+            .context("Failed to decode authenticated block header")?;
+        if header.number == 0 {
+            return Ok(stored_set_id);
+        }
+
+        let previous_block: H256 = header.parent_hash.0.into();
+        let previous_proof = self
+            .fetch_block_inclusion_proof(previous_block, &address.to_root_bytes())
+            .await?;
+        let previous_set_id = u64::decode(&mut previous_proof.stored_data.as_slice())
+            .context("Failed to decode authenticated parent authority set id")?;
+
+        Ok(if previous_set_id != stored_set_id {
+            previous_set_id
+        } else {
+            stored_set_id
+        })
     }
 
     pub async fn get_events_at(
@@ -863,6 +931,7 @@ impl GearApi {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     #[test]
     fn storage_correct() {
@@ -888,5 +957,13 @@ mod tests {
             next_validator_set_address,
             expected_next_validator_set_address.to_root_bytes()
         );
+    }
+
+    #[test]
+    fn block_header_hash_must_match_requested_block() {
+        let header = b"authenticated header";
+        let hash = H256::from(Blake2Hasher::hash(header).0);
+        assert!(validate_block_header_hash(hash, header).is_ok());
+        assert!(validate_block_header_hash(hash, b"forged header").is_err());
     }
 }

--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -69,6 +69,11 @@ fn decode_authenticated_queue_id(storage: Option<&[u8]>) -> AnyResult<u64> {
     }
 }
 
+fn decode_authenticated_queue_merkle_root(storage: Option<&[u8]>) -> AnyResult<H256> {
+    let mut data = storage.context("Authenticated queue merkle root is missing")?;
+    H256::decode(&mut data).context("Failed to decode authenticated queue merkle root")
+}
+
 #[derive(Clone)]
 pub struct GearApi {
     pub api: gsdk::Api,
@@ -817,9 +822,11 @@ impl GearApi {
         &self,
         block: H256,
     ) -> AnyResult<(u64, H256)> {
-        let merkle_root_proof = self.fetch_sent_message_inclusion_proof(block).await?;
-        let merkle_root = H256::decode(&mut merkle_root_proof.stored_data.as_slice())
-            .context("Failed to decode authenticated queue merkle root")?;
+        let merkle_root_address = gsdk::gear::storage().gear_eth_bridge().queue_merkle_root();
+        let merkle_root_storage = self
+            .fetch_authenticated_storage_value(block, &merkle_root_address.to_root_bytes())
+            .await?;
+        let merkle_root = decode_authenticated_queue_merkle_root(merkle_root_storage.as_deref())?;
 
         let queue_id_address = gsdk::gear::storage().gear_eth_bridge().queue_id();
         let queue_id_storage = self
@@ -1020,5 +1027,16 @@ mod tests {
     #[test]
     fn authenticated_queue_id_rejects_malformed_value() {
         assert!(decode_authenticated_queue_id(Some(&[1, 2, 3])).is_err());
+    }
+
+    #[test]
+    fn authenticated_queue_merkle_root_requires_valid_value() {
+        let root = H256::repeat_byte(7);
+        assert_eq!(
+            decode_authenticated_queue_merkle_root(Some(&root.encode())).unwrap(),
+            root
+        );
+        assert!(decode_authenticated_queue_merkle_root(None).is_err());
+        assert!(decode_authenticated_queue_merkle_root(Some(&[1, 2, 3])).is_err());
     }
 }

--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -62,6 +62,13 @@ fn validate_block_header_hash(expected: H256, encoded_header: &[u8]) -> AnyResul
     Ok(())
 }
 
+fn decode_authenticated_queue_id(storage: Option<&[u8]>) -> AnyResult<u64> {
+    match storage {
+        Some(mut data) => u64::decode(&mut data).context("Failed to decode authenticated queue id"),
+        None => Ok(0),
+    }
+}
+
 #[derive(Clone)]
 pub struct GearApi {
     pub api: gsdk::Api,
@@ -583,6 +590,38 @@ impl GearApi {
         })
     }
 
+    async fn fetch_authenticated_storage_value(
+        &self,
+        block: H256,
+        address: &[u8],
+    ) -> AnyResult<Option<Vec<u8>>> {
+        let expected_block_hash = block;
+        let block = (*self.api).blocks().at(expected_block_hash).await?;
+        let encoded_header = block.header().encode();
+        validate_block_header_hash(expected_block_hash, &encoded_header)?;
+
+        let storage_proof = self
+            .api
+            .legacy()
+            .state_get_read_proof(vec![address], Some(block.hash()))
+            .await?
+            .proof
+            .into_iter()
+            .map(|bytes| bytes.0);
+        let storage_proof =
+            sp_trie::StorageProof::new(storage_proof).to_memory_db::<sp_core::Blake2Hasher>();
+        let state_root = block.header().state_root.0.into();
+
+        sp_trie::read_trie_value::<sp_trie::LayoutV1<sp_core::Blake2Hasher>, _>(
+            &storage_proof,
+            &state_root,
+            address,
+            None,
+            None,
+        )
+        .map_err(|err| anyhow!("Failed to authenticate storage at address {address:?}: {err}"))
+    }
+
     async fn fetch_storage_inclusion_proof(
         &self,
         block: H256,
@@ -783,11 +822,13 @@ impl GearApi {
             .context("Failed to decode authenticated queue merkle root")?;
 
         let queue_id_address = gsdk::gear::storage().gear_eth_bridge().queue_id();
-        let queue_id_proof = self
-            .fetch_block_inclusion_proof(block, &queue_id_address.to_root_bytes())
+        let queue_id_storage = self
+            .fetch_authenticated_storage_value(block, &queue_id_address.to_root_bytes())
             .await?;
-        let queue_id = u64::decode(&mut queue_id_proof.stored_data.as_slice())
-            .context("Failed to decode authenticated queue id")?;
+        if queue_id_storage.is_none() {
+            log::warn!("Authenticated QueueId entry not found in storage, using 0 as default");
+        }
+        let queue_id = decode_authenticated_queue_id(queue_id_storage.as_deref())?;
 
         Ok((queue_id, merkle_root))
     }
@@ -965,5 +1006,19 @@ mod tests {
         let hash = H256::from(Blake2Hasher::hash(header).0);
         assert!(validate_block_header_hash(hash, header).is_ok());
         assert!(validate_block_header_hash(hash, b"forged header").is_err());
+    }
+
+    #[test]
+    fn authenticated_queue_id_preserves_legacy_missing_value() {
+        assert_eq!(decode_authenticated_queue_id(None).unwrap(), 0);
+        assert_eq!(
+            decode_authenticated_queue_id(Some(&42u64.encode())).unwrap(),
+            42
+        );
+    }
+
+    #[test]
+    fn authenticated_queue_id_rejects_malformed_value() {
+        assert!(decode_authenticated_queue_id(Some(&[1, 2, 3])).is_err());
     }
 }

--- a/gear-rpc-client/src/lib.rs
+++ b/gear-rpc-client/src/lib.rs
@@ -847,23 +847,32 @@ impl GearApi {
         block: H256,
     ) -> AnyResult<u64> {
         let address = gsdk::gear::storage().grandpa().current_set_id();
-        let proof = self
-            .fetch_block_inclusion_proof(block, &address.to_root_bytes())
-            .await?;
-        let stored_set_id = u64::decode(&mut proof.stored_data.as_slice())
-            .context("Failed to decode authenticated authority set id")?;
-        let header = GearHeader::decode(&mut proof.block_header.as_slice())
+        let stored_set_id = self
+            .fetch_authenticated_storage_value(block, &address.to_root_bytes())
+            .await?
+            .context("Authenticated authority set id is missing")
+            .and_then(|data| {
+                u64::decode(&mut data.as_slice())
+                    .context("Failed to decode authenticated authority set id")
+            })?;
+        let block_data = (*self.api).blocks().at(block).await?;
+        let encoded_header = block_data.header().encode();
+        validate_block_header_hash(block, &encoded_header)?;
+        let header = GearHeader::decode(&mut encoded_header.as_slice())
             .context("Failed to decode authenticated block header")?;
         if header.number == 0 {
             return Ok(stored_set_id);
         }
 
         let previous_block: H256 = header.parent_hash.0.into();
-        let previous_proof = self
-            .fetch_block_inclusion_proof(previous_block, &address.to_root_bytes())
-            .await?;
-        let previous_set_id = u64::decode(&mut previous_proof.stored_data.as_slice())
-            .context("Failed to decode authenticated parent authority set id")?;
+        let previous_set_id = self
+            .fetch_authenticated_storage_value(previous_block, &address.to_root_bytes())
+            .await?
+            .context("Authenticated parent authority set id is missing")
+            .and_then(|data| {
+                u64::decode(&mut data.as_slice())
+                    .context("Failed to decode authenticated parent authority set id")
+            })?;
 
         Ok(if previous_set_id != stored_set_id {
             previous_set_id

--- a/gnark-wrapper/main.go
+++ b/gnark-wrapper/main.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark-crypto/kzg"
@@ -104,16 +105,82 @@ func dataFile(dataDir string, name string) string {
 	return filepath.Join(dataDir, name)
 }
 
-//export prove
-func prove(circuitData *C.char, dataPath *C.char) *C.char {
-	dataDir := C.GoString(dataPath)
-	pk, err := loadProvingKey(dataDir)
-	if err != nil {
-		compile(circuitData, dataDir)
-		pk, _ = loadProvingKey(dataDir)
+type provingArtifacts struct {
+	pk   plonk.ProvingKey
+	r1cs constraint.ConstraintSystem
+	vk   plonk.VerifyingKey
+}
+
+type provingArtifactsCacheEntry struct {
+	once      sync.Once
+	artifacts *provingArtifacts
+	err       error
+}
+
+// Proving keys, R1CS, and verifying keys are immutable for a generated
+// circuit. Keep them in memory for the lifetime of the Go archive instead of
+// deserializing all three files for every cgo prove call. A data directory must
+// not be replaced with artifacts for another circuit while this process runs.
+var provingArtifactsCache sync.Map // map[absolute data dir]*provingArtifactsCacheEntry
+
+func normalizedDataDir(dataDir string) string {
+	if dataDir == "" {
+		dataDir = defaultDataDir
+	}
+	absolute, err := filepath.Abs(dataDir)
+	if err == nil {
+		return absolute
+	}
+	return filepath.Clean(dataDir)
+}
+
+func loadProvingArtifacts(dataDir string, circuitData string) (*provingArtifacts, error) {
+	dataDir = normalizedDataDir(dataDir)
+	entry := &provingArtifactsCacheEntry{}
+	actual, _ := provingArtifactsCache.LoadOrStore(dataDir, entry)
+	entry = actual.(*provingArtifactsCacheEntry)
+
+	load := func() (*provingArtifacts, error) {
+		pk, err := loadProvingKey(dataDir)
+		if err != nil {
+			return nil, fmt.Errorf("load proving key: %w", err)
+		}
+		r1cs, err := loadR1CS(dataDir)
+		if err != nil {
+			return nil, fmt.Errorf("load R1CS: %w", err)
+		}
+		vk, err := loadVerifyingKey(dataDir)
+		if err != nil {
+			return nil, fmt.Errorf("load verifying key: %w", err)
+		}
+		return &provingArtifacts{pk: pk, r1cs: r1cs, vk: vk}, nil
 	}
 
-	r1cs := loadR1CS(dataDir)
+	entry.once.Do(func() {
+		artifacts, err := load()
+		if err != nil {
+			// Preserve the existing behavior of generating artifacts on a cache
+			// miss, while also recovering from a partially written artifact set.
+			compile(circuitData, dataDir)
+			artifacts, err = load()
+		}
+		if err != nil {
+			entry.err = err
+			return
+		}
+		entry.artifacts = artifacts
+	})
+
+	return entry.artifacts, entry.err
+}
+
+//export prove
+func prove(circuitData *C.char, dataPath *C.char) *C.char {
+	dataDir := normalizedDataDir(C.GoString(dataPath))
+	artifacts, err := loadProvingArtifacts(dataDir, C.GoString(circuitData))
+	if err != nil {
+		panic(err)
+	}
 
 	assignment, err := deserializeCircuit(C.GoString(circuitData))
 	if err != nil {
@@ -121,18 +188,17 @@ func prove(circuitData *C.char, dataPath *C.char) *C.char {
 	}
 	witness, _ := frontend.NewWitness(&assignment, ecc.BN254.ScalarField())
 
-	proof, err := plonk.Prove(r1cs, pk, witness)
+	proof, err := plonk.Prove(artifacts.r1cs, artifacts.pk, witness)
 	if err != nil {
 		errorString := fmt.Sprintf("Prover error: %s. Gnark circuit may be outdated or plonky2 proof is incorrect", err)
 		panic(errorString)
 	}
 
-	vk := loadVerifyingKey(dataDir)
 	publicWitness, err := witness.Public()
 	if err != nil {
 		panic(err)
 	}
-	err = plonk.Verify(proof, vk, publicWitness)
+	err = plonk.Verify(proof, artifacts.vk, publicWitness)
 	if err != nil {
 		errorString := fmt.Sprintf("Verifier error: %s. Gnark circuit may be outdated, please recompile it", err)
 		panic(errorString)
@@ -143,8 +209,8 @@ func prove(circuitData *C.char, dataPath *C.char) *C.char {
 	return C.CString(rawProof)
 }
 
-func compile(circuitData *C.char, dataDir string) {
-	circuit, err := deserializeCircuit(C.GoString(circuitData))
+func compile(circuitData string, dataDir string) {
+	circuit, err := deserializeCircuit(circuitData)
 	if err != nil {
 		panic(err)
 	}
@@ -290,19 +356,18 @@ func compressPublicInputs(pis []gl.Variable) []frontend.Variable {
 	return compressedPis
 }
 
-func loadVerifyingKey(dataDir string) plonk.VerifyingKey {
+func loadVerifyingKey(dataDir string) (plonk.VerifyingKey, error) {
 	vkFile, err := os.Open(dataFile(dataDir, "verifying.key"))
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
-	vk := plonk.NewVerifyingKey(ecc.BN254)
-	_, err = vk.ReadFrom(vkFile)
-	if err != nil {
-		fmt.Println(err)
-	}
-	vkFile.Close()
+	defer vkFile.Close()
 
-	return vk
+	vk := plonk.NewVerifyingKey(ecc.BN254)
+	if _, err = vk.ReadFrom(vkFile); err != nil {
+		return nil, err
+	}
+	return vk, nil
 }
 
 func loadProvingKey(dataDir string) (plonk.ProvingKey, error) {
@@ -310,31 +375,27 @@ func loadProvingKey(dataDir string) (plonk.ProvingKey, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer pkFile.Close()
+
 	pk := plonk.NewProvingKey(ecc.BN254)
-	pkReader := bufio.NewReader(pkFile)
-	_, err = pk.ReadFrom(pkReader)
-	if err != nil {
+	if _, err = pk.ReadFrom(bufio.NewReader(pkFile)); err != nil {
 		return nil, err
 	}
-	pkFile.Close()
-
 	return pk, nil
 }
 
-func loadR1CS(dataDir string) constraint.ConstraintSystem {
+func loadR1CS(dataDir string) (constraint.ConstraintSystem, error) {
 	r1cs := plonk.NewCS(ecc.BN254)
 	r1csFile, err := os.Open(dataFile(dataDir, "r1cs"))
 	if err != nil {
-		fmt.Println(err)
+		return nil, err
 	}
-	r1csReader := bufio.NewReader(r1csFile)
-	_, err = r1cs.ReadFrom(r1csReader)
-	if err != nil {
-		fmt.Println(err)
-	}
-	r1csFile.Close()
+	defer r1csFile.Close()
 
-	return r1cs
+	if _, err = r1cs.ReadFrom(bufio.NewReader(r1csFile)); err != nil {
+		return nil, err
+	}
+	return r1cs, nil
 }
 
 func loadSRS(dataDir string) kzg.SRS {

--- a/prover/src/block_finality/validator_set_hash.rs
+++ b/prover/src/block_finality/validator_set_hash.rs
@@ -59,7 +59,7 @@ impl ValidatorSetHash {
 
         const MAX_DATA_LENGTH_ESTIMATION: usize = ED25519_PUBLIC_KEY_SIZE * MAX_VALIDATOR_COUNT;
 
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof = circuit.prove::<MAX_DATA_LENGTH_ESTIMATION>(
             self.validator_set
                 .into_iter()

--- a/prover/src/block_finality/validator_signs_chain/indexed_validator_sign.rs
+++ b/prover/src/block_finality/validator_signs_chain/indexed_validator_sign.rs
@@ -6,17 +6,25 @@ use plonky2::{
         target::Target,
         witness::{PartialWitness, WitnessWrite},
     },
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData, VerifierCircuitData},
+        proof::ProofWithPublicInputsTarget,
+    },
 };
 
 use plonky2_field::types::Field;
+use std::sync::{Arc, OnceLock};
 
-use super::{single_validator_sign::SingleValidatorSign, GrandpaMessageTarget};
+use super::{
+    single_validator_sign::{PublicInputsTarget as SingleValidatorSignTarget, SingleValidatorSign},
+    GrandpaMessageTarget,
+};
 use crate::{
     block_finality::validator_set_hash::ValidatorSetHashTarget,
     common::{
         targets::{impl_target_set, Blake2Target, TargetSet},
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     consts::GRANDPA_VOTE_LENGTH,
     prelude::*,
@@ -47,6 +55,85 @@ pub struct IndexedValidatorSign {
     pub signature: [u8; consts::ED25519_SIGNATURE_SIZE],
 }
 
+struct IndexedValidatorSignCircuitTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    validator_set_hash_proof: ProofWithPublicInputsTarget<D>,
+    sign_proof: ProofWithPublicInputsTarget<D>,
+    index_target: Target,
+}
+
+impl IndexedValidatorSignCircuitTemplate {
+    fn cached(
+        validator_set_hash_proof: &ProofWithCircuitData<ValidatorSetHashTarget>,
+        sign_proof: &ProofWithCircuitData<SingleValidatorSignTarget>,
+    ) -> &'static Self {
+        // The recursive circuit shape is independent of the validator index,
+        // signature, and message. Reuse it while supplying those proofs as
+        // witnesses for each signer.
+        static CACHE: OnceLock<IndexedValidatorSignCircuitTemplate> = OnceLock::new();
+        CACHE.get_or_init(|| Self::build(validator_set_hash_proof, sign_proof))
+    }
+
+    fn build(
+        validator_set_hash_proof: &ProofWithCircuitData<ValidatorSetHashTarget>,
+        sign_proof: &ProofWithCircuitData<SingleValidatorSignTarget>,
+    ) -> Self {
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+
+        let validator_set_hash_data = validator_set_hash_proof.circuit_data();
+        let validator_set_hash_proof_target =
+            builder.add_virtual_proof_with_pis(&validator_set_hash_data.common);
+        let validator_set_hash_verifier =
+            builder.constant_verifier_data(&validator_set_hash_data.verifier_only);
+        builder.verify_proof::<C>(
+            &validator_set_hash_proof_target,
+            &validator_set_hash_verifier,
+            &validator_set_hash_data.common,
+        );
+        let validator_set_hash_target = ValidatorSetHashTarget::parse_exact(
+            &mut validator_set_hash_proof_target
+                .public_inputs
+                .clone()
+                .into_iter(),
+        );
+
+        let index_target = builder.add_virtual_target();
+        let validator = validator_set_hash_target
+            .validator_set
+            .random_read(index_target, &mut builder);
+
+        let sign_data = sign_proof.circuit_data();
+        let sign_proof_target = builder.add_virtual_proof_with_pis(&sign_data.common);
+        let sign_verifier = builder.constant_verifier_data(&sign_data.verifier_only);
+        builder.verify_proof::<C>(&sign_proof_target, &sign_verifier, &sign_data.common);
+        let sign_target = SingleValidatorSignTarget::parse_exact(
+            &mut sign_proof_target.public_inputs.clone().into_iter(),
+        );
+
+        validator.connect(&sign_target.public_key, &mut builder);
+
+        IndexedValidatorSignTarget {
+            validator_set_hash: validator_set_hash_target.hash,
+            validator_count: validator_set_hash_target.validator_set_length,
+            validator_idx: index_target,
+            message: sign_target.message,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            validator_set_hash_proof: validator_set_hash_proof_target,
+            sign_proof: sign_proof_target,
+            index_target,
+        }
+    }
+}
+
 impl IndexedValidatorSign {
     pub fn prove(
         &self,
@@ -60,33 +147,21 @@ impl IndexedValidatorSign {
             message: self.message,
         }
         .prove();
+        let template =
+            IndexedValidatorSignCircuitTemplate::cached(valiadtor_set_hash_proof, &sign_proof);
 
-        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
         let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(
+            &template.validator_set_hash_proof,
+            &valiadtor_set_hash_proof.proof(),
+        );
+        witness.set_proof_with_pis_target(&template.sign_proof, &sign_proof.proof());
+        witness.set_target(template.index_target, F::from_canonical_usize(self.index));
 
-        let validator_set_hash_target =
-            builder.recursively_verify_constant_proof(valiadtor_set_hash_proof, &mut witness);
-
-        let index_target = builder.add_virtual_target();
-        witness.set_target(index_target, F::from_canonical_usize(self.index));
-
-        let validator = validator_set_hash_target
-            .validator_set
-            .random_read(index_target, &mut builder);
-
-        let sign_target = builder.recursively_verify_constant_proof(&sign_proof, &mut witness);
-
-        validator.connect(&sign_target.public_key, &mut builder);
-
-        IndexedValidatorSignTarget {
-            validator_set_hash: validator_set_hash_target.hash,
-            validator_count: validator_set_hash_target.validator_set_length,
-
-            validator_idx: index_target,
-            message: sign_target.message,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        ProofWithCircuitData::prove_from_builder(builder, witness)
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &template.circuit_data,
+            Arc::clone(&template.verifier_data),
+            witness,
+        )
     }
 }

--- a/prover/src/block_finality/validator_signs_chain/mod.rs
+++ b/prover/src/block_finality/validator_signs_chain/mod.rs
@@ -7,21 +7,28 @@ use plonky2::{
     },
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, CircuitData, CommonCircuitData},
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget,
+        },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
     recursion::dummy_circuit::cyclic_base_proof,
 };
 use plonky2_field::types::Field;
 use rayon::ThreadPoolBuilder;
-use std::{iter, time::Instant};
+use std::{
+    iter,
+    sync::{Arc, Mutex, OnceLock},
+    time::Instant,
+};
 
 mod indexed_validator_sign;
 mod single_validator_sign;
 
 use crate::{
     common::{
-        array_to_bits, common_data_for_recursion,
+        array_to_bits, common_data_for_recursion, get_env_variable,
         targets::{
             impl_parsable_target_set, impl_target_set, Blake2Target, ParsableTargetSet, TargetSet,
             VerifierDataTarget,
@@ -131,94 +138,99 @@ impl ValidatorSignsChain {
         self.pre_commits
             .sort_by(|a, b| a.validator_idx.cmp(&b.validator_idx));
 
-        let (sender, receiver) = std::sync::mpsc::channel::<Request>();
-        let thread = std::thread::spawn(move || {
-            let Ok(request) = receiver.recv() else {
-                return None;
-            };
+        // Bound the queue so slow recursive composition cannot retain every
+        // large signer proof while workers continue producing them.
+        let channel_capacity = get_env_variable("SIGN_PROOF_CHANNEL_CAPACITY", 2usize).max(1);
+        let (sender, receiver) = std::sync::mpsc::sync_channel::<Request>(channel_capacity);
+        let composed_result = Arc::new(Mutex::new(None));
 
-            let (proof_initial, proof_maybe) = request.into();
+        // Keep one bounded pool for both concurrent signer proofs. The old
+        // implementation nested a two-thread scheduler around two pools of
+        // `worker_thread_count` threads, which could create roughly twice the
+        // requested workers and contend with Plonky2's parallel prover.
+        // One worker is needed for composition while another proves a signer.
+        let worker_thread_count = self.count_thread.unwrap_or(30).max(2);
+        let pool = ThreadPoolBuilder::new()
+            .stack_size(get_env_variable(
+                "RUST_MIN_STACK",
+                crate::consts::SIZE_THREAD_STACK_MIN,
+            ))
+            .num_threads(worker_thread_count)
+            .build()
+            .expect("ValidatorSignsChain: failed to create ThreadPool");
 
-            let initial_data = SignCompositionInitialData {
-                validator_set_hash,
+        let worker_func = |pre_commit: &ProcessedPreCommit| {
+            let proof = IndexedValidatorSign {
+                public_key: pre_commit.public_key,
+                index: pre_commit.validator_idx,
+                signature: pre_commit.signature,
                 message: self.message,
-            };
-            let mut composed_proof =
-                SignComposition::build(&proof_initial).prove_initial(initial_data);
-            if let Some(proof) = proof_maybe {
-                composed_proof =
-                    SignComposition::build(&proof).prove_recursive(composed_proof.proof());
             }
+            .prove(&validator_set_hash_proof);
 
-            while let Ok(request) = receiver.recv() {
-                let (proof, proof_maybe) = request.into();
-
-                composed_proof =
-                    SignComposition::build(&proof).prove_recursive(composed_proof.proof());
-                if let Some(proof) = proof_maybe {
-                    composed_proof =
-                        SignComposition::build(&proof).prove_recursive(composed_proof.proof());
-                }
-            }
-
-            Some(composed_proof)
-        });
-
-        let pool = ThreadPoolBuilder::new().num_threads(2).build().unwrap();
-        let worker_thread_count = self.count_thread.unwrap_or(30);
-        let pools = [
-            ThreadPoolBuilder::new()
-                .num_threads(worker_thread_count)
-                .build()
-                .unwrap(),
-            ThreadPoolBuilder::new()
-                .num_threads(worker_thread_count)
-                .build()
-                .unwrap(),
-        ];
-
-        let worker_func = |pre_commit: &ProcessedPreCommit, pool: &rayon::ThreadPool| {
-            let (index, proof) = pool.install(|| {
-                let proof = IndexedValidatorSign {
-                    public_key: pre_commit.public_key,
-                    index: pre_commit.validator_idx,
-                    signature: pre_commit.signature,
-                    message: self.message,
-                }
-                .prove(&validator_set_hash_proof);
-
-                (pre_commit.validator_idx, proof)
-            });
-
-            (index, proof)
+            (pre_commit.validator_idx, proof)
         };
 
-        send_proof_requests_for_pre_commits(
-            &self.pre_commits,
-            |left, right| {
-                let (result_1, result_2) = pool.join(
-                    || worker_func(left, &pools[0]),
-                    || worker_func(right, &pools[1]),
-                );
+        // Run composition inside the same pool as signer proofs, rather than
+        // creating a separate OS thread that falls back to Rayon’s global pool.
+        pool.scope(|scope| {
+            let composed_result = Arc::clone(&composed_result);
+            scope.spawn(move |_| {
+                let result = (|| {
+                    let Ok(request) = receiver.recv() else {
+                        return None;
+                    };
 
-                sender
-                    .send(Request::Pair(Box::new((result_1, result_2))))
-                    .unwrap();
-            },
-            |single| {
-                sender
-                    .send(Request::SingleItem(Box::new(worker_func(
-                        single, &pools[1],
-                    ))))
-                    .unwrap();
-            },
-        );
+                    let (proof_initial, proof_maybe) = request.into();
+                    let initial_data = SignCompositionInitialData {
+                        validator_set_hash,
+                        message: self.message,
+                    };
+                    let mut composed_proof =
+                        SignComposition::build(&proof_initial).prove_initial(initial_data);
+                    if let Some(proof) = proof_maybe {
+                        composed_proof =
+                            SignComposition::build(&proof).prove_recursive(composed_proof.proof());
+                    }
 
-        drop(sender);
-        let composed_proof = thread
-            .join()
-            .expect("should be joinable")
-            .expect("there is a proof");
+                    while let Ok(request) = receiver.recv() {
+                        let (proof, proof_maybe) = request.into();
+                        composed_proof =
+                            SignComposition::build(&proof).prove_recursive(composed_proof.proof());
+                        if let Some(proof) = proof_maybe {
+                            composed_proof = SignComposition::build(&proof)
+                                .prove_recursive(composed_proof.proof());
+                        }
+                    }
+
+                    Some(composed_proof)
+                })();
+                *composed_result.lock().unwrap() = result;
+            });
+
+            send_proof_requests_for_pre_commits(
+                &self.pre_commits,
+                |left, right| {
+                    let (result_1, result_2) =
+                        pool.join(|| worker_func(left), || worker_func(right));
+
+                    sender
+                        .send(Request::Pair(Box::new((result_1, result_2))))
+                        .unwrap();
+                },
+                |single| {
+                    let result = pool.install(|| worker_func(single));
+                    sender.send(Request::SingleItem(Box::new(result))).unwrap();
+                },
+            );
+
+            drop(sender);
+        });
+        let composed_proof = composed_result
+            .lock()
+            .unwrap()
+            .take()
+            .expect("composition worker should return");
 
         log::info!("inner_proofs time: {}ms", now.elapsed().as_millis());
 
@@ -283,87 +295,49 @@ struct SignCompositionInitialData {
     message: [u8; GRANDPA_VOTE_LENGTH],
 }
 
-/// Inner cyclic recursion proof.
-struct SignComposition {
-    cyclic_circuit_data: CircuitData<F, C, D>,
-
-    common_data: CommonCircuitData<F, D>,
-
+/// Circuit shape shared by all signer-composition layers.
+///
+/// The inner proof and verifier data are supplied through the witness for each
+/// use; only the recursive circuit shape is cached.
+struct SignCompositionCircuitTemplate {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
     condition: BoolTarget,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
-
-    witness: PartialWitness<F>,
+    verifier_data_target: VerifierCircuitTarget,
 }
 
-impl SignComposition {
-    fn prove_initial(
-        mut self,
-        initial_data: SignCompositionInitialData,
-    ) -> ProofWithCircuitData<SignCompositionTarget> {
-        log::debug!("    Proving sign composition recursion layer(initial)...");
-
-        let validator_set_hash = array_to_bits(&initial_data.validator_set_hash);
-        let message = array_to_bits(&initial_data.message);
-
-        let public_inputs = validator_set_hash
-            .into_iter()
-            .map(|bit| bit as usize)
-            .chain(iter::once(0))
-            .chain(message.into_iter().map(|bit| bit as usize))
-            .chain(iter::once(0))
-            .chain(iter::once(0))
-            .map(F::from_canonical_usize);
-
-        // Length check.
-        SignCompositionTargetWithoutCircuitData::parse_public_inputs_exact(
-            &mut public_inputs.clone(),
-        );
-
-        let public_inputs = public_inputs.enumerate().collect();
-
-        self.witness.set_bool_target(self.condition, false);
-        self.witness.set_proof_with_pis_target::<C, D>(
-            &self.inner_cyclic_proof_with_pis,
-            &cyclic_base_proof(
-                &self.common_data,
-                &self.cyclic_circuit_data.verifier_only,
-                public_inputs,
-            ),
-        );
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven sign composition recursion layer(initial)...");
-
-        result
+impl SignCompositionCircuitTemplate {
+    fn cached(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> &'static Self {
+        // All IndexedValidatorSign proofs in one proving run use the same
+        // circuit. Keep one recursion template instead of rebuilding it for
+        // every validator signature. This process-wide cache assumes all
+        // signer proofs use the deployment's single circuit configuration.
+        static CACHE: OnceLock<SignCompositionCircuitTemplate> = OnceLock::new();
+        CACHE.get_or_init(|| Self::build(inner_proof))
     }
 
-    fn prove_recursive(
-        mut self,
-        composed_proof: ProofWithPublicInputs<F, C, D>,
-    ) -> ProofWithCircuitData<SignCompositionTarget> {
-        log::debug!("    Proving sign composition recursion layer...");
-        self.witness.set_bool_target(self.condition, true);
-        self.witness
-            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven sign composition recursion layer");
-
-        result
-    }
-
-    fn build(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> SignComposition {
-        log::debug!("    Building sign composition recursion layer...");
+    fn build(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> Self {
+        log::debug!("    Building sign composition recursion template...");
 
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::new(config);
-        let mut pw = PartialWitness::new();
+        let mut inner_proof_witness = PartialWitness::new();
 
-        let inner_proof_pis = builder.recursively_verify_constant_proof(inner_proof, &mut pw);
+        let inner_circuit_data = inner_proof.circuit_data();
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_circuit_data.common);
+        let inner_verifier_data = builder.constant_verifier_data(&inner_circuit_data.verifier_only);
+        builder.verify_proof::<C>(
+            &inner_proof_with_pis,
+            &inner_verifier_data,
+            &inner_circuit_data.common,
+        );
+        inner_proof_witness.set_proof_with_pis_target(&inner_proof_with_pis, &inner_proof.proof());
+        let inner_proof_pis = IndexedValidatorSignTarget::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         let mut virtual_targets = iter::repeat(()).map(|_| builder.add_virtual_target());
         let future_inner_cyclic_proof_pis =
@@ -438,18 +412,116 @@ impl SignComposition {
             )
             .expect("Failed to build circuit");
 
-        let cyclic_circuit_data = builder.build::<C>();
+        let cyclic_circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(cyclic_circuit_data.verifier_data());
 
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        log::debug!("    Built sign composition recursion template");
 
-        log::debug!("    Built sign composition recursion layer");
-
-        SignComposition {
+        Self {
             cyclic_circuit_data,
-            common_data,
+            verifier_data,
+            common_data: Arc::new(common_data),
             condition,
+            inner_proof_with_pis,
             inner_cyclic_proof_with_pis,
-            witness: pw,
+            verifier_data_target,
+        }
+    }
+}
+
+/// Inner cyclic recursion proof.
+struct SignComposition {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
+    condition: BoolTarget,
+    inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    witness: PartialWitness<F>,
+}
+
+impl SignComposition {
+    fn prove_initial(
+        mut self,
+        initial_data: SignCompositionInitialData,
+    ) -> ProofWithCircuitData<SignCompositionTarget> {
+        log::debug!("    Proving sign composition recursion layer(initial)...");
+
+        let validator_set_hash = array_to_bits(&initial_data.validator_set_hash);
+        let message = array_to_bits(&initial_data.message);
+
+        let public_inputs = validator_set_hash
+            .into_iter()
+            .map(|bit| bit as usize)
+            .chain(iter::once(0))
+            .chain(message.into_iter().map(|bit| bit as usize))
+            .chain(iter::once(0))
+            .chain(iter::once(0))
+            .map(F::from_canonical_usize);
+
+        // Length check.
+        SignCompositionTargetWithoutCircuitData::parse_public_inputs_exact(
+            &mut public_inputs.clone(),
+        );
+
+        let public_inputs = public_inputs.enumerate().collect();
+
+        self.witness.set_bool_target(self.condition, false);
+        self.witness.set_proof_with_pis_target::<C, D>(
+            &self.inner_cyclic_proof_with_pis,
+            &cyclic_base_proof(
+                &self.common_data,
+                &self.cyclic_circuit_data.verifier_only,
+                public_inputs,
+            ),
+        );
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.cyclic_circuit_data,
+            Arc::clone(&self.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven sign composition recursion layer(initial)...");
+
+        result
+    }
+
+    fn prove_recursive(
+        mut self,
+        composed_proof: ProofWithPublicInputs<F, C, D>,
+    ) -> ProofWithCircuitData<SignCompositionTarget> {
+        log::debug!("    Proving sign composition recursion layer...");
+        self.witness.set_bool_target(self.condition, true);
+        self.witness
+            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.cyclic_circuit_data,
+            Arc::clone(&self.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven sign composition recursion layer");
+
+        result
+    }
+
+    fn build(inner_proof: &ProofWithCircuitData<IndexedValidatorSignTarget>) -> Self {
+        let template = SignCompositionCircuitTemplate::cached(inner_proof);
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&template.inner_proof_with_pis, &inner_proof.proof());
+        witness.set_verifier_data_target(
+            &template.verifier_data_target,
+            &template.cyclic_circuit_data.verifier_only,
+        );
+
+        Self {
+            cyclic_circuit_data: Arc::clone(&template.cyclic_circuit_data),
+            verifier_data: Arc::clone(&template.verifier_data),
+            common_data: Arc::clone(&template.common_data),
+            condition: template.condition,
+            inner_cyclic_proof_with_pis: template.inner_cyclic_proof_with_pis.clone(),
+            witness,
         }
     }
 }

--- a/prover/src/common/blake2/mod.rs
+++ b/prover/src/common/blake2/mod.rs
@@ -32,7 +32,6 @@ use plonky2_blake2b256::circuit::{
 use plonky2_field::types::Field;
 use std::{
     env, fs, io, iter,
-    marker::PhantomData,
     sync::{Arc, LazyLock},
     time::Instant,
 };
@@ -168,6 +167,9 @@ impl BuilderTargets {
 /// the valid inputs.
 pub struct CircuitTargets {
     circuit: CircuitData<F, C, D>,
+    // The verifier data is immutable. Keep one shared copy instead of cloning
+    // CommonCircuitData for every hash proof.
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     target_block_count: Target,
     target_proof: ProofWithPublicInputsTarget<D>,
 }
@@ -179,6 +181,7 @@ impl From<BuilderTargets> for CircuitTargets {
         let now = Instant::now();
 
         let circuit = value.builder.build::<C>();
+        let verifier_data = Arc::new(circuit.verifier_data());
 
         log::trace!(
             "From<BuilderTargets> for CircuitTargets exit. Time: {}ms",
@@ -187,6 +190,7 @@ impl From<BuilderTargets> for CircuitTargets {
 
         Self {
             circuit,
+            verifier_data,
             target_block_count: value.target_block_count,
             target_proof: value.target_proof,
         }
@@ -198,6 +202,15 @@ impl CircuitTargets {
         let builder_targets = BuilderTargets::new();
 
         builder_targets.into()
+    }
+
+    /// Return the process-wide generic Blake2 circuit. Its shape and verifier
+    /// data are independent of the input, so rebuilding it per hash is wasted
+    /// work and duplicates a large CommonCircuitData allocation. The cache is
+    /// process-wide and assumes one deployment configuration per process.
+    pub fn cached() -> &'static Self {
+        static CACHE: LazyLock<CircuitTargets> = LazyLock::new(CircuitTargets::new);
+        &CACHE
     }
 
     pub fn prove<const MAX_DATA_LENGTH_ESTIMATION: usize>(
@@ -239,14 +252,24 @@ impl CircuitTargets {
             now.elapsed().as_millis()
         );
 
-        ProofWithCircuitData {
-            proof,
-            circuit_data: Arc::from(self.circuit.verifier_data()),
-            public_inputs,
-            public_inputs_parser: PhantomData,
-        }
+        ProofWithCircuitData::from_proof_and_shared_circuit_data(
+            ProofWithPublicInputs {
+                proof,
+                public_inputs,
+            },
+            Arc::clone(&self.verifier_data),
+        )
     }
 
+    pub fn common(&self) -> &CommonCircuitData<F, D> {
+        &self.circuit.common
+    }
+
+    pub fn verifier_only(&self) -> &VerifierOnlyCircuitData<C, D> {
+        &self.circuit.verifier_only
+    }
+
+    #[allow(dead_code)]
     pub fn into_inner(self) -> (CircuitData<F, C, D>, Target, ProofWithPublicInputsTarget<D>) {
         (self.circuit, self.target_block_count, self.target_proof)
     }

--- a/prover/src/common/blake2/variative.rs
+++ b/prover/src/common/blake2/variative.rs
@@ -1,44 +1,74 @@
 use super::*;
 use plonky2::plonk::circuit_data::ProverCircuitData;
 
-static CACHED_PROVER_TARGETS2: LazyLock<(ProverCircuitData<F, C, D>, Vec<Target>)> =
-    LazyLock::new(|| {
-        let index = 2;
+struct CachedProverTargets {
+    prover_data: ProverCircuitData<F, C, D>,
+    targets: Vec<Target>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+}
 
-        let path = env::var("VBLAKE2_CACHE_PATH")
-            .expect(r#"VariativeBlake2: "VBLAKE2_CACHE_PATH" is set"#);
-        let serializer_gate = GateSerializer;
-        let serializer_generator = GeneratorSerializer::<C, D>::default();
+fn load_cached_prover_targets(index: usize) -> CachedProverTargets {
+    let path =
+        env::var("VBLAKE2_CACHE_PATH").expect(r#"VariativeBlake2: "VBLAKE2_CACHE_PATH" is set"#);
+    let serializer_gate = GateSerializer;
+    let serializer_generator = GeneratorSerializer::<C, D>::default();
 
-        let now = Instant::now();
-        let prover_data = {
-            let file = fs::OpenOptions::new()
-                .read(true)
-                .open(format!("{path}/prover_circuit_data-{index}"))
-                .expect("VariativeBlake2: open a file with correctly formed data for read");
-            let reader = io::BufReader::with_capacity(*BUFFER_SIZE, file);
+    let now = Instant::now();
+    let prover_data = {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .open(format!("{path}/prover_circuit_data-{index}"))
+            .expect("VariativeBlake2: open a file with correctly formed data for read");
+        let reader = io::BufReader::with_capacity(*BUFFER_SIZE, file);
 
-            let mut read_adapter = ReadAdapter::new(reader, None);
+        let mut read_adapter = ReadAdapter::new(reader, None);
 
-            read_adapter
-                .read_prover_circuit_data::<F, C, D>(&serializer_gate, &serializer_generator)
-                .expect("Correctly formed serialized data")
-        };
+        read_adapter
+            .read_prover_circuit_data::<F, C, D>(&serializer_gate, &serializer_generator)
+            .expect("Correctly formed serialized data")
+    };
 
-        log::trace!(
-            "Loading CACHED_PROVER_TARGETS2 time: {}ms",
-            now.elapsed().as_millis()
-        );
+    log::trace!(
+        "Loading cached VariativeBlake2 circuit (index = {index}) time: {}ms",
+        now.elapsed().as_millis()
+    );
 
-        let serialized = fs::read(format!("{path}/prover_circuit_data-targets-{index}"))
-            .expect("VariativeBlake2: Good file with serialized data");
-        let mut buffer_read = Buffer::new(&serialized[..]);
-        let targets = buffer_read
-            .read_target_vec()
-            .expect("VariativeBlake2: buffer_read.read_target_vec()");
+    let serialized = fs::read(format!("{path}/prover_circuit_data-targets-{index}"))
+        .expect("VariativeBlake2: Good file with serialized data");
+    let mut buffer_read = Buffer::new(&serialized[..]);
+    let targets = buffer_read
+        .read_target_vec()
+        .expect("VariativeBlake2: buffer_read.read_target_vec()");
 
-        (prover_data, targets)
+    // Clone the common data once when populating the process cache. Every
+    // proof below shares this Arc rather than cloning the 655k-gate metadata.
+    let verifier_data = Arc::new(VerifierCircuitData {
+        verifier_only: VERIFIER_DATA_BY_BLOCK_COUNT[index - 1].clone(),
+        common: prover_data.common.clone(),
     });
+
+    CachedProverTargets {
+        prover_data,
+        targets,
+        verifier_data,
+    }
+}
+
+static CACHED_PROVER_TARGETS1: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(1));
+static CACHED_PROVER_TARGETS2: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(2));
+// Production traces show indices 3, 4, and 15 are also hot in storage and
+// validator-set proofs. Each serialized prover circuit is large, so keep this
+// explicit bounded set rather than retaining all 50 possible block counts.
+static CACHED_PROVER_TARGETS3: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(3));
+static CACHED_PROVER_TARGETS4: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(4));
+static CACHED_PROVER_TARGETS15: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(15));
+static CACHED_PROVER_TARGETS16: LazyLock<CachedProverTargets> =
+    LazyLock::new(|| load_cached_prover_targets(16));
 
 impl_target_set! {
     pub struct VariativeBlake2Target {
@@ -57,9 +87,68 @@ impl VariativeBlake2 {
     pub fn prove(data: &[u8]) -> ProofWithCircuitData<VariativeBlake2Target> {
         let index = data.len().div_ceil(BLOCK_BYTES).max(1);
 
-        if index == 2 {
-            let (ref prover_data, ref targets) = *CACHED_PROVER_TARGETS2;
-            return Self::prove_inner(index, prover_data, targets, data);
+        match index {
+            1 => {
+                let cached = &*CACHED_PROVER_TARGETS1;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            2 => {
+                let cached = &*CACHED_PROVER_TARGETS2;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            3 => {
+                let cached = &*CACHED_PROVER_TARGETS3;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            4 => {
+                let cached = &*CACHED_PROVER_TARGETS4;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            15 => {
+                let cached = &*CACHED_PROVER_TARGETS15;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            16 => {
+                let cached = &*CACHED_PROVER_TARGETS16;
+                return Self::prove_inner(
+                    index,
+                    &cached.prover_data,
+                    &cached.targets,
+                    Arc::clone(&cached.verifier_data),
+                    data,
+                );
+            }
+            _ => {}
         }
 
         let path = env::var("VBLAKE2_CACHE_PATH")
@@ -94,13 +183,19 @@ impl VariativeBlake2 {
             .read_target_vec()
             .expect("VariativeBlake2: buffer_read.read_target_vec()");
 
-        Self::prove_inner(index, &prover_data, &targets, data)
+        let verifier_data = Arc::new(VerifierCircuitData {
+            verifier_only: VERIFIER_DATA_BY_BLOCK_COUNT[index - 1].clone(),
+            common: prover_data.common.clone(),
+        });
+
+        Self::prove_inner(index, &prover_data, &targets, verifier_data, data)
     }
 
     fn prove_inner(
-        index: usize,
+        _index: usize,
         prover_data: &ProverCircuitData<F, C, D>,
         targets: &[Target],
+        verifier_data: Arc<VerifierCircuitData<F, C, D>>,
         data: &[u8],
     ) -> ProofWithCircuitData<VariativeBlake2Target> {
         let witness = Self::set_witness(targets, data);
@@ -117,15 +212,13 @@ impl VariativeBlake2 {
             now.elapsed().as_millis()
         );
 
-        ProofWithCircuitData {
-            proof,
-            circuit_data: Arc::from(VerifierCircuitData {
-                verifier_only: VERIFIER_DATA_BY_BLOCK_COUNT[index - 1].clone(),
-                common: prover_data.common.clone(),
-            }),
-            public_inputs,
-            public_inputs_parser: PhantomData,
-        }
+        ProofWithCircuitData::from_proof_and_shared_circuit_data(
+            ProofWithPublicInputs {
+                proof,
+                public_inputs,
+            },
+            verifier_data,
+        )
     }
 
     #[allow(dead_code)]

--- a/prover/src/common/mod.rs
+++ b/prover/src/common/mod.rs
@@ -164,6 +164,11 @@ where
         &self.circuit_data
     }
 
+    /// Clone the shared verifier data handle without cloning circuit metadata.
+    pub(crate) fn shared_circuit_data(&self) -> Arc<VerifierCircuitData<F, C, D>> {
+        Arc::clone(&self.circuit_data)
+    }
+
     /// Get type-erased public inouts.
     pub fn public_inputs(&self) -> Vec<GoldilocksField> {
         self.public_inputs.clone()

--- a/prover/src/common/mod.rs
+++ b/prover/src/common/mod.rs
@@ -86,9 +86,20 @@ where
             public_inputs,
         } = circuit_data.prove(witness).unwrap();
 
-        ProofWithCircuitData {
+        // Move the verifier data out of the owned circuit instead of cloning the
+        // (potentially very large) common circuit data.
+        let CircuitData {
+            verifier_only,
+            common,
+            ..
+        } = circuit_data;
+
+        Self {
             proof,
-            circuit_data: Arc::from(circuit_data.verifier_data()),
+            circuit_data: Arc::new(VerifierCircuitData {
+                verifier_only,
+                common,
+            }),
             public_inputs,
             public_inputs_parser: PhantomData,
         }
@@ -99,14 +110,24 @@ where
         circuit_data: &CircuitData<F, C, D>,
         witness: PartialWitness<F>,
     ) -> ProofWithCircuitData<TS> {
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+        Self::prove_from_shared_circuit_data(circuit_data, verifier_data, witness)
+    }
+
+    /// Prove using circuit data and verifier data shared by a cached circuit.
+    pub(crate) fn prove_from_shared_circuit_data(
+        circuit_data: &CircuitData<F, C, D>,
+        verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+        witness: PartialWitness<F>,
+    ) -> ProofWithCircuitData<TS> {
         let ProofWithPublicInputs {
             proof,
             public_inputs,
         } = circuit_data.prove(witness).unwrap();
 
-        ProofWithCircuitData {
+        Self {
             proof,
-            circuit_data: Arc::from(circuit_data.verifier_data()),
+            circuit_data: verifier_data,
             public_inputs,
             public_inputs_parser: PhantomData,
         }
@@ -117,6 +138,14 @@ where
         proof: ProofWithPublicInputs<F, C, D>,
         circuit_data: VerifierCircuitData<F, C, D>,
     ) -> Self {
+        Self::from_proof_and_shared_circuit_data(proof, Arc::new(circuit_data))
+    }
+
+    /// Create a new `ProofWithCircuitData` using shared verifier data.
+    pub(crate) fn from_proof_and_shared_circuit_data(
+        proof: ProofWithPublicInputs<F, C, D>,
+        circuit_data: Arc<VerifierCircuitData<F, C, D>>,
+    ) -> Self {
         let ProofWithPublicInputs {
             proof,
             public_inputs,
@@ -124,7 +153,7 @@ where
 
         Self {
             proof,
-            circuit_data: Arc::from(circuit_data),
+            circuit_data,
             public_inputs,
             public_inputs_parser: PhantomData,
         }
@@ -187,15 +216,18 @@ pub trait CircuitImplBuilder {
 
 pub struct CircuitDataCache<BUILDER: CircuitImplBuilder> {
     circuit_data: CircuitData<F, C, D>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     witness_targets: BUILDER::WitnessTargets,
 }
 
 impl<BUILDER: CircuitImplBuilder> CircuitDataCache<BUILDER> {
     pub fn new() -> CircuitDataCache<BUILDER> {
         let (circuit_data, witness_targets) = BUILDER::build();
+        let verifier_data = Arc::new(circuit_data.verifier_data());
 
         CircuitDataCache {
             circuit_data,
+            verifier_data,
             witness_targets,
         }
     }
@@ -206,7 +238,11 @@ impl<BUILDER: CircuitImplBuilder> CircuitDataCache<BUILDER> {
     ) -> ProofWithCircuitData<BUILDER::PublicInputsTarget> {
         let mut witness = PartialWitness::new();
         impl_builder.set_witness(self.witness_targets.clone(), &mut witness);
-        ProofWithCircuitData::prove_from_circuit_data(&self.circuit_data, witness)
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.circuit_data,
+            Arc::clone(&self.verifier_data),
+            witness,
+        )
     }
 }
 

--- a/prover/src/final_proof/message_sent.rs
+++ b/prover/src/final_proof/message_sent.rs
@@ -5,6 +5,7 @@ use crate::{
     common::{
         array_to_bits,
         blake2::{CircuitTargets as Blake2CircuitTargets, MAX_DATA_BYTES},
+        get_env_variable,
         targets::{
             impl_target_set, ArrayTarget, Blake2Target, Blake2TargetGoldilocks,
             MessageTargetGoldilocks, TargetBitOperations, TargetSet,
@@ -25,10 +26,24 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
 };
 use rayon::{
-    iter::{IntoParallelIterator, ParallelIterator},
-    ThreadPoolBuilder,
+    iter::{IntoParallelRefIterator, ParallelIterator},
+    ThreadPool, ThreadPoolBuilder,
 };
-use std::env;
+
+use std::sync::LazyLock;
+
+fn header_thread_pool() -> &'static ThreadPool {
+    static POOL: LazyLock<ThreadPool> = LazyLock::new(|| {
+        let stack_size = get_env_variable("RUST_MIN_STACK", crate::consts::SIZE_THREAD_STACK_MIN);
+        let thread_count = get_env_variable("HEADER_PROOF_THREADS", 5usize).max(1);
+        ThreadPoolBuilder::new()
+            .stack_size(stack_size)
+            .num_threads(thread_count)
+            .build()
+            .expect("MessageSent: failed to create ThreadPool")
+    });
+    &POOL
+}
 
 impl_target_set! {
     /// Public inputs for `MessageSent`.
@@ -93,38 +108,37 @@ impl MessageSent {
         let finality_proof_target =
             builder.recursively_verify_constant_proof(&finality_proof, &mut witness);
 
-        // prove chain of headers
-        let thread_pool = ThreadPoolBuilder::new()
-            .stack_size(
-                env::var("RUST_MIN_STACK")
-                    .expect("RUST_MIN_STACK should be set")
-                    .parse::<usize>()
-                    .expect("RUST_MIN_STACK should have the correct value"),
-            )
-            // TODO: 782
-            .num_threads(5)
-            .build()
-            .expect("MessageSent: failed to create ThreadPool");
+        // Prove the header chain in bounded chunks. The old implementation
+        // retained every per-header proof and nested a local pool inside the
+        // global Rayon pool. Both behaviors caused large memory spikes on long
+        // chains. Hash one chunk in a single explicit pool, fold it into the
+        // already-proven suffix, then release the chunk before continuing.
+        let chunk_size = get_env_variable("HEADER_PROOF_CHUNK_SIZE", 8usize).max(1);
+        let thread_pool = header_thread_pool();
 
-        let circuit_blake2 = Blake2CircuitTargets::new();
+        let circuit_blake2 = Blake2CircuitTargets::cached();
+        let circuit_chain = HeaderChainCircuit::cached();
         let mut headers = self.headers;
         headers.sort_by_key(|header| header.number);
 
-        let proof_hashes = headers
-            .into_par_iter()
-            .map(|header| {
-                thread_pool
-                    .scope(|_| circuit_blake2.prove::<MAX_DATA_BYTES>(header.encode().as_ref()))
-            })
-            .collect::<Vec<_>>();
+        let mut proof_chain = None;
+        for header_chunk in headers.rchunks(chunk_size) {
+            let proof_hashes = thread_pool.install(|| {
+                header_chunk
+                    .par_iter()
+                    .map(|header| circuit_blake2.prove::<MAX_DATA_BYTES>(header.encode().as_ref()))
+                    .collect::<Vec<_>>()
+            });
 
-        let circuit_chain = HeaderChainCircuit::default();
-        let proof_chain =
-            proof_hashes
-                .into_iter()
-                .rfold(None, |proof_recursive, proof_header_hash| {
+            // rchunks yields newest-to-oldest chunks. Folding each chunk from
+            // newest to oldest preserves the original parent-link direction.
+            proof_chain = proof_hashes.into_iter().rfold(
+                proof_chain,
+                |proof_recursive, proof_header_hash| {
                     Some(circuit_chain.prove(&proof_header_hash, proof_recursive.as_ref()))
-                });
+                },
+            );
+        }
         let proof_chain = proof_chain.expect("Headers is not an empty list");
 
         let target_proof_chain = builder.add_virtual_proof_with_pis(circuit_chain.common());

--- a/prover/src/header_chain.rs
+++ b/prover/src/header_chain.rs
@@ -16,14 +16,17 @@ use plonky2::{
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::{
-            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
-            VerifierOnlyCircuitData,
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget, VerifierOnlyCircuitData,
         },
         proof::ProofWithPublicInputsTarget,
     },
     recursion::dummy_circuit,
 };
-use std::time::Instant;
+use std::{
+    sync::{Arc, LazyLock},
+    time::Instant,
+};
 
 impl_parsable_target_set! {
     pub struct HeaderChainTarget {
@@ -58,12 +61,12 @@ impl BuilderTargets {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let one = builder.one();
 
-        let (circuit, ..) = Blake2CircuitTargets::new().into_inner();
+        let circuit = Blake2CircuitTargets::cached();
 
-        let target_proof_inner = builder.add_virtual_proof_with_pis(&circuit.common);
-        let target_verifier = builder.constant_verifier_data(&circuit.verifier_only);
+        let target_proof_inner = builder.add_virtual_proof_with_pis(circuit.common());
+        let target_verifier = builder.constant_verifier_data(circuit.verifier_only());
 
-        builder.verify_proof::<C>(&target_proof_inner, &target_verifier, &circuit.common);
+        builder.verify_proof::<C>(&target_proof_inner, &target_verifier, circuit.common());
 
         let mut iter_public_inputs = target_proof_inner.public_inputs.iter().copied();
         let GenericBlake2Target {
@@ -146,6 +149,7 @@ impl BuilderTargets {
 
 pub struct CircuitTargets {
     circuit: CircuitData<F, C, D>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     target_verifier_circuit: VerifierCircuitTarget,
     target_proof_inner: ProofWithPublicInputsTarget<D>,
     target_condition: BoolTarget,
@@ -164,6 +168,7 @@ impl From<BuilderTargets> for CircuitTargets {
         let now = Instant::now();
 
         let circuit = value.builder.build::<C>();
+        let verifier_data = Arc::new(circuit.verifier_data());
 
         log::trace!(
             "From<BuilderTargets> for CircuitTargets exit. Time: {}ms",
@@ -172,6 +177,7 @@ impl From<BuilderTargets> for CircuitTargets {
 
         Self {
             circuit,
+            verifier_data,
             target_verifier_circuit: value.target_verifier_circuit,
             target_proof_inner: value.target_proof_inner,
             target_condition: value.target_condition,
@@ -181,6 +187,14 @@ impl From<BuilderTargets> for CircuitTargets {
 }
 
 impl CircuitTargets {
+    /// Return the process-wide header-chain circuit. The circuit shape is
+    /// independent of the headers being proved. The cache assumes one
+    /// deployment circuit configuration per process.
+    pub fn cached() -> &'static Self {
+        static CACHE: LazyLock<CircuitTargets> = LazyLock::new(CircuitTargets::default);
+        &CACHE
+    }
+
     pub fn prove(
         &self,
         proof_inner: &ProofWithCircuitData<GenericBlake2Target>,
@@ -231,7 +245,10 @@ impl CircuitTargets {
             now.elapsed().as_millis()
         );
 
-        ProofWithCircuitData::from_proof_and_circuit_data(proof, self.circuit.verifier_data())
+        ProofWithCircuitData::from_proof_and_shared_circuit_data(
+            proof,
+            Arc::clone(&self.verifier_data),
+        )
     }
 
     pub fn common(&self) -> &CommonCircuitData<F, D> {

--- a/prover/src/storage_inclusion/block_header_parser.rs
+++ b/prover/src/storage_inclusion/block_header_parser.rs
@@ -46,7 +46,7 @@ pub struct BlockHeaderParser {
 
 impl BlockHeaderParser {
     pub fn prove(self) -> ProofWithCircuitData<BlockHeaderParserTarget> {
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof = circuit.prove::<MAX_DATA_BYTES>(&self.header_data);
 
         let config = CircuitConfig::standard_recursion_config();

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -142,6 +142,7 @@ struct CircuitTemplate {
     inner_common_num_gates: usize,
     inner_common_num_public_inputs: usize,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+    inner_common_data: CommonCircuitData<F, D>,
 }
 
 impl CircuitTemplate {
@@ -161,6 +162,14 @@ impl CircuitTemplate {
         assert_eq!(
             template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
             "BranchNodeChain cache received incompatible inner circuit digest"
+        );
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "BranchNodeChain cache received incompatible inner common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "BranchNodeChain cache received incompatible inner verifier data"
         );
         template
     }
@@ -271,6 +280,7 @@ impl CircuitTemplate {
             inner_common_num_gates: inner_data.common.gates.len(),
             inner_common_num_public_inputs: inner_data.common.num_public_inputs,
             inner_verifier_only: inner_data.verifier_only.clone(),
+            inner_common_data: inner_data.common.clone(),
         }
     }
 }

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -71,6 +71,7 @@ struct FinalProjectionTemplate {
     circuit_data: Arc<CircuitData<F, C, D>>,
     verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_common_data: CommonCircuitData<F, D>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
@@ -83,15 +84,18 @@ impl FinalProjectionTemplate {
         // carried by the per-call inner proof witness.
         static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "BranchNodeChain final projection received incompatible common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "BranchNodeChain final projection received incompatible verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "BranchNodeChain final projection received incompatible common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "BranchNodeChain final projection received incompatible verifier data"
+            );
+        }
         template
     }
 
@@ -135,6 +139,7 @@ impl FinalProjectionTemplate {
             circuit_data,
             verifier_data,
             inner_proof_with_pis,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_common_data: inner_data.common.clone(),
             inner_verifier_only: inner_data.verifier_only.clone(),
         }
@@ -217,8 +222,7 @@ struct CircuitTemplate {
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
     condition: BoolTarget,
     verifier_data_target: VerifierCircuitTarget,
-    inner_common_num_gates: usize,
-    inner_common_num_public_inputs: usize,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
     inner_common_data: CommonCircuitData<F, D>,
 }
@@ -227,28 +231,18 @@ impl CircuitTemplate {
     fn cached(inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>) -> &'static Self {
         static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            template.inner_common_num_gates,
-            inner_data.common.gates.len(),
-            "BranchNodeChain cache received incompatible inner circuit gate count"
-        );
-        assert_eq!(
-            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
-            "BranchNodeChain cache received incompatible inner public-input count"
-        );
-        assert_eq!(
-            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
-            "BranchNodeChain cache received incompatible inner circuit digest"
-        );
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "BranchNodeChain cache received incompatible inner common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "BranchNodeChain cache received incompatible inner verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "BranchNodeChain cache received incompatible inner common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "BranchNodeChain cache received incompatible inner verifier data"
+            );
+        }
         template
     }
 
@@ -355,8 +349,7 @@ impl CircuitTemplate {
             inner_cyclic_proof_with_pis,
             condition,
             verifier_data_target,
-            inner_common_num_gates: inner_data.common.gates.len(),
-            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_verifier_only: inner_data.verifier_only.clone(),
             inner_common_data: inner_data.common.clone(),
         }

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -67,26 +67,104 @@ pub struct BranchNodeChain {
     pub nodes: Vec<BranchNodeData>,
 }
 
+struct FinalProjectionTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_common_data: CommonCircuitData<F, D>,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+}
+
+impl FinalProjectionTemplate {
+    fn cached(
+        inner_proof: &ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData>,
+    ) -> &'static Self {
+        // The projection has one fixed inner proof shape; chain contents are
+        // carried by the per-call inner proof witness.
+        static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "BranchNodeChain final projection received incompatible common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "BranchNodeChain final projection received incompatible verifier data"
+        );
+        template
+    }
+
+    fn instantiate(
+        &self,
+        inner_proof: &ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData>,
+    ) -> FinalProjectionCircuit<'_> {
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        FinalProjectionCircuit {
+            template: self,
+            witness,
+        }
+    }
+
+    fn build(
+        inner_proof: &ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData>,
+    ) -> Self {
+        log::debug!("Building branch node chain final projection template...");
+
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(&inner_proof_with_pis, &inner_verifier, &inner_data.common);
+        let inner_target = BranchNodeChainParserTargetWithVerifierData::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        BranchNodeChainParserTarget {
+            root_hash: inner_target.inner.root_hash,
+            leaf_hash: inner_target.inner.leaf_hash,
+            partial_address: inner_target.inner.partial_address,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            inner_proof_with_pis,
+            inner_common_data: inner_data.common.clone(),
+            inner_verifier_only: inner_data.verifier_only.clone(),
+        }
+    }
+}
+
+struct FinalProjectionCircuit<'a> {
+    template: &'a FinalProjectionTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl FinalProjectionCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<BranchNodeChainParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
 impl BranchNodeChain {
     pub fn prove(self) -> ProofWithCircuitData<BranchNodeChainParserTarget> {
         log::debug!("Proving branch node chain...");
 
         let inner = self.inner_proof();
 
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut witness = PartialWitness::new();
-
-        let public_inputs = builder.recursively_verify_constant_proof(&inner, &mut witness);
-
-        BranchNodeChainParserTarget {
-            root_hash: public_inputs.inner.root_hash,
-            leaf_hash: public_inputs.inner.leaf_hash,
-            partial_address: public_inputs.inner.partial_address,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        let result = ProofWithCircuitData::prove_from_builder(builder, witness);
+        let result = FinalProjectionTemplate::cached(&inner)
+            .instantiate(&inner)
+            .prove();
 
         log::debug!("Proven branch node chain");
 

--- a/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/branch_node_chain.rs
@@ -7,17 +7,25 @@ use plonky2::{
     },
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, CircuitData, CommonCircuitData},
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget, VerifierOnlyCircuitData,
+        },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
     recursion::dummy_circuit::cyclic_base_proof,
 };
 use plonky2_field::types::Field;
 use sp_core::{Blake2Hasher, Hasher};
-use std::iter;
+use std::{
+    iter,
+    sync::{Arc, OnceLock},
+};
 
 use super::{
-    hashed_branch_parser::HashedBranchParser, storage_address::StorageAddressTarget, BranchNodeData,
+    hashed_branch_parser::{HashedBranchParser, HashedBranchParserTarget},
+    storage_address::StorageAddressTarget,
+    BranchNodeData,
 };
 use crate::{
     common::{
@@ -108,7 +116,8 @@ impl BranchNodeChain {
                 },
             };
 
-            let circuit = Circuit::build(inner_circuit);
+            let inner_proof = inner_circuit.prove();
+            let circuit = CircuitTemplate::cached(&inner_proof).instantiate(&inner_proof);
 
             let new_proof = if let Some(composed_proof) = composed_proof {
                 circuit.prove_recursive(composed_proof.proof())
@@ -122,76 +131,71 @@ impl BranchNodeChain {
     }
 }
 
-struct Circuit {
-    cyclic_circuit_data: CircuitData<F, C, D>,
-
-    common_data: CommonCircuitData<F, D>,
-
-    condition: BoolTarget,
+struct CircuitTemplate {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
-
-    witness: PartialWitness<F>,
+    condition: BoolTarget,
+    verifier_data_target: VerifierCircuitTarget,
+    inner_common_num_gates: usize,
+    inner_common_num_public_inputs: usize,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
 
-impl Circuit {
-    fn prove_initial(
-        mut self,
-        root_hash: [u8; BLAKE2_DIGEST_SIZE],
-    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
-        log::debug!("    Proving storage trie recursion layer(initial)...");
-
-        let root_hash_bits = array_to_bits(&root_hash);
-        let public_inputs = root_hash_bits
-            .into_iter()
-            .map(F::from_bool)
-            .enumerate()
-            .collect();
-
-        self.witness.set_bool_target(self.condition, false);
-        self.witness.set_proof_with_pis_target::<C, D>(
-            &self.inner_cyclic_proof_with_pis,
-            &cyclic_base_proof(
-                &self.common_data,
-                &self.cyclic_circuit_data.verifier_only,
-                public_inputs,
-            ),
+impl CircuitTemplate {
+    fn cached(inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>) -> &'static Self {
+        static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            template.inner_common_num_gates,
+            inner_data.common.gates.len(),
+            "BranchNodeChain cache received incompatible inner circuit gate count"
         );
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven storage trie recursion layer(initial)...");
-
-        result
+        assert_eq!(
+            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
+            "BranchNodeChain cache received incompatible inner public-input count"
+        );
+        assert_eq!(
+            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
+            "BranchNodeChain cache received incompatible inner circuit digest"
+        );
+        template
     }
 
-    fn prove_recursive(
-        mut self,
-        composed_proof: ProofWithPublicInputs<F, C, D>,
-    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
-        log::debug!("    Proving storage trie recursion layer...");
-        self.witness.set_bool_target(self.condition, true);
-        self.witness
-            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven storage trie recursion layer");
-
-        result
+    fn instantiate<'a>(
+        &'a self,
+        inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>,
+    ) -> Circuit<'a> {
+        let mut witness = PartialWitness::new();
+        witness.set_verifier_data_target(
+            &self.verifier_data_target,
+            &self.cyclic_circuit_data.verifier_only,
+        );
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        Circuit {
+            template: self,
+            witness,
+        }
     }
 
-    fn build(inner: HashedBranchParser) -> Circuit {
-        let inner_proof = inner.prove();
+    fn build(inner_proof: &ProofWithCircuitData<HashedBranchParserTarget>) -> Self {
+        log::debug!("    Building storage trie recursion template...");
 
-        log::debug!("    Building storage trie recursion layer...");
-
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut pw = PartialWitness::new();
-
-        let inner_proof_pis = builder.recursively_verify_constant_proof(&inner_proof, &mut pw);
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier_data = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(
+            &inner_proof_with_pis,
+            &inner_verifier_data,
+            &inner_data.common,
+        );
+        let inner_proof_pis = HashedBranchParserTarget::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         let mut virtual_targets = iter::repeat(()).map(|_| builder.add_virtual_target());
         let future_inner_cyclic_proof_pis =
@@ -251,18 +255,83 @@ impl Circuit {
             )
             .expect("Failed to build circuit");
 
-        let cyclic_circuit_data = builder.build::<C>();
+        let cyclic_circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(cyclic_circuit_data.verifier_data());
 
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        log::debug!("    Built storage trie recursion template");
 
-        log::debug!("    Built storage parser recursion layer");
-
-        Circuit {
+        Self {
             cyclic_circuit_data,
-            common_data,
-            condition,
+            verifier_data,
+            common_data: Arc::new(common_data),
+            inner_proof_with_pis,
             inner_cyclic_proof_with_pis,
-            witness: pw,
+            condition,
+            verifier_data_target,
+            inner_common_num_gates: inner_data.common.gates.len(),
+            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_only: inner_data.verifier_only.clone(),
         }
+    }
+}
+
+struct Circuit<'a> {
+    template: &'a CircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl Circuit<'_> {
+    fn prove_initial(
+        mut self,
+        root_hash: [u8; BLAKE2_DIGEST_SIZE],
+    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
+        log::debug!("    Proving storage trie recursion layer(initial)...");
+
+        let root_hash_bits = array_to_bits(&root_hash);
+        let public_inputs = root_hash_bits
+            .into_iter()
+            .map(F::from_bool)
+            .enumerate()
+            .collect();
+
+        self.witness.set_bool_target(self.template.condition, false);
+        self.witness.set_proof_with_pis_target::<C, D>(
+            &self.template.inner_cyclic_proof_with_pis,
+            &cyclic_base_proof(
+                &self.template.common_data,
+                &self.template.cyclic_circuit_data.verifier_only,
+                public_inputs,
+            ),
+        );
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven storage trie recursion layer(initial)...");
+
+        result
+    }
+
+    fn prove_recursive(
+        mut self,
+        composed_proof: ProofWithPublicInputs<F, C, D>,
+    ) -> ProofWithCircuitData<BranchNodeChainParserTargetWithVerifierData> {
+        log::debug!("    Proving storage trie recursion layer...");
+        self.witness.set_bool_target(self.template.condition, true);
+        self.witness
+            .set_proof_with_pis_target(&self.template.inner_cyclic_proof_with_pis, &composed_proof);
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven storage trie recursion layer");
+
+        result
     }
 }

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
@@ -44,7 +44,7 @@ impl HashedBranchParser {
         const MAX_DATA_LENGTH_ESTIMATION: usize =
             MAX_BRANCH_NODE_DATA_LENGTH_IN_BLOCKS * NODE_DATA_BLOCK_BYTES;
 
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof =
             circuit.prove::<MAX_DATA_LENGTH_ESTIMATION>(&self.branch_parser.node_data);
         let branch_parser_proof = self.branch_parser.prove();

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
@@ -1,15 +1,23 @@
 //! Circuit that's used to prove correct parsing of branch node.
 
 use plonky2::{
-    iop::witness::PartialWitness,
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    iop::witness::{PartialWitness, WitnessWrite},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierOnlyCircuitData,
+        },
+        proof::ProofWithPublicInputsTarget,
+    },
 };
+use std::sync::{Arc, OnceLock};
 
 use crate::{
     common::{
-        blake2::CircuitTargets as Blake2CircuitTargets,
+        blake2::{CircuitTargets as Blake2CircuitTargets, GenericBlake2Target},
         targets::{impl_parsable_target_set, Blake2Target, TargetSet},
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     prelude::*,
     storage_inclusion::storage_trie_proof::node_parser::{
@@ -17,7 +25,10 @@ use crate::{
     },
 };
 
-use super::{node_parser::branch_parser::BranchParser, storage_address::StorageAddressTarget};
+use super::{
+    node_parser::branch_parser::{BranchParser, BranchParserTarget},
+    storage_address::StorageAddressTarget,
+};
 
 impl_parsable_target_set! {
     /// Public inputs for `HashedBranchParser`.
@@ -39,6 +50,151 @@ pub struct HashedBranchParser {
     pub branch_parser: BranchParser,
 }
 
+struct HashedBranchParserCircuitTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    hasher_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    branch_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    hasher_common_data: CommonCircuitData<F, D>,
+    hasher_verifier_only: VerifierOnlyCircuitData<C, D>,
+    branch_common_data: CommonCircuitData<F, D>,
+    branch_verifier_only: VerifierOnlyCircuitData<C, D>,
+}
+
+impl HashedBranchParserCircuitTemplate {
+    fn cached(
+        hasher_proof: &ProofWithCircuitData<GenericBlake2Target>,
+        branch_proof: &ProofWithCircuitData<BranchParserTarget>,
+    ) -> &'static Self {
+        // Both inner proof shapes are fixed by the deployment circuit config;
+        // node contents remain per-call witnesses.
+        static CACHE: OnceLock<HashedBranchParserCircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(hasher_proof, branch_proof));
+        let hasher_data = hasher_proof.circuit_data();
+        let branch_data = branch_proof.circuit_data();
+        assert_eq!(
+            &template.hasher_common_data, &hasher_data.common,
+            "HashedBranchParser cache received incompatible hasher common data"
+        );
+        assert_eq!(
+            &template.hasher_verifier_only, &hasher_data.verifier_only,
+            "HashedBranchParser cache received incompatible hasher verifier data"
+        );
+        assert_eq!(
+            &template.branch_common_data, &branch_data.common,
+            "HashedBranchParser cache received incompatible branch common data"
+        );
+        assert_eq!(
+            &template.branch_verifier_only, &branch_data.verifier_only,
+            "HashedBranchParser cache received incompatible branch verifier data"
+        );
+        template
+    }
+
+    fn instantiate(
+        &self,
+        hasher_proof: &ProofWithCircuitData<GenericBlake2Target>,
+        branch_proof: &ProofWithCircuitData<BranchParserTarget>,
+    ) -> HashedBranchParserCircuit<'_> {
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.hasher_proof_with_pis, &hasher_proof.proof());
+        witness.set_proof_with_pis_target(&self.branch_proof_with_pis, &branch_proof.proof());
+        HashedBranchParserCircuit {
+            template: self,
+            witness,
+        }
+    }
+
+    fn build(
+        hasher_proof: &ProofWithCircuitData<GenericBlake2Target>,
+        branch_proof: &ProofWithCircuitData<BranchParserTarget>,
+    ) -> Self {
+        log::debug!("Building hashed branch parser circuit template...");
+
+        let hasher_data = hasher_proof.circuit_data();
+        let branch_data = branch_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+
+        let hasher_proof_with_pis = builder.add_virtual_proof_with_pis(&hasher_data.common);
+        let hasher_verifier = builder.constant_verifier_data(&hasher_data.verifier_only);
+        builder.verify_proof::<C>(
+            &hasher_proof_with_pis,
+            &hasher_verifier,
+            &hasher_data.common,
+        );
+        let hasher_target = GenericBlake2Target::parse_exact(
+            &mut hasher_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        let branch_proof_with_pis = builder.add_virtual_proof_with_pis(&branch_data.common);
+        let branch_verifier = builder.constant_verifier_data(&branch_data.verifier_only);
+        builder.verify_proof::<C>(
+            &branch_proof_with_pis,
+            &branch_verifier,
+            &branch_data.common,
+        );
+        let branch_target = BranchParserTarget::parse_exact(
+            &mut branch_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        hasher_target
+            .length
+            .connect(&branch_target.node_data_length, &mut builder);
+
+        let mut branch_parser_node_data = branch_target.padded_node_data.into_targets_iter();
+        let mut hasher_node_data = hasher_target.data.into_targets_iter();
+        loop {
+            let branch_parser_byte = branch_parser_node_data.next();
+            let hasher_byte = hasher_node_data.next();
+
+            match (branch_parser_byte, hasher_byte) {
+                (Some(a), Some(b)) => builder.connect(a, b),
+                (Some(_), None) => {
+                    panic!("Generic blake2 hasher circuit have insifficient maximum data length")
+                }
+                _ => break,
+            }
+        }
+
+        HashedBranchParserTarget {
+            node_hash: hasher_target.hash,
+            child_node_hash: branch_target.child_node_hash,
+            partial_address: branch_target.partial_address,
+            resulting_partial_address: branch_target.resulting_partial_address,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            hasher_proof_with_pis,
+            branch_proof_with_pis,
+            hasher_common_data: hasher_data.common.clone(),
+            hasher_verifier_only: hasher_data.verifier_only.clone(),
+            branch_common_data: branch_data.common.clone(),
+            branch_verifier_only: branch_data.verifier_only.clone(),
+        }
+    }
+}
+
+struct HashedBranchParserCircuit<'a> {
+    template: &'a HashedBranchParserCircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl HashedBranchParserCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<HashedBranchParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
 impl HashedBranchParser {
     pub fn prove(self) -> ProofWithCircuitData<HashedBranchParserTarget> {
         const MAX_DATA_LENGTH_ESTIMATION: usize =
@@ -50,45 +206,11 @@ impl HashedBranchParser {
         let branch_parser_proof = self.branch_parser.prove();
 
         log::debug!("Composing hasher proof and branch parser proof...");
-
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut witness = PartialWitness::new();
-
-        let hasher_target = builder.recursively_verify_constant_proof(&hasher_proof, &mut witness);
-        let branch_parser_target =
-            builder.recursively_verify_constant_proof(&branch_parser_proof, &mut witness);
-
-        hasher_target
-            .length
-            .connect(&branch_parser_target.node_data_length, &mut builder);
-
-        let mut branch_parser_node_data = branch_parser_target.padded_node_data.into_targets_iter();
-        let mut hasher_node_data = hasher_target.data.into_targets_iter();
-        loop {
-            let branch_parser_byte = branch_parser_node_data.next();
-            let hasher_byte = hasher_node_data.next();
-
-            match (branch_parser_byte, hasher_byte) {
-                (Some(a), Some(b)) => {
-                    builder.connect(a, b);
-                }
-                (Some(_), None) => {
-                    panic!("Generic blake2 hasher circuit have insifficient maximum data length");
-                }
-                _ => break,
-            }
-        }
-
-        HashedBranchParserTarget {
-            node_hash: hasher_target.hash,
-            child_node_hash: branch_parser_target.child_node_hash,
-            partial_address: branch_parser_target.partial_address,
-            resulting_partial_address: branch_parser_target.resulting_partial_address,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        let result = ProofWithCircuitData::prove_from_builder(builder, witness);
+        let template =
+            HashedBranchParserCircuitTemplate::cached(&hasher_proof, &branch_parser_proof);
+        let result = template
+            .instantiate(&hasher_proof, &branch_parser_proof)
+            .prove();
 
         log::debug!("Composed hasher proof and branch parser proof");
 

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_branch_parser.rs
@@ -55,8 +55,10 @@ struct HashedBranchParserCircuitTemplate {
     verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     hasher_proof_with_pis: ProofWithPublicInputsTarget<D>,
     branch_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    hasher_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     hasher_common_data: CommonCircuitData<F, D>,
     hasher_verifier_only: VerifierOnlyCircuitData<C, D>,
+    branch_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     branch_common_data: CommonCircuitData<F, D>,
     branch_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
@@ -70,24 +72,30 @@ impl HashedBranchParserCircuitTemplate {
         // node contents remain per-call witnesses.
         static CACHE: OnceLock<HashedBranchParserCircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(hasher_proof, branch_proof));
-        let hasher_data = hasher_proof.circuit_data();
-        let branch_data = branch_proof.circuit_data();
-        assert_eq!(
-            &template.hasher_common_data, &hasher_data.common,
-            "HashedBranchParser cache received incompatible hasher common data"
-        );
-        assert_eq!(
-            &template.hasher_verifier_only, &hasher_data.verifier_only,
-            "HashedBranchParser cache received incompatible hasher verifier data"
-        );
-        assert_eq!(
-            &template.branch_common_data, &branch_data.common,
-            "HashedBranchParser cache received incompatible branch common data"
-        );
-        assert_eq!(
-            &template.branch_verifier_only, &branch_data.verifier_only,
-            "HashedBranchParser cache received incompatible branch verifier data"
-        );
+        let hasher_verifier_data = hasher_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.hasher_verifier_data, &hasher_verifier_data) {
+            let hasher_data = hasher_verifier_data.as_ref();
+            assert_eq!(
+                &template.hasher_common_data, &hasher_data.common,
+                "HashedBranchParser cache received incompatible hasher common data"
+            );
+            assert_eq!(
+                &template.hasher_verifier_only, &hasher_data.verifier_only,
+                "HashedBranchParser cache received incompatible hasher verifier data"
+            );
+        }
+        let branch_verifier_data = branch_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.branch_verifier_data, &branch_verifier_data) {
+            let branch_data = branch_verifier_data.as_ref();
+            assert_eq!(
+                &template.branch_common_data, &branch_data.common,
+                "HashedBranchParser cache received incompatible branch common data"
+            );
+            assert_eq!(
+                &template.branch_verifier_only, &branch_data.verifier_only,
+                "HashedBranchParser cache received incompatible branch verifier data"
+            );
+        }
         template
     }
 
@@ -172,8 +180,10 @@ impl HashedBranchParserCircuitTemplate {
             verifier_data,
             hasher_proof_with_pis,
             branch_proof_with_pis,
+            hasher_verifier_data: hasher_proof.shared_circuit_data(),
             hasher_common_data: hasher_data.common.clone(),
             hasher_verifier_only: hasher_data.verifier_only.clone(),
+            branch_verifier_data: branch_proof.shared_circuit_data(),
             branch_common_data: branch_data.common.clone(),
             branch_verifier_only: branch_data.verifier_only.clone(),
         }

--- a/prover/src/storage_inclusion/storage_trie_proof/hashed_leaf_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/hashed_leaf_parser.rs
@@ -44,7 +44,7 @@ impl HashedLeafParser {
         const MAX_DATA_LENGTH_ESTIMATION: usize =
             MAX_LEAF_NODE_DATA_LENGTH_IN_BLOCKS * NODE_DATA_BLOCK_BYTES;
 
-        let circuit = Blake2CircuitTargets::new();
+        let circuit = Blake2CircuitTargets::cached();
         let hasher_proof = circuit.prove::<MAX_DATA_LENGTH_ESTIMATION>(&self.leaf_parser.node_data);
         let leaf_parser_proof = self.leaf_parser.prove();
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/child_node_parser.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/child_node_parser.rs
@@ -5,14 +5,17 @@ use plonky2::{
         target::{BoolTarget, Target},
         witness::{PartialWitness, WitnessWrite},
     },
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData},
+    },
 };
 use plonky2_field::types::Field;
 
 use crate::{
     common::{
         targets::{impl_parsable_target_set, ArrayTarget, Blake2Target, TargetSet},
-        ProofWithCircuitData,
+        CircuitDataCache, CircuitImplBuilder, ProofWithCircuitData,
     },
     prelude::{
         consts::{BLAKE2_DIGEST_SIZE, BLAKE2_DIGEST_SIZE_IN_BITS},
@@ -60,24 +63,31 @@ impl ChildNodeParser {
     pub fn prove(self) -> ProofWithCircuitData<ChildNodeParserTarget> {
         log::debug!("Proving child node parser...");
 
+        static CACHE: std::sync::OnceLock<CircuitDataCache<ChildNodeParser>> =
+            std::sync::OnceLock::new();
+        let data = CACHE.get_or_init(CircuitDataCache::new).prove(self);
+
+        log::debug!("Proven child node parser");
+
+        data
+    }
+}
+
+impl CircuitImplBuilder for ChildNodeParser {
+    type WitnessTargets = ChildNodeParserWitnessTargets;
+    type PublicInputsTarget = ChildNodeParserTarget;
+
+    fn build() -> (CircuitData<F, C, D>, Self::WitnessTargets) {
         let mut config = CircuitConfig::standard_recursion_config();
         config.num_wires = 160;
         config.num_routed_wires = 130;
 
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let mut pw = PartialWitness::new();
 
         let node_data = BranchNodeDataPaddedTarget::add_virtual_unsafe(&mut builder);
-        node_data.set_witness(&self.node_data, &mut pw);
-
         let read_offset = builder.add_virtual_target();
-        pw.set_target(read_offset, F::from_canonical_usize(self.read_offset));
-
         let assert_child_hash = builder.add_virtual_bool_target_unsafe();
-        pw.set_bool_target(assert_child_hash, self.assert_child_hash);
-
         let claimed_child_hash = Blake2Target::add_virtual_unsafe(&mut builder);
-        claimed_child_hash.set_witness(&self.claimed_child_hash, &mut pw);
 
         // Read only one byte as we don't support compact integers in other modes than single-byte.
         let encoded_length_size = builder.one();
@@ -126,20 +136,43 @@ impl ChildNodeParser {
         ]);
 
         ChildNodeParserTarget {
-            node_data,
+            node_data: node_data.clone(),
             read_offset,
             resulting_read_offset,
             assert_child_hash,
-            claimed_child_hash,
+            claimed_child_hash: claimed_child_hash.clone(),
         }
         .register_as_public_inputs(&mut builder);
 
-        let data = ProofWithCircuitData::prove_from_builder(builder, pw);
+        let witness_targets = ChildNodeParserWitnessTargets {
+            node_data: node_data.clone(),
+            read_offset,
+            assert_child_hash,
+            claimed_child_hash: claimed_child_hash.clone(),
+        };
 
-        log::debug!("Proven child node parser");
-
-        data
+        (builder.build::<C>(), witness_targets)
     }
+
+    fn set_witness(&self, targets: Self::WitnessTargets, witness: &mut PartialWitness<F>) {
+        targets.node_data.set_witness(&self.node_data, witness);
+        witness.set_target(
+            targets.read_offset,
+            F::from_canonical_usize(self.read_offset),
+        );
+        witness.set_bool_target(targets.assert_child_hash, self.assert_child_hash);
+        targets
+            .claimed_child_hash
+            .set_witness(&self.claimed_child_hash, witness);
+    }
+}
+
+#[derive(Clone)]
+pub struct ChildNodeParserWitnessTargets {
+    node_data: BranchNodeDataPaddedTarget,
+    read_offset: Target,
+    assert_child_hash: BoolTarget,
+    claimed_child_hash: Blake2Target,
 }
 
 #[cfg(test)]

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -176,6 +176,7 @@ struct CircuitTemplate {
     inner_common_num_gates: usize,
     inner_common_num_public_inputs: usize,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+    inner_common_data: CommonCircuitData<F, D>,
 }
 
 impl CircuitTemplate {
@@ -195,6 +196,14 @@ impl CircuitTemplate {
         assert_eq!(
             template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
             "ChildNodeArrayParser cache received incompatible inner circuit digest"
+        );
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "ChildNodeArrayParser cache received incompatible inner common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "ChildNodeArrayParser cache received incompatible inner verifier data"
         );
         template
     }
@@ -321,6 +330,7 @@ impl CircuitTemplate {
             inner_common_num_gates: inner_data.common.gates.len(),
             inner_common_num_public_inputs: inner_data.common.num_public_inputs,
             inner_verifier_only: inner_data.verifier_only.clone(),
+            inner_common_data: inner_data.common.clone(),
         }
     }
 }

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -7,14 +7,17 @@ use plonky2::{
     },
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, CircuitData, CommonCircuitData},
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
+            VerifierOnlyCircuitData,
+        },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
     recursion::dummy_circuit::cyclic_base_proof,
 };
 use plonky2_field::types::Field;
 
-use self::child_node_parser::ChildNodeParser;
+use self::child_node_parser::{ChildNodeParser, ChildNodeParserTarget};
 use crate::{
     common::{
         array_to_bits, common_data_for_recursion,
@@ -29,7 +32,10 @@ use crate::{
         BranchNodeDataPaddedTarget, MAX_BRANCH_NODE_DATA_LENGTH_IN_BLOCKS, NODE_DATA_BLOCK_BYTES,
     },
 };
-use std::iter;
+use std::{
+    iter,
+    sync::{Arc, OnceLock},
+};
 
 mod child_node_parser;
 
@@ -121,7 +127,8 @@ impl ChildNodeArrayParser {
                 claimed_child_hash,
             };
 
-            let circuit = Circuit::build(inner_circuit);
+            let inner_proof = inner_circuit.prove();
+            let circuit = CircuitTemplate::cached(&inner_proof).instantiate(&inner_proof);
 
             cyclic_proof = Some(if let Some(cyclic_proof) = cyclic_proof {
                 circuit.prove_recursive(cyclic_proof.proof())
@@ -158,94 +165,72 @@ impl_target_set! {
     }
 }
 
-struct Circuit {
-    cyclic_circuit_data: CircuitData<F, C, D>,
-
-    common_data: CommonCircuitData<F, D>,
-
-    condition: BoolTarget,
+struct CircuitTemplate {
+    cyclic_circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<plonky2::plonk::circuit_data::VerifierCircuitData<F, C, D>>,
+    common_data: Arc<CommonCircuitData<F, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
-
-    witness: PartialWitness<F>,
+    condition: BoolTarget,
+    verifier_data_target: VerifierCircuitTarget,
+    inner_common_num_gates: usize,
+    inner_common_num_public_inputs: usize,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
 
-impl Circuit {
-    fn prove_initial(
-        mut self,
-        initial_data: InitialData,
-    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
-        log::debug!("    Proving child node parser recursion layer(initial)...");
-
-        let public_inputs = initial_data
-            .node_data
-            .into_iter()
-            .flatten()
-            .map(|byte| byte as usize)
-            .chain(iter::once(initial_data.read_offset))
-            .chain(iter::once(0))
-            .chain(iter::once(0))
-            .chain(iter::once(initial_data.claimed_child_index_in_array))
-            .chain(
-                array_to_bits(&initial_data.claimed_child_hash)
-                    .into_iter()
-                    .map(|bit| bit as usize),
-            )
-            .map(F::from_canonical_usize);
-
-        // Length check.
-        CyclicRecursionTarget::parse_public_inputs_exact(&mut public_inputs.clone());
-
-        let public_inputs = public_inputs.enumerate().collect();
-
-        self.witness.set_bool_target(self.condition, false);
-        self.witness.set_proof_with_pis_target::<C, D>(
-            &self.inner_cyclic_proof_with_pis,
-            &cyclic_base_proof(
-                &self.common_data,
-                &self.cyclic_circuit_data.verifier_only,
-                public_inputs,
-            ),
+impl CircuitTemplate {
+    fn cached(inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>) -> &'static Self {
+        static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            template.inner_common_num_gates,
+            inner_data.common.gates.len(),
+            "ChildNodeArrayParser cache received incompatible inner circuit gate count"
         );
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven child node parser recursion layer(initial)...");
-
-        result
+        assert_eq!(
+            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
+            "ChildNodeArrayParser cache received incompatible inner public-input count"
+        );
+        assert_eq!(
+            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
+            "ChildNodeArrayParser cache received incompatible inner circuit digest"
+        );
+        template
     }
 
-    fn prove_recursive(
-        mut self,
-        composed_proof: ProofWithPublicInputs<F, C, D>,
-    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
-        log::debug!("    Proving child node parser recursion layer...");
-        self.witness.set_bool_target(self.condition, true);
-        self.witness
-            .set_proof_with_pis_target(&self.inner_cyclic_proof_with_pis, &composed_proof);
-
-        let result =
-            ProofWithCircuitData::prove_from_circuit_data(&self.cyclic_circuit_data, self.witness);
-
-        log::debug!("    Proven child node parser recursion layer");
-
-        result
+    fn instantiate<'a>(
+        &'a self,
+        inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>,
+    ) -> Circuit<'a> {
+        let mut witness = PartialWitness::new();
+        witness.set_verifier_data_target(
+            &self.verifier_data_target,
+            &self.cyclic_circuit_data.verifier_only,
+        );
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        Circuit {
+            template: self,
+            witness,
+        }
     }
 
-    fn build(inner_circuit: ChildNodeParser) -> Circuit {
-        log::debug!("    Proving child node correctness...");
+    fn build(inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>) -> Self {
+        log::debug!("    Building child node parser recursion template...");
 
-        let inner_proof = inner_circuit.prove();
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
 
-        log::debug!("    Proven child node correctness");
-
-        log::debug!("    Building child node parser recursion layer...");
-
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
-        let mut pw = PartialWitness::new();
-
-        let inner_proof_pis = builder.recursively_verify_constant_proof(&inner_proof, &mut pw);
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier_data = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(
+            &inner_proof_with_pis,
+            &inner_verifier_data,
+            &inner_data.common,
+        );
+        let inner_proof_pis = ChildNodeParserTarget::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         let mut virtual_targets = iter::repeat(()).map(|_| builder.add_virtual_target());
         let future_inner_cyclic_proof_pis = CyclicRecursionTarget::parse(&mut virtual_targets);
@@ -320,19 +305,96 @@ impl Circuit {
             )
             .expect("Failed to build circuit");
 
-        let cyclic_circuit_data = builder.build::<C>();
+        let cyclic_circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(cyclic_circuit_data.verifier_data());
 
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        log::debug!("    Built child node parser recursion template");
 
-        log::debug!("    Built child node parser recursion layer");
-
-        Circuit {
+        Self {
             cyclic_circuit_data,
-            common_data,
-            condition,
+            verifier_data,
+            common_data: Arc::new(common_data),
+            inner_proof_with_pis,
             inner_cyclic_proof_with_pis,
-            witness: pw,
+            condition,
+            verifier_data_target,
+            inner_common_num_gates: inner_data.common.gates.len(),
+            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_only: inner_data.verifier_only.clone(),
         }
+    }
+}
+
+struct Circuit<'a> {
+    template: &'a CircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl Circuit<'_> {
+    fn prove_initial(
+        mut self,
+        initial_data: InitialData,
+    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
+        log::debug!("    Proving child node parser recursion layer(initial)...");
+
+        let public_inputs = initial_data
+            .node_data
+            .into_iter()
+            .flatten()
+            .map(|byte| byte as usize)
+            .chain(iter::once(initial_data.read_offset))
+            .chain(iter::once(0))
+            .chain(iter::once(0))
+            .chain(iter::once(initial_data.claimed_child_index_in_array))
+            .chain(
+                array_to_bits(&initial_data.claimed_child_hash)
+                    .into_iter()
+                    .map(|bit| bit as usize),
+            )
+            .map(F::from_canonical_usize);
+
+        CyclicRecursionTarget::parse_public_inputs_exact(&mut public_inputs.clone());
+        let public_inputs = public_inputs.enumerate().collect();
+
+        self.witness.set_bool_target(self.template.condition, false);
+        self.witness.set_proof_with_pis_target::<C, D>(
+            &self.template.inner_cyclic_proof_with_pis,
+            &cyclic_base_proof(
+                &self.template.common_data,
+                &self.template.cyclic_circuit_data.verifier_only,
+                public_inputs,
+            ),
+        );
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven child node parser recursion layer(initial)...");
+
+        result
+    }
+
+    fn prove_recursive(
+        mut self,
+        composed_proof: ProofWithPublicInputs<F, C, D>,
+    ) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {
+        log::debug!("    Proving child node parser recursion layer...");
+        self.witness.set_bool_target(self.template.condition, true);
+        self.witness
+            .set_proof_with_pis_target(&self.template.inner_cyclic_proof_with_pis, &composed_proof);
+
+        let result = ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.cyclic_circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        );
+
+        log::debug!("    Proven child node parser recursion layer");
+
+        result
     }
 }
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -8,8 +8,8 @@ use plonky2::{
     plonk::{
         circuit_builder::CircuitBuilder,
         circuit_data::{
-            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
-            VerifierOnlyCircuitData,
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierCircuitTarget, VerifierOnlyCircuitData,
         },
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
@@ -25,7 +25,7 @@ use crate::{
             impl_parsable_target_set, impl_target_set, Blake2Target, ParsableTargetSet, TargetSet,
             VerifierDataTarget,
         },
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     prelude::{consts::BLAKE2_DIGEST_SIZE, *},
     storage_inclusion::storage_trie_proof::node_parser::{
@@ -79,27 +79,102 @@ pub struct ChildNodeArrayParser {
     pub children_lengths: Vec<usize>,
 }
 
-impl ChildNodeArrayParser {
-    pub fn prove(self) -> ProofWithCircuitData<ChildNodeArrayParserTarget> {
-        let inner_proof = self.inner_proof();
+struct FinalProjectionTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_common_data: CommonCircuitData<F, D>,
+    inner_verifier_only: VerifierOnlyCircuitData<C, D>,
+}
 
-        let config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::new(config);
+impl FinalProjectionTemplate {
+    fn cached(
+        inner_proof: &ProofWithCircuitData<CyclicRecursionTargetWithVerifierData>,
+    ) -> &'static Self {
+        // The projection has one fixed inner proof shape; child contents are
+        // carried by the per-call inner proof witness.
+        static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(inner_proof));
+        let inner_data = inner_proof.circuit_data();
+        assert_eq!(
+            &template.inner_common_data, &inner_data.common,
+            "ChildNodeArrayParser final projection received incompatible common data"
+        );
+        assert_eq!(
+            &template.inner_verifier_only, &inner_data.verifier_only,
+            "ChildNodeArrayParser final projection received incompatible verifier data"
+        );
+        template
+    }
+
+    fn instantiate(
+        &self,
+        inner_proof: &ProofWithCircuitData<CyclicRecursionTargetWithVerifierData>,
+    ) -> FinalProjectionCircuit<'_> {
         let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.inner_proof_with_pis, &inner_proof.proof());
+        FinalProjectionCircuit {
+            template: self,
+            witness,
+        }
+    }
 
-        let inner_proof_pis = builder.recursively_verify_constant_proof(&inner_proof, &mut witness);
+    fn build(inner_proof: &ProofWithCircuitData<CyclicRecursionTargetWithVerifierData>) -> Self {
+        log::debug!("Building child node array parser final projection template...");
+
+        let inner_data = inner_proof.circuit_data();
+        let mut builder = CircuitBuilder::new(CircuitConfig::standard_recursion_config());
+        let inner_proof_with_pis = builder.add_virtual_proof_with_pis(&inner_data.common);
+        let inner_verifier = builder.constant_verifier_data(&inner_data.verifier_only);
+        builder.verify_proof::<C>(&inner_proof_with_pis, &inner_verifier, &inner_data.common);
+        let inner_target = CyclicRecursionTargetWithVerifierData::parse_exact(
+            &mut inner_proof_with_pis.public_inputs.clone().into_iter(),
+        );
 
         ChildNodeArrayParserTarget {
-            node_data: inner_proof_pis.inner.node_data,
-            initial_read_offset: inner_proof_pis.inner.initial_read_offset,
-            final_read_offset: inner_proof_pis.inner.read_offset,
-            overall_children_amount: inner_proof_pis.inner.overall_children_amount,
-            claimed_child_index_in_array: inner_proof_pis.inner.claimed_child_index_in_array,
-            claimed_child_hash: inner_proof_pis.inner.claimed_child_hash,
+            node_data: inner_target.inner.node_data,
+            initial_read_offset: inner_target.inner.initial_read_offset,
+            final_read_offset: inner_target.inner.read_offset,
+            overall_children_amount: inner_target.inner.overall_children_amount,
+            claimed_child_index_in_array: inner_target.inner.claimed_child_index_in_array,
+            claimed_child_hash: inner_target.inner.claimed_child_hash,
         }
         .register_as_public_inputs(&mut builder);
 
-        ProofWithCircuitData::prove_from_builder(builder, witness)
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            inner_proof_with_pis,
+            inner_common_data: inner_data.common.clone(),
+            inner_verifier_only: inner_data.verifier_only.clone(),
+        }
+    }
+}
+
+struct FinalProjectionCircuit<'a> {
+    template: &'a FinalProjectionTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl FinalProjectionCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<ChildNodeArrayParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
+impl ChildNodeArrayParser {
+    pub fn prove(self) -> ProofWithCircuitData<ChildNodeArrayParserTarget> {
+        let inner_proof = self.inner_proof();
+        FinalProjectionTemplate::cached(&inner_proof)
+            .instantiate(&inner_proof)
+            .prove()
     }
 
     fn inner_proof(self) -> ProofWithCircuitData<CyclicRecursionTargetWithVerifierData> {

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/child_node_array_parser/mod.rs
@@ -83,6 +83,7 @@ struct FinalProjectionTemplate {
     circuit_data: Arc<CircuitData<F, C, D>>,
     verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_common_data: CommonCircuitData<F, D>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
 }
@@ -95,15 +96,18 @@ impl FinalProjectionTemplate {
         // carried by the per-call inner proof witness.
         static CACHE: OnceLock<FinalProjectionTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "ChildNodeArrayParser final projection received incompatible common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "ChildNodeArrayParser final projection received incompatible verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "ChildNodeArrayParser final projection received incompatible common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "ChildNodeArrayParser final projection received incompatible verifier data"
+            );
+        }
         template
     }
 
@@ -148,6 +152,7 @@ impl FinalProjectionTemplate {
             circuit_data,
             verifier_data,
             inner_proof_with_pis,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_common_data: inner_data.common.clone(),
             inner_verifier_only: inner_data.verifier_only.clone(),
         }
@@ -248,8 +253,7 @@ struct CircuitTemplate {
     inner_cyclic_proof_with_pis: ProofWithPublicInputsTarget<D>,
     condition: BoolTarget,
     verifier_data_target: VerifierCircuitTarget,
-    inner_common_num_gates: usize,
-    inner_common_num_public_inputs: usize,
+    inner_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     inner_verifier_only: VerifierOnlyCircuitData<C, D>,
     inner_common_data: CommonCircuitData<F, D>,
 }
@@ -258,28 +262,18 @@ impl CircuitTemplate {
     fn cached(inner_proof: &ProofWithCircuitData<ChildNodeParserTarget>) -> &'static Self {
         static CACHE: OnceLock<CircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(inner_proof));
-        let inner_data = inner_proof.circuit_data();
-        assert_eq!(
-            template.inner_common_num_gates,
-            inner_data.common.gates.len(),
-            "ChildNodeArrayParser cache received incompatible inner circuit gate count"
-        );
-        assert_eq!(
-            template.inner_common_num_public_inputs, inner_data.common.num_public_inputs,
-            "ChildNodeArrayParser cache received incompatible inner public-input count"
-        );
-        assert_eq!(
-            template.inner_verifier_only.circuit_digest, inner_data.verifier_only.circuit_digest,
-            "ChildNodeArrayParser cache received incompatible inner circuit digest"
-        );
-        assert_eq!(
-            &template.inner_common_data, &inner_data.common,
-            "ChildNodeArrayParser cache received incompatible inner common data"
-        );
-        assert_eq!(
-            &template.inner_verifier_only, &inner_data.verifier_only,
-            "ChildNodeArrayParser cache received incompatible inner verifier data"
-        );
+        let inner_verifier_data = inner_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.inner_verifier_data, &inner_verifier_data) {
+            let inner_data = inner_verifier_data.as_ref();
+            assert_eq!(
+                &template.inner_common_data, &inner_data.common,
+                "ChildNodeArrayParser cache received incompatible inner common data"
+            );
+            assert_eq!(
+                &template.inner_verifier_only, &inner_data.verifier_only,
+                "ChildNodeArrayParser cache received incompatible inner verifier data"
+            );
+        }
         template
     }
 
@@ -402,8 +396,7 @@ impl CircuitTemplate {
             inner_cyclic_proof_with_pis,
             condition,
             verifier_data_target,
-            inner_common_num_gates: inner_data.common.gates.len(),
-            inner_common_num_public_inputs: inner_data.common.num_public_inputs,
+            inner_verifier_data: inner_proof.shared_circuit_data(),
             inner_verifier_only: inner_data.verifier_only.clone(),
             inner_common_data: inner_data.common.clone(),
         }

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -15,7 +15,7 @@ use plonky2::{
         proof::ProofWithPublicInputsTarget,
     },
 };
-use plonky2_field::types::Field;
+use plonky2_field::types::{Field, PrimeField64};
 use sp_core::H256;
 use std::sync::{Arc, OnceLock};
 use trie_db::{node::Node, ChildReference, NodeCodec, TrieLayout};
@@ -46,6 +46,16 @@ use child_node_array_parser::ChildNodeArrayParser;
 
 mod bitmap_parser;
 mod child_node_array_parser;
+
+/// Circuit digest used by the deployed recursive and Gnark verifier artifacts.
+/// An intentional circuit change must update every dependent artifact before
+/// this fingerprint is changed.
+const DEPLOYED_BRANCH_PARSER_CIRCUIT_DIGEST: [u64; 4] = [
+    17_409_790_683_616_089_390,
+    15_806_974_348_444_331_405,
+    16_311_428_230_950_506_818,
+    9_327_205_214_850_258_051,
+];
 
 impl_parsable_target_set! {
     /// `BranchParser` public inputs.
@@ -229,6 +239,15 @@ impl BranchParserCircuitTemplate {
         .register_as_public_inputs(&mut builder);
 
         let circuit_data = Arc::new(builder.build::<C>());
+        assert_eq!(
+            circuit_data
+                .verifier_only
+                .circuit_digest
+                .elements
+                .map(|element| element.to_canonical_u64()),
+            DEPLOYED_BRANCH_PARSER_CIRCUIT_DIGEST,
+            "BranchParser circuit digest changed; regenerate all dependent recursive and Gnark artifacts before deployment",
+        );
         let verifier_data = Arc::new(circuit_data.verifier_data());
 
         Self {
@@ -436,12 +455,7 @@ mod tests {
                 .circuit_digest
                 .elements
                 .map(|element| element.to_canonical_u64()),
-            [
-                17_409_790_683_616_089_390,
-                15_806_974_348_444_331_405,
-                16_311_428_230_950_506_818,
-                9_327_205_214_850_258_051,
-            ],
+            DEPLOYED_BRANCH_PARSER_CIRCUIT_DIGEST,
             "BranchParser circuit digest changed; existing recursive and Gnark artifacts must remain compatible",
         );
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -6,10 +6,18 @@ use plonky2::{
         target::Target,
         witness::{PartialWitness, WitnessWrite},
     },
-    plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{
+            CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData,
+            VerifierOnlyCircuitData,
+        },
+        proof::ProofWithPublicInputsTarget,
+    },
 };
 use plonky2_field::types::Field;
 use sp_core::H256;
+use std::sync::{Arc, OnceLock};
 use trie_db::{node::Node, ChildReference, NodeCodec, TrieLayout};
 
 use super::{
@@ -20,7 +28,7 @@ use super::{
 use crate::{
     common::{
         targets::{Blake2Target, HalfByteTarget, TargetSet},
-        BuilderExt, ProofWithCircuitData,
+        ProofWithCircuitData,
     },
     consts::BLAKE2_DIGEST_SIZE,
     impl_parsable_target_set,
@@ -75,13 +83,194 @@ struct Metadata {
     claimed_child_hash: [u8; BLAKE2_DIGEST_SIZE],
 }
 
+struct BranchParserCircuitTemplate {
+    circuit_data: Arc<CircuitData<F, C, D>>,
+    verifier_data: Arc<VerifierCircuitData<F, C, D>>,
+    child_proof_with_pis: ProofWithPublicInputsTarget<D>,
+    partial_address: StorageAddressTarget,
+    claimed_child_node_nibble: Target,
+    child_common_data: CommonCircuitData<F, D>,
+    child_verifier_only: VerifierOnlyCircuitData<C, D>,
+    child_num_public_inputs: usize,
+}
+
+impl BranchParserCircuitTemplate {
+    fn cached(child_proof: &ProofWithCircuitData<ChildNodeArrayParserTarget>) -> &'static Self {
+        // Node bytes, addresses, and child metadata are witnesses; the parser
+        // circuit shape is fixed by the compile-time trie bounds.
+        static CACHE: OnceLock<BranchParserCircuitTemplate> = OnceLock::new();
+        let template = CACHE.get_or_init(|| Self::build(child_proof));
+        let child_data = child_proof.circuit_data();
+        assert_eq!(
+            template.child_common_num_gates(),
+            child_data.common.gates.len(),
+            "BranchParser cache received incompatible child circuit gate count"
+        );
+        assert_eq!(
+            template.child_num_public_inputs, child_data.common.num_public_inputs,
+            "BranchParser cache received incompatible child public-input count"
+        );
+        assert_eq!(
+            template.child_verifier_only.circuit_digest, child_data.verifier_only.circuit_digest,
+            "BranchParser cache received incompatible child circuit digest"
+        );
+        assert_eq!(
+            &template.child_common_data, &child_data.common,
+            "BranchParser cache received incompatible child common data"
+        );
+        assert_eq!(
+            &template.child_verifier_only, &child_data.verifier_only,
+            "BranchParser cache received incompatible child verifier data"
+        );
+        template
+    }
+
+    fn child_common_num_gates(&self) -> usize {
+        self.child_common_data.gates.len()
+    }
+
+    fn instantiate(
+        &self,
+        child_proof: &ProofWithCircuitData<ChildNodeArrayParserTarget>,
+        partial_address_nibbles: &[u8],
+        claimed_child_node_nibble: u8,
+    ) -> BranchParserCircuit<'_> {
+        let mut witness = PartialWitness::new();
+        witness.set_proof_with_pis_target(&self.child_proof_with_pis, &child_proof.proof());
+        self.partial_address
+            .set_witness(partial_address_nibbles, &mut witness);
+        witness.set_target(
+            self.claimed_child_node_nibble,
+            F::from_canonical_u8(claimed_child_node_nibble),
+        );
+        BranchParserCircuit {
+            template: self,
+            witness,
+        }
+    }
+
+    fn build(child_proof: &ProofWithCircuitData<ChildNodeArrayParserTarget>) -> Self {
+        log::debug!("Building branch parser circuit template...");
+
+        let child_data = child_proof.circuit_data();
+        let mut config = CircuitConfig::standard_recursion_config();
+        config.num_wires = 160;
+        config.num_routed_wires = 130;
+
+        let mut builder = CircuitBuilder::new(config);
+        let child_proof_with_pis = builder.add_virtual_proof_with_pis(&child_data.common);
+        let child_verifier = builder.constant_verifier_data(&child_data.verifier_only);
+        builder.verify_proof::<C>(&child_proof_with_pis, &child_verifier, &child_data.common);
+        let child_target = ChildNodeArrayParserTarget::parse_exact(
+            &mut child_proof_with_pis.public_inputs.clone().into_iter(),
+        );
+
+        let node_data_target = BranchNodeDataPaddedTarget::add_virtual_safe(&mut builder);
+        let partial_address_target = StorageAddressTarget::add_virtual_unsafe(&mut builder);
+        let node_data_length_target = builder.add_virtual_target();
+        let claimed_child_node_nibble_target = builder.add_virtual_target();
+        let claimed_child_node_nibble_target =
+            HalfByteTarget::from_target_safe(claimed_child_node_nibble_target, &mut builder);
+        let child_node_hash_target = Blake2Target::add_virtual_safe(&mut builder);
+
+        let first_node_data_block = node_data_target.constant_read(0);
+        let parsed_node_header = header_parser::define(
+            HeaderParserInputTarget {
+                first_bytes: first_node_data_block.constant_read_array(0),
+            },
+            header_parser::HeaderDescriptor::branch_without_value(),
+            &mut builder,
+        );
+        let parsed_nibbles = nibble_parser::define(
+            NibbleParserInputTarget {
+                first_node_data_block: first_node_data_block.clone(),
+                read_offset: parsed_node_header.resulting_offset,
+                nibble_count: parsed_node_header.nibble_count,
+                partial_address: partial_address_target.clone(),
+            },
+            &mut builder,
+        );
+        let child_nibble_address_part = StorageAddressTarget::from_single_nibble_target(
+            claimed_child_node_nibble_target,
+            &mut builder,
+        );
+        let resulting_address = parsed_nibbles
+            .partial_address
+            .append(child_nibble_address_part, &mut builder);
+        let parsed_bitmap = bitmap_parser::define(
+            BitmapParserInputTarget {
+                first_node_data_block,
+                read_offset: parsed_nibbles.resulting_offset,
+                claimed_child_node_nibble: claimed_child_node_nibble_target,
+            },
+            &mut builder,
+        );
+
+        child_target
+            .node_data
+            .connect(&node_data_target, &mut builder);
+        child_target
+            .initial_read_offset
+            .connect(&parsed_bitmap.resulting_offset, &mut builder);
+        child_target
+            .final_read_offset
+            .connect(&node_data_length_target, &mut builder);
+        child_target
+            .overall_children_amount
+            .connect(&parsed_bitmap.overall_children_amount, &mut builder);
+        child_target
+            .claimed_child_index_in_array
+            .connect(&parsed_bitmap.child_index_in_array, &mut builder);
+        child_target
+            .claimed_child_hash
+            .connect(&child_node_hash_target, &mut builder);
+
+        BranchParserTarget {
+            padded_node_data: node_data_target.clone(),
+            node_data_length: node_data_length_target,
+            child_node_hash: child_node_hash_target,
+            partial_address: partial_address_target.clone(),
+            resulting_partial_address: resulting_address,
+        }
+        .register_as_public_inputs(&mut builder);
+
+        let circuit_data = Arc::new(builder.build::<C>());
+        let verifier_data = Arc::new(circuit_data.verifier_data());
+
+        Self {
+            circuit_data,
+            verifier_data,
+            child_proof_with_pis,
+            partial_address: partial_address_target,
+            claimed_child_node_nibble: claimed_child_node_nibble_target.to_target(),
+            child_common_data: child_data.common.clone(),
+            child_verifier_only: child_data.verifier_only.clone(),
+            child_num_public_inputs: child_data.common.num_public_inputs,
+        }
+    }
+}
+
+struct BranchParserCircuit<'a> {
+    template: &'a BranchParserCircuitTemplate,
+    witness: PartialWitness<F>,
+}
+
+impl BranchParserCircuit<'_> {
+    fn prove(self) -> ProofWithCircuitData<BranchParserTarget> {
+        ProofWithCircuitData::prove_from_shared_circuit_data(
+            &self.template.circuit_data,
+            Arc::clone(&self.template.verifier_data),
+            self.witness,
+        )
+    }
+}
+
 impl BranchParser {
     pub fn prove(self) -> ProofWithCircuitData<BranchParserTarget> {
         let metadata = self.parse_metadata();
-
         let child_node_parser_proof = ChildNodeArrayParser {
             initial_data: child_node_array_parser::InitialData {
-                node_data: compose_padded_node_data(self.node_data),
+                node_data: compose_padded_node_data(self.node_data.clone()),
                 read_offset: metadata.children_data_offset,
                 claimed_child_index_in_array: metadata.claimed_child_index_in_array,
                 claimed_child_hash: metadata.claimed_child_hash,
@@ -91,100 +280,13 @@ impl BranchParser {
         .prove();
 
         log::debug!("Proving branch node parser...");
-
-        let mut config = CircuitConfig::standard_recursion_config();
-        config.num_wires = 160;
-        config.num_routed_wires = 130;
-
-        let mut builder = CircuitBuilder::new(config);
-        let mut witness = PartialWitness::new();
-
-        let node_data_target = BranchNodeDataPaddedTarget::add_virtual_safe(&mut builder);
-
-        let partial_address_target = StorageAddressTarget::add_virtual_unsafe(&mut builder);
-        partial_address_target.set_witness(&self.partial_address_nibbles, &mut witness);
-
-        let node_data_length_target: Target = builder.add_virtual_target();
-
-        let claimed_child_node_nibble_target = builder.add_virtual_target();
-        witness.set_target(
-            claimed_child_node_nibble_target,
-            F::from_canonical_u8(self.claimed_child_node_nibble),
+        let template = BranchParserCircuitTemplate::cached(&child_node_parser_proof);
+        let circuit = template.instantiate(
+            &child_node_parser_proof,
+            &self.partial_address_nibbles,
+            self.claimed_child_node_nibble,
         );
-        let claimed_child_node_nibble_target =
-            HalfByteTarget::from_target_safe(claimed_child_node_nibble_target, &mut builder);
-
-        let child_node_hash_target = Blake2Target::add_virtual_safe(&mut builder);
-
-        let first_node_data_block = node_data_target.constant_read(0);
-
-        let parsed_node_header = {
-            let first_bytes = first_node_data_block.constant_read_array(0);
-
-            let input = HeaderParserInputTarget { first_bytes };
-            header_parser::define(
-                input,
-                header_parser::HeaderDescriptor::branch_without_value(),
-                &mut builder,
-            )
-        };
-
-        let parsed_nibbles = {
-            let input = NibbleParserInputTarget {
-                first_node_data_block: first_node_data_block.clone(),
-                read_offset: parsed_node_header.resulting_offset,
-                nibble_count: parsed_node_header.nibble_count,
-                partial_address: partial_address_target.clone(),
-            };
-            nibble_parser::define(input, &mut builder)
-        };
-
-        let child_nibble_address_part = StorageAddressTarget::from_single_nibble_target(
-            claimed_child_node_nibble_target,
-            &mut builder,
-        );
-        let resulting_address = parsed_nibbles
-            .partial_address
-            .append(child_nibble_address_part, &mut builder);
-
-        let parsed_bitmap = {
-            let input = BitmapParserInputTarget {
-                first_node_data_block,
-                read_offset: parsed_nibbles.resulting_offset,
-                claimed_child_node_nibble: claimed_child_node_nibble_target,
-            };
-
-            bitmap_parser::define(input, &mut builder)
-        };
-
-        {
-            let ChildNodeArrayParserTarget {
-                node_data,
-                initial_read_offset,
-                final_read_offset,
-                overall_children_amount,
-                claimed_child_index_in_array,
-                claimed_child_hash,
-            } = builder.recursively_verify_constant_proof(&child_node_parser_proof, &mut witness);
-
-            node_data.connect(&node_data_target, &mut builder);
-            initial_read_offset.connect(&parsed_bitmap.resulting_offset, &mut builder);
-            final_read_offset.connect(&node_data_length_target, &mut builder);
-            overall_children_amount.connect(&parsed_bitmap.overall_children_amount, &mut builder);
-            claimed_child_index_in_array.connect(&parsed_bitmap.child_index_in_array, &mut builder);
-            claimed_child_hash.connect(&child_node_hash_target, &mut builder);
-        }
-
-        BranchParserTarget {
-            padded_node_data: node_data_target,
-            node_data_length: node_data_length_target,
-            child_node_hash: child_node_hash_target,
-            partial_address: partial_address_target,
-            resulting_partial_address: resulting_address,
-        }
-        .register_as_public_inputs(&mut builder);
-
-        let result = ProofWithCircuitData::prove_from_builder(builder, witness);
+        let result = circuit.prove();
 
         log::debug!("Proven branch node parser");
 

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -147,13 +147,11 @@ impl BranchParserCircuitTemplate {
         config.num_routed_wires = 130;
 
         let mut builder = CircuitBuilder::new(config);
-        let child_proof_with_pis = builder.add_virtual_proof_with_pis(&child_data.common);
-        let child_verifier = builder.constant_verifier_data(&child_data.verifier_only);
-        builder.verify_proof::<C>(&child_proof_with_pis, &child_verifier, &child_data.common);
-        let child_target = ChildNodeArrayParserTarget::parse_exact(
-            &mut child_proof_with_pis.public_inputs.clone().into_iter(),
-        );
 
+        // Keep the recursive child verifier at the same position as the
+        // pre-cache circuit. Plonky2 target/gate order is part of the circuit
+        // digest, so moving it earlier would invalidate existing recursive and
+        // Gnark verifier artifacts even though the constraints are equivalent.
         let node_data_target = BranchNodeDataPaddedTarget::add_virtual_safe(&mut builder);
         let partial_address_target = StorageAddressTarget::add_virtual_unsafe(&mut builder);
         let node_data_length_target = builder.add_virtual_target();
@@ -193,6 +191,13 @@ impl BranchParserCircuitTemplate {
                 claimed_child_node_nibble: claimed_child_node_nibble_target,
             },
             &mut builder,
+        );
+
+        let child_proof_with_pis = builder.add_virtual_proof_with_pis(&child_data.common);
+        let child_verifier = builder.constant_verifier_data(&child_data.verifier_only);
+        builder.verify_proof::<C>(&child_proof_with_pis, &child_verifier, &child_data.common);
+        let child_target = ChildNodeArrayParserTarget::parse_exact(
+            &mut child_proof_with_pis.public_inputs.clone().into_iter(),
         );
 
         child_target
@@ -339,6 +344,7 @@ impl BranchParser {
 
 #[cfg(test)]
 mod tests {
+    use plonky2_field::types::PrimeField64;
     use std::iter;
     use trie_db::NibbleSlice;
 
@@ -423,6 +429,21 @@ mod tests {
             BranchParserTarget::parse_public_inputs_exact(&mut proof.public_inputs().into_iter());
 
         assert!(proof.verify());
+        assert_eq!(
+            proof
+                .circuit_data()
+                .verifier_only
+                .circuit_digest
+                .elements
+                .map(|element| element.to_canonical_u64()),
+            [
+                17_409_790_683_616_089_390,
+                15_806_974_348_444_331_405,
+                16_311_428_230_950_506_818,
+                9_327_205_214_850_258_051,
+            ],
+            "BranchParser circuit digest changed; existing recursive and Gnark artifacts must remain compatible",
+        );
 
         assert_eq!(
             pis.resulting_partial_address.length,

--- a/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
+++ b/prover/src/storage_inclusion/storage_trie_proof/node_parser/branch_parser/mod.rs
@@ -89,9 +89,9 @@ struct BranchParserCircuitTemplate {
     child_proof_with_pis: ProofWithPublicInputsTarget<D>,
     partial_address: StorageAddressTarget,
     claimed_child_node_nibble: Target,
+    child_verifier_data: Arc<VerifierCircuitData<F, C, D>>,
     child_common_data: CommonCircuitData<F, D>,
     child_verifier_only: VerifierOnlyCircuitData<C, D>,
-    child_num_public_inputs: usize,
 }
 
 impl BranchParserCircuitTemplate {
@@ -100,33 +100,22 @@ impl BranchParserCircuitTemplate {
         // circuit shape is fixed by the compile-time trie bounds.
         static CACHE: OnceLock<BranchParserCircuitTemplate> = OnceLock::new();
         let template = CACHE.get_or_init(|| Self::build(child_proof));
-        let child_data = child_proof.circuit_data();
-        assert_eq!(
-            template.child_common_num_gates(),
-            child_data.common.gates.len(),
-            "BranchParser cache received incompatible child circuit gate count"
-        );
-        assert_eq!(
-            template.child_num_public_inputs, child_data.common.num_public_inputs,
-            "BranchParser cache received incompatible child public-input count"
-        );
-        assert_eq!(
-            template.child_verifier_only.circuit_digest, child_data.verifier_only.circuit_digest,
-            "BranchParser cache received incompatible child circuit digest"
-        );
-        assert_eq!(
-            &template.child_common_data, &child_data.common,
-            "BranchParser cache received incompatible child common data"
-        );
-        assert_eq!(
-            &template.child_verifier_only, &child_data.verifier_only,
-            "BranchParser cache received incompatible child verifier data"
-        );
+        let child_verifier_data = child_proof.shared_circuit_data();
+        if !Arc::ptr_eq(&template.child_verifier_data, &child_verifier_data) {
+            // The normal hot path reuses the exact cached verifier-data Arc.
+            // Retain a full fallback check for separately allocated but
+            // compatible circuit data.
+            let child_data = child_verifier_data.as_ref();
+            assert_eq!(
+                &template.child_common_data, &child_data.common,
+                "BranchParser cache received incompatible child common data"
+            );
+            assert_eq!(
+                &template.child_verifier_only, &child_data.verifier_only,
+                "BranchParser cache received incompatible child verifier data"
+            );
+        }
         template
-    }
-
-    fn child_common_num_gates(&self) -> usize {
-        self.child_common_data.gates.len()
     }
 
     fn instantiate(
@@ -243,9 +232,9 @@ impl BranchParserCircuitTemplate {
             child_proof_with_pis,
             partial_address: partial_address_target,
             claimed_child_node_nibble: claimed_child_node_nibble_target.to_target(),
+            child_verifier_data: child_proof.shared_circuit_data(),
             child_common_data: child_data.common.clone(),
             child_verifier_only: child_data.verifier_only.clone(),
-            child_num_public_inputs: child_data.common.num_public_inputs,
         }
     }
 }

--- a/relayer/src/config.rs
+++ b/relayer/src/config.rs
@@ -525,7 +525,7 @@ fn build_options(source: OptionSource<'_>) -> anyhow::Result<MerkleRootRelayerOp
                     source.relayer_id
                 ));
             }
-            CriticalThreshold::Timeout((duration.as_secs() / 3) as u32)
+            CriticalThreshold::Timeout(duration)
         }
         cli::CriticalThreshold::AuthoritySetChange => CriticalThreshold::AuthoritySetChange,
     };
@@ -864,6 +864,10 @@ data_path = "/tmp/testnet-gnark"
             PathBuf::from("/tmp/mainnet-gnark")
         );
         assert_eq!(relayer.options.count_thread, None);
+        assert_eq!(
+            relayer.options.critical_threshold,
+            CriticalThreshold::Timeout(Duration::from_secs(14 * 60 * 60))
+        );
     }
 
     #[test]

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -57,11 +57,16 @@ fn main() -> AnyResult<()> {
 
     // we need at least 2 native threads to run some of the blocking tasks like proof composition
     // so lets set minimum to 4 threads or to available parallelism.
-    tokio::runtime::Builder::new_multi_thread()
+    let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .max_blocking_threads(std::thread::available_parallelism()?.get().max(4))
-        .build()?
-        .block_on(run())
+        .build()?;
+    let result = runtime.block_on(run());
+    if let Err(error) = result {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+    Ok(())
 }
 
 async fn run() -> AnyResult<()> {

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -19,7 +19,7 @@ use primitive_types::{H256, U256};
 use prometheus::IntGauge;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
@@ -43,6 +43,7 @@ pub mod submitter;
 const MERKLE_ROOT_SUPERVISOR_INTERVAL: Duration = Duration::from_secs(15 * 60);
 const MERKLE_ROOT_SUPERVISOR_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 const MAX_PENDING_HTTP_REQUESTS_PER_ROOT: usize = 128;
+type PendingContinuation = ((u32, H256), u32);
 
 enum EthereumRootRead {
     Fetched(Option<H256>),
@@ -257,6 +258,9 @@ pub struct MerkleRootRelayer {
     first_pending_timestamp: Option<Instant>,
     queued_root_timestamps: VecDeque<Instant>,
     merkle_root_batch: Vec<PendingMerkleRoot>,
+    pending_continuations: VecDeque<PendingContinuation>,
+    pending_submissions: VecDeque<(u32, H256)>,
+    pending_submission_keys: HashSet<(u32, H256)>,
 
     options: MerkleRootRelayerOptions,
 
@@ -302,6 +306,9 @@ impl MerkleRootRelayer {
             first_pending_timestamp: None,
             queued_root_timestamps: VecDeque::with_capacity(8),
             merkle_root_batch: Vec::with_capacity(8),
+            pending_continuations: VecDeque::new(),
+            pending_submissions: VecDeque::new(),
+            pending_submission_keys: HashSet::new(),
 
             options,
             save_interval,
@@ -321,6 +328,12 @@ impl MerkleRootRelayer {
             } else {
                 break;
             }
+        }
+    }
+
+    fn queue_submission(&mut self, key: (u32, H256)) {
+        if self.pending_submission_keys.insert(key) {
+            self.pending_submissions.push_back(key);
         }
     }
 
@@ -519,21 +532,8 @@ impl MerkleRootRelayer {
                     log::info!(
                         "Merkle root relayer {relayer_id}: merkle root {hash} for block #{block_number} is waiting for proof submission"
                     );
-                    let proof = merkle_root
-                        .proof
-                        .clone()
-                        .expect("proof should be available if root is in SubmitProof state; check your storage");
-
                     reinstate(MerkleRootStatus::SubmitProof);
-
-                    if !submitter.submit_merkle_root(block_number, hash, proof) {
-                        log::error!(
-                            "Merkle root relayer {relayer_id}: proof submitter connection closed, exiting"
-                        );
-                        return Err(anyhow::anyhow!(
-                            "Merkle root relayer {relayer_id}: proof submitter connection closed during startup recovery"
-                        ));
-                    }
+                    self.queue_submission((block_number, hash));
                 }
 
                 MerkleRootStatus::SubmitProof => {
@@ -559,6 +559,8 @@ impl MerkleRootRelayer {
                 }
             }
         }
+        self.pending_continuations
+            .extend(recover_finalized_continuations(&self.roots));
 
         self.initialize_contract_cursor(&mut eth_api).await?;
         // Consume the interval's immediate first tick before supervision so a failed
@@ -735,7 +737,7 @@ impl MerkleRootRelayer {
                 prover,
                 authority_set_sync,
                 block,
-                ProofTarget::SignedAnchor,
+                ProofTarget::Recovery,
                 Batch::No,
                 Priority::No,
                 ForceGeneration::Yes,
@@ -849,13 +851,6 @@ impl MerkleRootRelayer {
                 )
                 .await;
 
-            if let Err(err) = self.storage.save(&self.roots).await {
-                log::error!(
-                    "Merkle root relayer {}: failed to save block state: {err:?}",
-                    self.options.relayer_id
-                );
-            }
-
             match result {
                 Ok(true) => continue,
                 Ok(false) => {
@@ -886,7 +881,48 @@ impl MerkleRootRelayer {
         eth_api: &mut EthApi,
     ) -> anyhow::Result<bool> {
         let client = self.api_provider.client();
+        let pending_submission = self
+            .pending_submissions
+            .front()
+            .map(|&(block_number, merkle_root)| {
+                let proof = self
+                    .roots
+                    .get(&(block_number, merkle_root))
+                    .and_then(|root| root.proof.clone())
+                    .with_context(|| {
+                        format!(
+                            "Queued merkle root {merkle_root} for block #{block_number} has no proof"
+                        )
+                    })?;
+                Ok::<_, anyhow::Error>(submitter::Request {
+                    era: None,
+                    merkle_root_block: block_number,
+                    merkle_root,
+                    proof,
+                })
+            })
+            .transpose()?;
+        let has_pending_submission = pending_submission.is_some();
+        let submission_tx = submitter.request_sender();
         tokio::select! {
+            submission = async {
+                submission_tx
+                    .send(pending_submission.expect("submission branch requires queued work"))
+                    .await
+            }, if has_pending_submission => {
+                if submission.is_err() {
+                    log::warn!(
+                        "Merkle root relayer {}: proof submitter connection closed, exiting",
+                        self.options.relayer_id
+                    );
+                    return Ok(false);
+                }
+                let key = self
+                    .pending_submissions
+                    .pop_front()
+                    .expect("submitted work was read from the pending queue");
+                self.pending_submission_keys.remove(&key);
+            }
             _ = self.save_interval.tick() => {
                 log::trace!("60 seconds passed, saving current state");
                 if let Err(err) = self.storage.save(&self.roots).await {
@@ -1005,6 +1041,8 @@ impl MerkleRootRelayer {
                                         if let Some(root) =
                                             self.roots.get_mut(&(block_number, merkle_root))
                                         {
+                                            root.http_requests
+                                                .retain(|request| !request.is_closed());
                                             if root.http_requests.len()
                                                 >= MAX_PENDING_HTTP_REQUESTS_PER_ROOT
                                             {
@@ -1147,16 +1185,8 @@ impl MerkleRootRelayer {
                                 );
                             }
                         }
-                        self.storage.save(&self.roots).await?;
-
-                        if !local_proof_only
-                            && !submitter.submit_merkle_root(block_number, merkle_root, proof)
-                        {
-                            log::warn!(
-                                "Merkle root relayer {}: proof submitter connection closed, exiting",
-                                self.options.relayer_id
-                            );
-                            return Ok(false);
+                        if !local_proof_only {
+                            self.queue_submission(root_key);
                         }
                     }
                     prover::Response::Batched {
@@ -1176,15 +1206,7 @@ impl MerkleRootRelayer {
                                 "Selected batched merkle root {merkle_root} for block #{block_number} not found in storage"
                             ));
                         }
-                        self.storage.save(&self.roots).await?;
-
-                        if !submitter.submit_merkle_root(block_number, merkle_root, proof) {
-                            log::warn!(
-                                "Merkle root relayer {}: proof submitter connection closed, exiting",
-                                self.options.relayer_id
-                            );
-                            return Ok(false);
-                        }
+                        self.queue_submission((block_number, merkle_root));
                     }
                 }
             }
@@ -1286,6 +1308,38 @@ impl MerkleRootRelayer {
                 }
             }
 
+            continuation = async { self.pending_continuations.pop_front() },
+                if !self.pending_continuations.is_empty() => {
+                let Some((anchor_key, block_number)) = continuation else {
+                    unreachable!("continuation branch requires queued work");
+                };
+                let block_hash = client.block_number_to_hash(block_number).await?;
+                let block = client.get_block_at(block_hash).await?;
+                let block = GearBlock::from_subxt_block(&client, block).await?;
+                self.try_proof_merkle_root(
+                    prover,
+                    authority_set_sync,
+                    block,
+                    ProofTarget::SignedAnchor,
+                    Batch::No,
+                    Priority::No,
+                    ForceGeneration::Yes,
+                )
+                .await?;
+
+                if let Some(root) = self.roots.get_mut(&anchor_key) {
+                    if let Some(index) = root
+                        .continuation_source_blocks
+                        .iter()
+                        .position(|block| *block == block_number)
+                    {
+                        root.continuation_source_blocks.remove(index);
+                    }
+                }
+                self.storage.save(&self.roots).await?;
+                tokio::task::yield_now().await;
+            }
+
             response = submitter.recv() => {
                 let Some(response) = response else {
                     log::warn!(
@@ -1295,22 +1349,8 @@ impl MerkleRootRelayer {
                     return Ok(false);
                 };
 
-                let continuation_blocks = self.finalize_merkle_root(response).await?;
-                for block_number in continuation_blocks {
-                    let block_hash = client.block_number_to_hash(block_number).await?;
-                    let block = client.get_block_at(block_hash).await?;
-                    let block = GearBlock::from_subxt_block(&client, block).await?;
-                    self.try_proof_merkle_root(
-                        prover,
-                        authority_set_sync,
-                        block,
-                        ProofTarget::SignedAnchor,
-                        Batch::No,
-                        Priority::No,
-                        ForceGeneration::Yes,
-                    )
-                    .await?;
-                }
+                let continuations = self.finalize_merkle_root(response).await?;
+                self.pending_continuations.extend(continuations);
             }
         }
         Ok(true)
@@ -1319,7 +1359,7 @@ impl MerkleRootRelayer {
     async fn finalize_merkle_root(
         &mut self,
         response: submitter::Response,
-    ) -> anyhow::Result<Vec<u32>> {
+    ) -> anyhow::Result<Vec<PendingContinuation>> {
         if let Some(era) = response.era {
             log::info!(
                 "Merkle root relayer {}: era #{} merkle root {} for block #{} is finalized with status: {:?}",
@@ -1556,7 +1596,7 @@ impl MerkleRootRelayer {
                 block_inclusion_proof.required_authority_set_id,
                 true,
             ),
-            ProofTarget::SignedAnchor => {
+            ProofTarget::SignedAnchor | ProofTarget::Recovery => {
                 let signed_target_block_number = block_inclusion_proof.block_number;
                 let contract_limit = contract_anchor_limit(
                     self.last_confirmed_block,
@@ -1651,26 +1691,16 @@ impl MerkleRootRelayer {
             }
         };
         let proof_target_block_hash = block_inclusion_proof.block_hash;
-        let (chain_queue_id, chain_merkle_root) = api
-            .fetch_authenticated_queue_merkle_root(block_hash)
-            .await?;
-        if chain_queue_id != queue_id || chain_merkle_root != merkle_root {
-            return Err(anyhow::anyhow!(
-                "Selected proof target #{block_number} does not match Vara queue state"
-            ));
-        }
 
         let selected_key = (block_number, merkle_root);
         let selected_state = self.roots.get(&selected_key).and_then(|root| {
-            if matches!(root.status, MerkleRootStatus::Finalized)
-                && self
-                    .last_confirmed_block
-                    .is_some_and(|confirmed| block_number <= confirmed)
-                && root.proof.as_ref().is_some_and(|proof| {
-                    proof.block_number == block_number
-                        && H256::from(proof.merkle_root) == merkle_root
-                })
-            {
+            if reusable_finalized_root(
+                root,
+                self.last_confirmed_block,
+                block_number,
+                merkle_root,
+                matches!(proof_target, ProofTarget::Recovery),
+            ) {
                 Some(true)
             } else if matches!(
                 root.status,
@@ -1717,8 +1747,12 @@ impl MerkleRootRelayer {
             {
                 root.continuation_source_blocks.push(source_block_number);
             }
-            let should_schedule_single =
-                matches!(batch, Batch::No) && root.promote_to_single_proof();
+            let should_schedule_single = matches!(batch, Batch::No)
+                && if matches!(proof_target, ProofTarget::Recovery) {
+                    root.promote_to_recovery_proof()
+                } else {
+                    root.promote_to_single_proof()
+                };
 
             if let Some(index) = self.merkle_root_batch.iter().position(|pending| {
                 pending.block_number == block_number && pending.merkle_root == merkle_root
@@ -2005,6 +2039,45 @@ impl MerkleRoot {
             false
         }
     }
+
+    fn promote_to_recovery_proof(&mut self) -> bool {
+        if matches!(self.status, MerkleRootStatus::Finalized) {
+            self.status = MerkleRootStatus::GenerateProof;
+        }
+        self.promote_to_single_proof()
+    }
+}
+
+fn recover_finalized_continuations(
+    roots: &HashMap<(u32, H256), MerkleRoot>,
+) -> Vec<PendingContinuation> {
+    let mut continuations = roots
+        .iter()
+        .filter(|(_, root)| matches!(root.status, MerkleRootStatus::Finalized))
+        .flat_map(|(key, root)| {
+            root.continuation_source_blocks
+                .iter()
+                .map(|block| (*key, *block))
+        })
+        .collect::<Vec<_>>();
+    continuations.sort_unstable();
+    continuations.dedup();
+    continuations
+}
+
+fn reusable_finalized_root(
+    root: &MerkleRoot,
+    last_confirmed_block: Option<u32>,
+    block_number: u32,
+    merkle_root: H256,
+    force_recovery: bool,
+) -> bool {
+    !force_recovery
+        && matches!(root.status, MerkleRootStatus::Finalized)
+        && last_confirmed_block.is_some_and(|confirmed| block_number <= confirmed)
+        && root.proof.as_ref().is_some_and(|proof| {
+            proof.block_number == block_number && H256::from(proof.merkle_root) == merkle_root
+        })
 }
 fn is_local_proof_only(roots: &HashMap<(u32, H256), MerkleRoot>, root_key: (u32, H256)) -> bool {
     roots
@@ -2024,23 +2097,27 @@ fn finalize_confirmed_roots(
     roots: &mut HashMap<(u32, H256), MerkleRoot>,
     confirmed_root: (u32, H256),
     covered_roots: &[(u32, H256)],
-) -> (Vec<u32>, Vec<u32>) {
+) -> (Vec<u32>, Vec<PendingContinuation>) {
     let mut covered_source_blocks = Vec::new();
-    let mut continuation_blocks = Vec::new();
+    let mut continuations = Vec::new();
 
     for key in std::iter::once(&confirmed_root).chain(covered_roots) {
         if let Some(root) = roots.get_mut(key) {
             root.status = MerkleRootStatus::Finalized;
             covered_source_blocks.extend_from_slice(&root.covered_source_blocks);
-            continuation_blocks.extend_from_slice(&root.continuation_source_blocks);
+            continuations.extend(
+                root.continuation_source_blocks
+                    .iter()
+                    .map(|block| (*key, *block)),
+            );
         }
     }
 
     covered_source_blocks.sort_unstable();
     covered_source_blocks.dedup();
-    continuation_blocks.sort_unstable();
-    continuation_blocks.dedup();
-    (covered_source_blocks, continuation_blocks)
+    continuations.sort_unstable();
+    continuations.dedup();
+    (covered_source_blocks, continuations)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2131,6 +2208,7 @@ pub struct PendingMerkleRoot {
 enum ProofTarget {
     Exact,
     SignedAnchor,
+    Recovery,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -2211,10 +2289,36 @@ pub enum StartupSyncStrategy {
 mod tests {
     use super::{
         anchor_covers_source, contract_anchor_limit, critical_timeout_reached,
-        finalize_confirmed_roots, is_local_proof_only, CriticalThreshold, FinalProof, MerkleRoot,
-        MerkleRootStatus, RawBlockInclusionProof, H256,
+        finalize_confirmed_roots, is_local_proof_only, recover_finalized_continuations,
+        reusable_finalized_root, CriticalThreshold, FinalProof, MerkleRoot, MerkleRootStatus,
+        RawBlockInclusionProof, H256,
     };
     use std::{collections::HashMap, time::Duration};
+
+    fn root(block_number: u32, block_hash: H256) -> MerkleRoot {
+        MerkleRoot {
+            block_number,
+            block_hash,
+            queue_id: 1,
+            message_nonces: Vec::new(),
+            http_requests: Vec::new(),
+            proof: None,
+            covered_roots: Vec::new(),
+            covered_source_blocks: Vec::new(),
+            continuation_source_blocks: Vec::new(),
+            batch: true,
+            single_proof_in_flight: false,
+            status: MerkleRootStatus::GenerateProof,
+            block_inclusion_proof: RawBlockInclusionProof {
+                justification_round: 0,
+                required_authority_set_id: 1,
+                validator_set: Vec::new(),
+                block_hash,
+                block_number,
+                pre_commits: Vec::new(),
+            },
+        }
+    }
 
     #[test]
     fn critical_timeout_is_reached_at_threshold() {
@@ -2297,31 +2401,6 @@ mod tests {
 
     #[test]
     fn confirmed_anchor_finalizes_covered_roots_and_releases_sources() {
-        fn root(block_number: u32, block_hash: H256) -> MerkleRoot {
-            MerkleRoot {
-                block_number,
-                block_hash,
-                queue_id: 1,
-                message_nonces: Vec::new(),
-                http_requests: Vec::new(),
-                proof: None,
-                covered_roots: Vec::new(),
-                covered_source_blocks: Vec::new(),
-                continuation_source_blocks: Vec::new(),
-                batch: true,
-                single_proof_in_flight: false,
-                status: MerkleRootStatus::GenerateProof,
-                block_inclusion_proof: RawBlockInclusionProof {
-                    justification_round: 0,
-                    required_authority_set_id: 1,
-                    validator_set: Vec::new(),
-                    block_hash,
-                    block_number,
-                    pre_commits: Vec::new(),
-                },
-            }
-        }
-
         let covered_key = (100, H256::repeat_byte(1));
         let anchor_key = (120, H256::repeat_byte(2));
         let mut covered_root = root(covered_key.0, H256::repeat_byte(3));
@@ -2366,7 +2445,56 @@ mod tests {
         assert!(exact_root.promote_to_single_proof());
         assert!(matches!(exact_root.status, MerkleRootStatus::Finalized));
         assert_eq!(covered_sources, vec![90]);
-        assert_eq!(continuation_blocks, vec![130]);
+        assert_eq!(continuation_blocks, vec![(anchor_key, 130)]);
+    }
+
+    #[test]
+    fn recovery_does_not_reuse_a_locally_finalized_root() {
+        let block_number = 120;
+        let merkle_root = H256::repeat_byte(2);
+        let mut root = root(block_number, H256::repeat_byte(4));
+        root.status = MerkleRootStatus::Finalized;
+        root.proof = Some(FinalProof {
+            proof: vec![1],
+            block_number,
+            merkle_root: *merkle_root.as_fixed_bytes(),
+        });
+
+        assert!(reusable_finalized_root(
+            &root,
+            Some(block_number),
+            block_number,
+            merkle_root,
+            false,
+        ));
+        assert!(!reusable_finalized_root(
+            &root,
+            Some(block_number),
+            block_number,
+            merkle_root,
+            true,
+        ));
+
+        assert!(root.promote_to_recovery_proof());
+        assert!(matches!(root.status, MerkleRootStatus::GenerateProof));
+        assert!(root.single_proof_in_flight);
+    }
+
+    #[test]
+    fn restart_recovers_only_finalized_continuations() {
+        let finalized_key = (120, H256::repeat_byte(2));
+        let pending_key = (121, H256::repeat_byte(3));
+        let mut finalized = root(finalized_key.0, H256::repeat_byte(4));
+        finalized.status = MerkleRootStatus::Finalized;
+        finalized.continuation_source_blocks = vec![131, 130];
+        let mut pending = root(pending_key.0, H256::repeat_byte(5));
+        pending.continuation_source_blocks = vec![132];
+        let roots = HashMap::from([(finalized_key, finalized), (pending_key, pending)]);
+
+        assert_eq!(
+            recover_finalized_continuations(&roots),
+            vec![(finalized_key, 130), (finalized_key, 131)]
+        );
     }
 
     #[test]

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -42,6 +42,7 @@ pub mod submitter;
 
 const MERKLE_ROOT_SUPERVISOR_INTERVAL: Duration = Duration::from_secs(15 * 60);
 const MERKLE_ROOT_SUPERVISOR_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_PENDING_HTTP_REQUESTS_PER_ROOT: usize = 128;
 
 enum EthereumRootRead {
     Fetched(Option<H256>),
@@ -213,9 +214,9 @@ impl Relayer {
 
 impl_metered_service!(
     struct Metrics {
-        last_submitted_block: IntGauge = IntGauge::new(
+        last_confirmed_block: IntGauge = IntGauge::new(
             "merkle_root_relayer_last_submitted_block",
-            "Block number of the last submitted merkle root"
+            "Block number of the last confirmed merkle root"
         ),
         first_pending_timestamp: IntGauge = IntGauge::new(
             "merkle_root_relayer_first_pending_timestamp",
@@ -250,7 +251,9 @@ pub struct MerkleRootRelayer {
     /// Set of blocks that are waiting for authority set sync.
     waiting_for_authority_set_sync: BTreeMap<u64, Vec<GearBlock>>,
 
-    last_submitted_block: Option<u32>,
+    last_confirmed_block: Option<u32>,
+    last_confirmed_timestamp_ms: Option<u64>,
+    max_block_distance: Option<u32>,
     first_pending_timestamp: Option<Instant>,
     queued_root_timestamps: VecDeque<Instant>,
     merkle_root_batch: Vec<PendingMerkleRoot>,
@@ -293,7 +296,9 @@ impl MerkleRootRelayer {
 
             waiting_for_authority_set_sync: BTreeMap::new(),
 
-            last_submitted_block: None,
+            last_confirmed_block: None,
+            last_confirmed_timestamp_ms: None,
+            max_block_distance: None,
             first_pending_timestamp: None,
             queued_root_timestamps: VecDeque::with_capacity(8),
             merkle_root_batch: Vec::with_capacity(8),
@@ -334,11 +339,20 @@ impl MerkleRootRelayer {
         log::info!("Starting merkle root relayer {relayer_id}");
         let mut roots = match self.storage.load().await {
             Ok(roots) => roots,
-            Err(err) => {
-                log::error!(
-                    "Merkle root relayer {relayer_id}: failed to load merkle roots from storage: {err}"
+            Err(err)
+                if err
+                    .downcast_ref::<std::io::Error>()
+                    .is_some_and(|err| err.kind() == std::io::ErrorKind::NotFound) =>
+            {
+                log::info!(
+                    "Merkle root relayer {relayer_id}: no persisted merkle-root state found"
                 );
                 Default::default()
+            }
+            Err(err) => {
+                return Err(err).context(format!(
+                    "Merkle root relayer {relayer_id}: failed to load merkle roots from storage"
+                ));
             }
         };
         let gear_api = self.api_provider.client();
@@ -374,12 +388,18 @@ impl MerkleRootRelayer {
                 self.roots.insert(
                     (block_number, hash),
                     MerkleRoot {
-                        queue_id: 0,
+                        queue_id: merkle_root.queue_id,
                         block_number,
                         block_hash,
-                        status,
+                        status: status.clone(),
                         message_nonces: Vec::new(),
                         proof: merkle_root.proof.clone(),
+                        covered_roots: merkle_root.covered_roots.clone(),
+                        covered_source_blocks: merkle_root.covered_source_blocks.clone(),
+                        continuation_source_blocks: merkle_root.continuation_source_blocks.clone(),
+                        batch: merkle_root.batch,
+                        single_proof_in_flight: matches!(status, MerkleRootStatus::GenerateProof)
+                            && !merkle_root.batch,
                         http_requests: Vec::new(),
                         block_inclusion_proof: merkle_root.block_inclusion_proof.clone(),
                     },
@@ -393,7 +413,8 @@ impl MerkleRootRelayer {
                         "Merkle root relayer {relayer_id}: merkle root {hash} for block #{block_number} is waiting for authority set sync with id {id}"
                     );
 
-                    let block = gear_api.get_block_at(block_hash).await?;
+                    let proof_target_hash = merkle_root.block_inclusion_proof.block_hash;
+                    let block = gear_api.get_block_at(proof_target_hash).await?;
                     let block = GearBlock::from_subxt_block(&gear_api, block).await?;
 
                     match self
@@ -411,7 +432,7 @@ impl MerkleRootRelayer {
                                 hash,
                                 authority_set_proof,
                                 merkle_root.queue_id,
-                                true,
+                                merkle_root.batch,
                                 merkle_root.block_inclusion_proof.clone(),
                             ) {
                                 log::error!(
@@ -433,16 +454,14 @@ impl MerkleRootRelayer {
                             // if authority set is older than last sealed era we need to seal this
                             // authority set first.
                             if *id <= last_sealed {
-                                last_sealed = *id - 1;
+                                last_sealed = id.saturating_sub(1);
                             }
 
-                            let force_sync = self
-                                .storage
-                                .proofs
-                                .get_latest_authority_set_id()
-                                .await
-                                .is_some_and(|latest| *id > latest)
-                                && *id > last_sealed;
+                            let force_sync =
+                                match self.storage.proofs.get_latest_authority_set_id().await {
+                                    Some(latest) => *id > latest,
+                                    None => true,
+                                } && *id > last_sealed;
 
                             let waiting =
                                 self.waiting_for_authority_set_sync.entry(*id).or_default();
@@ -470,7 +489,7 @@ impl MerkleRootRelayer {
                     // that proof for authority set id is already generated and thus should be available in storage.
                     // If it is not found that is a hard error and storage should be fixed.
                     let signed_by_authority_set_id =
-                        gear_api.signed_by_authority_set_id(block_hash).await?;
+                        merkle_root.block_inclusion_proof.required_authority_set_id;
                     let inner_proof = self
                         .storage
                         .proofs
@@ -484,7 +503,7 @@ impl MerkleRootRelayer {
                         hash,
                         inner_proof,
                         merkle_root.queue_id,
-                        true,
+                        merkle_root.batch,
                         merkle_root.block_inclusion_proof.clone(),
                     ) {
                         log::error!(
@@ -496,7 +515,7 @@ impl MerkleRootRelayer {
                     }
                 }
 
-                MerkleRootStatus::SubmitProof => {
+                MerkleRootStatus::SubmitProof if merkle_root.proof.is_some() => {
                     log::info!(
                         "Merkle root relayer {relayer_id}: merkle root {hash} for block #{block_number} is waiting for proof submission"
                     );
@@ -515,6 +534,12 @@ impl MerkleRootRelayer {
                             "Merkle root relayer {relayer_id}: proof submitter connection closed during startup recovery"
                         ));
                     }
+                }
+
+                MerkleRootStatus::SubmitProof => {
+                    return Err(anyhow::anyhow!(
+                        "Merkle root relayer {relayer_id}: merkle root {hash} for block #{block_number} has no proof in SubmitProof state"
+                    ));
                 }
 
                 MerkleRootStatus::Failed(err) => {
@@ -567,8 +592,8 @@ impl MerkleRootRelayer {
         let relayer_id = &self.options.relayer_id;
         let max_block_number = rpc::retry_eth(
             eth_api,
-            "read MessageQueue max block number",
-            |api| async move { api.max_block_number().await },
+            "read finalized MessageQueue max block number",
+            |api| async move { api.finalized_max_block_number().await },
         )
         .await?;
         let max_block_distance = rpc::retry_eth(
@@ -577,35 +602,40 @@ impl MerkleRootRelayer {
             |api| async move { api.max_block_distance().await },
         )
         .await?;
-        let last_block_hash = self.api_provider.client().latest_finalized_block().await?;
-        let last_block = self
-            .api_provider
-            .client()
-            .block_hash_to_number(last_block_hash)
-            .await?;
-        let max_block_number_in_storage = self.max_finalized_merkle_root_block();
-
-        log::info!("Merkle root relayer {relayer_id}: latest finalized block is #{last_block}, max block number in Ethereum MessageQueue contract is #{max_block_number} (MAX_BLOCK_DISTANCE={max_block_distance})");
-        if let Some(max_stored) = max_block_number_in_storage {
-            log::info!(
-                "Merkle root relayer {relayer_id}: max finalized merkle root in storage is at block #{max_stored}"
-            );
-        } else {
-            log::info!("Merkle root relayer {relayer_id}: no finalized merkle roots in storage");
-        }
-
-        self.last_submitted_block = Some(max_block_number_in_storage.unwrap_or(max_block_number));
-        Ok(())
-    }
-
-    fn max_finalized_merkle_root_block(&self) -> Option<u32> {
-        self.roots
+        let client = self.api_provider.client();
+        let last_block_hash = client.latest_finalized_block().await?;
+        let last_block = client.block_hash_to_number(last_block_hash).await?;
+        let max_block_number_in_storage = self
+            .roots
             .values()
             .filter(|root| {
                 root.proof.is_some() && matches!(root.status, MerkleRootStatus::Finalized)
             })
             .map(|root| root.block_number)
-            .max()
+            .max();
+        let confirmed_block = max_block_number;
+        let confirmed_block_hash = client.block_number_to_hash(confirmed_block).await?;
+        let confirmed_timestamp_ms = client.fetch_timestamp(confirmed_block_hash).await?;
+
+        log::info!("Merkle root relayer {relayer_id}: latest finalized block is #{last_block}, max block number in Ethereum MessageQueue contract is #{max_block_number} (MAX_BLOCK_DISTANCE={max_block_distance})");
+        if let Some(max_stored) = max_block_number_in_storage {
+            if max_stored > confirmed_block {
+                log::warn!(
+                    "Merkle root relayer {relayer_id}: ignoring local finalized root at block #{max_stored} because Ethereum MessageQueue is only at block #{confirmed_block}"
+                );
+            } else {
+                log::info!(
+                    "Merkle root relayer {relayer_id}: max finalized merkle root in storage is at block #{max_stored}"
+                );
+            }
+        } else {
+            log::info!("Merkle root relayer {relayer_id}: no finalized merkle roots in storage");
+        }
+
+        self.last_confirmed_block = Some(confirmed_block);
+        self.last_confirmed_timestamp_ms = Some(confirmed_timestamp_ms);
+        self.max_block_distance = Some(max_block_distance);
+        Ok(())
     }
 
     async fn supervise_contract_state(
@@ -626,12 +656,22 @@ impl MerkleRootRelayer {
         let block = self.signed_block_after(last_block).await?;
         let block_number = block.number();
         let block_hash = block.hash();
-        let (queue_id, merkle_root) = client.fetch_queue_merkle_root(block_hash).await?;
+        let block_timestamp_ms = client.fetch_timestamp(block_hash).await?;
+        let (_queue_id, merkle_root) = client
+            .fetch_authenticated_queue_merkle_root(block_hash)
+            .await?;
+        if self.last_confirmed_timestamp_ms.is_none() {
+            if let Some(last_confirmed_block) = self.last_confirmed_block {
+                let hash = client.block_number_to_hash(last_confirmed_block).await?;
+                self.last_confirmed_timestamp_ms = Some(client.fetch_timestamp(hash).await?);
+            }
+        }
 
         let threshold = critical_timeout_reached(
             self.options.critical_threshold,
-            self.last_submitted_block,
-            block_number,
+            self.last_confirmed_block,
+            self.last_confirmed_timestamp_ms,
+            block_timestamp_ms,
         );
 
         if merkle_root == H256::zero() && threshold.is_none() {
@@ -642,7 +682,7 @@ impl MerkleRootRelayer {
         }
 
         let eth_root = match self
-            .read_chainhead_merkle_root(eth_api, block_number)
+            .read_finalized_merkle_root(eth_api, block_number)
             .await?
         {
             EthereumRootRead::Fetched(root) => root,
@@ -654,33 +694,26 @@ impl MerkleRootRelayer {
         };
         if eth_root == Some(merkle_root) {
             log::info!(
-                "Merkle root relayer {relayer_id} supervisor: Ethereum already has merkle root {merkle_root} for block #{block_number}"
+                "Merkle root relayer {relayer_id} supervisor: finalized Ethereum state already has merkle root {merkle_root} for block #{block_number}"
             );
-            self.storage
-                .submitted_merkle_root(block_number, merkle_root)
-                .await;
+            if self
+                .last_confirmed_block
+                .is_none_or(|confirmed| block_number >= confirmed)
+            {
+                self.last_confirmed_block = Some(block_number);
+                self.last_confirmed_timestamp_ms = Some(block_timestamp_ms);
+            }
             return Ok(());
         }
 
-        if self
-            .storage
-            .is_merkle_root_submitted(block_number, merkle_root)
-            .await
-        {
-            log::info!(
-                "Merkle root relayer {relayer_id} supervisor: merkle root {merkle_root} for block #{block_number} was already submitted and is waiting for Ethereum confirmations"
-            );
-            return Ok(());
-        }
-
-        let Some((last_submitted_block, threshold)) = threshold else {
+        let Some((last_confirmed_block, threshold)) = threshold else {
             log::debug!(
                 "Merkle root relayer {relayer_id} supervisor: critical threshold is not reached for block #{block_number}, skipping forced proof generation"
             );
             return Ok(());
         };
         log::warn!(
-            "Merkle root relayer {relayer_id} supervisor: last submitted block {last_submitted_block} is older than supervised block number {block_number} by at least {threshold}, forcing proof generation"
+            "Merkle root relayer {relayer_id} supervisor: last confirmed block {last_confirmed_block} is older than supervised block number {block_number} by at least {threshold:?}, forcing proof generation"
         );
 
         if merkle_root == H256::zero() {
@@ -697,28 +730,32 @@ impl MerkleRootRelayer {
             );
         }
 
-        self.try_proof_merkle_root(
-            prover,
-            authority_set_sync,
-            block,
-            Batch::No,
-            Priority::No,
-            ForceGeneration::Yes,
-        )
-        .await?;
-        log::info!(
-            "Merkle root relayer {relayer_id} supervisor: proof request scheduled for queue #{queue_id}, merkle root {merkle_root} at block #{block_number}"
-        );
+        if let Some((selected_queue_id, selected_merkle_root)) = self
+            .try_proof_merkle_root(
+                prover,
+                authority_set_sync,
+                block,
+                ProofTarget::SignedAnchor,
+                Batch::No,
+                Priority::No,
+                ForceGeneration::Yes,
+            )
+            .await?
+        {
+            log::info!(
+                "Merkle root relayer {relayer_id} supervisor: proof request selected queue #{selected_queue_id}, merkle root {selected_merkle_root} from supervised block #{block_number}"
+            );
+        }
         Ok(())
     }
 
-    async fn read_chainhead_merkle_root(
+    async fn read_finalized_merkle_root(
         &self,
         eth_api: &mut EthApi,
         block_number: u32,
     ) -> anyhow::Result<EthereumRootRead> {
         let relayer_id = &self.options.relayer_id;
-        match eth_api.read_chainhead_merkle_root(block_number).await {
+        match eth_api.read_finalized_merkle_root(block_number).await {
             Ok(root) => return Ok(EthereumRootRead::Fetched(root.map(H256::from))),
             Err(err) if rpc::classify_ethereum_error(&err) == rpc::RetryDecision::Retry => {
                 log::warn!(
@@ -740,7 +777,7 @@ impl MerkleRootRelayer {
         };
         *eth_api = reconnected;
 
-        match eth_api.read_chainhead_merkle_root(block_number).await {
+        match eth_api.read_finalized_merkle_root(block_number).await {
             Ok(root) => Ok(EthereumRootRead::Fetched(root.map(H256::from))),
             Err(err) if rpc::classify_ethereum_error(&err) == rpc::RetryDecision::Retry => {
                 log::warn!(
@@ -767,6 +804,27 @@ impl MerkleRootRelayer {
             self.options.relayer_id
         );
         GearBlock::from_justification(&api, justification).await
+    }
+
+    async fn signed_block_at_or_before(&self, max_block_number: u32) -> anyhow::Result<GearBlock> {
+        let mut requested = max_block_number;
+        for _ in 0..8 {
+            let block = self.signed_block_after(requested).await?;
+            if block.number() <= max_block_number {
+                return Ok(block);
+            }
+
+            let overshoot = block.number() - max_block_number;
+            let next = requested.saturating_sub(overshoot.max(1));
+            if next == requested {
+                break;
+            }
+            requested = next;
+        }
+
+        Err(anyhow::anyhow!(
+            "Unable to find a GRANDPA-signed block at or before contract limit #{max_block_number}"
+        ))
     }
 
     async fn run_inner(
@@ -846,7 +904,7 @@ impl MerkleRootRelayer {
                 // update metrics
                 self.metrics.total_merkle_roots.set(self.roots.len() as i64);
                 self.metrics.total_waiting_for_authority_set_sync.set(self.waiting_for_authority_set_sync.values().map(|v| v.len()).sum::<usize>() as i64);
-                self.metrics.last_submitted_block.set(self.last_submitted_block.unwrap_or(0) as i64);
+                self.metrics.last_confirmed_block.set(self.last_confirmed_block.unwrap_or(0) as i64);
                 self.metrics.first_pending_timestamp.set(self.first_pending_timestamp.map(|t| t.elapsed().as_secs() as i64).unwrap_or(0));
                 self.metrics.batch_size.set(self.merkle_root_batch.len() as i64);
                 if let Some(first) = self.first_pending_timestamp {
@@ -909,20 +967,30 @@ impl MerkleRootRelayer {
                                 block_number,
                                 response
                             } => {
-                                // filter by `proof.is_some()` since some old storage entries do not contain proofs in them.
-                                if let Some((&(_, merkle_root), root)) = self.roots.iter().find(|(_, r)| r.block_number == block_number || r.proof.as_ref().filter(|proof| proof.block_number == block_number).is_some()).filter(|(_, r)| r.proof.is_some()) {
+                                // Exact requests may only use a proof whose target block and root
+                                // match the stored root metadata. Batched proofs target a later
+                                // anchor and must fall through to exact proof generation.
+                                if let Some((&(_, merkle_root), root)) = self.roots.iter().find(
+                                    |((root_block_number, root_merkle_root), root)| {
+                                        *root_block_number == block_number
+                                            && root.proof.as_ref().is_some_and(|proof| {
+                                                proof.block_number == *root_block_number
+                                                    && H256::from(proof.merkle_root)
+                                                        == *root_merkle_root
+                                            })
+                                    },
+                                ) {
                                     if let MerkleRootStatus::Finalized = root.status {
                                         let proof = root.proof.as_ref().expect("proof availability is checked above");
-                                        let Ok(_) = response.send(MerkleRootsResponse::MerkleRootProof {
+                                        if response.send(MerkleRootsResponse::MerkleRootProof {
                                             proof: proof.proof.clone(),
                                             proof_block_number: proof.block_number,
                                             block_number: root.block_number,
                                             block_hash: root.block_hash,
                                             merkle_root,
-                                        }) else {
-                                            log::error!("Merkle root relayer {}: HTTP response send failed", self.options.relayer_id);
-                                            return Ok(false);
-                                        };
+                                        }).is_err() {
+                                            log::debug!("Merkle root relayer {}: HTTP client disconnected before response", self.options.relayer_id);
+                                        }
                                         return Ok(true);
                                     }
                                 }
@@ -932,24 +1000,44 @@ impl MerkleRootRelayer {
                                 let block = api.get_block_at(block_hash).await?;
                                 let block = GearBlock::from_subxt_block(&client, block).await?;
 
-                                match self.try_proof_merkle_root(prover, authority_set_sync, block, Batch::No, Priority::Yes, ForceGeneration::Yes).await {
+                                match self.try_proof_merkle_root(prover, authority_set_sync, block, ProofTarget::Exact, Batch::No, Priority::Yes, ForceGeneration::Yes).await {
                                     Ok(Some((_, merkle_root))) => {
-                                        if let Some(r) = self.roots.get_mut(&(block_number, merkle_root)) { r.http_requests.push(response) } else {
-                                            response.send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number }).ok();
+                                        if let Some(root) =
+                                            self.roots.get_mut(&(block_number, merkle_root))
+                                        {
+                                            if root.http_requests.len()
+                                                >= MAX_PENDING_HTTP_REQUESTS_PER_ROOT
+                                            {
+                                                response
+                                                    .send(MerkleRootsResponse::Failed {
+                                                        message: format!(
+                                                            "Too many pending proof requests for block #{block_number}"
+                                                        ),
+                                                    })
+                                                    .ok();
+                                            } else {
+                                                root.http_requests.push(response);
+                                            }
+                                        } else {
+                                            response
+                                                .send(
+                                                    MerkleRootsResponse::NoMerkleRootOnBlock {
+                                                        block_number,
+                                                    },
+                                                )
+                                                .ok();
                                         }
                                     }
 
                                     Ok(None) => {
-                                        let Ok(_) = response.send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number }) else {
-                                            log::error!("Merkle root relayer {}: HTTP response send failed", self.options.relayer_id);
-                                            return Ok(false);
-                                        };
+                                        if response.send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number }).is_err() {
+                                            log::debug!("Merkle root relayer {}: HTTP client disconnected before response", self.options.relayer_id);
+                                        }
                                     }
                                     Err(err) => {
-                                        let Ok(_) = response.send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number }) else {
-                                            log::error!("Merkle root relayer {}: HTTP response send failed", self.options.relayer_id);
-                                            return Ok(false);
-                                        };
+                                        if response.send(MerkleRootsResponse::NoMerkleRootOnBlock { block_number }).is_err() {
+                                            log::debug!("Merkle root relayer {}: HTTP client disconnected before response", self.options.relayer_id);
+                                        }
                                         return Err(err);
                                     }
                                 }
@@ -971,20 +1059,8 @@ impl MerkleRootRelayer {
             block = blocks_rx.recv() => {
                 match block {
                     Ok(block) => {
-                        let mut force = ForceGeneration::No;
-                        let mut batch = Batch::Yes;
-                        let number = block.number();
-                        if let Some((last_submitted_block, threshold)) =
-                            critical_timeout_reached(
-                                self.options.critical_threshold,
-                                self.last_submitted_block,
-                                number,
-                            )
-                        {
-                            log::warn!("Merkle root relayer {}: last submitted block {last_submitted_block} is older than current block number {number} by at least {threshold}, forcing proof generation", self.options.relayer_id);
-                            force = ForceGeneration::Yes;
-                            batch = Batch::No;
-                        }
+                        let force = ForceGeneration::No;
+                        let batch = Batch::Yes;
 
 
                         if let Some(bridging_payment_address) = self.options.bridging_payment_address {
@@ -993,11 +1069,11 @@ impl MerkleRootRelayer {
                                 let pblock = GearBlock::from_subxt_block(&client, pblock).await?;
                                 log::info!("Merkle root relayer {}: priority bridging requested at block #{}, generating proof for merkle-root at block #{}", self.options.relayer_id, block.number(), pblock.number());
 
-                                self.try_proof_merkle_root(prover, authority_set_sync, pblock, Batch::Yes, Priority::Yes, ForceGeneration::Yes).await?;
+                                self.try_proof_merkle_root(prover, authority_set_sync, pblock, ProofTarget::SignedAnchor, Batch::Yes, Priority::Yes, ForceGeneration::Yes).await?;
                             }
                         }
 
-                        self.try_proof_merkle_root(prover, authority_set_sync, block, batch, Priority::No, force,).await?;
+                        self.try_proof_merkle_root(prover, authority_set_sync, block, ProofTarget::SignedAnchor, batch, Priority::No, force,).await?;
                     }
 
                     Err(RecvError::Lagged(n)) => {
@@ -1038,26 +1114,44 @@ impl MerkleRootRelayer {
                             self.options.relayer_id
                         );
 
-                        self.roots.entry((block_number, merkle_root))
-                            .and_modify(|merkle_root_entry| {
-                                merkle_root_entry.status = MerkleRootStatus::SubmitProof;
-                                merkle_root_entry.proof = Some(proof.clone());
-                                for rpc in merkle_root_entry.http_requests.drain(..) {
-                                    let Ok(_) = rpc.send(MerkleRootsResponse::MerkleRootProof {
-                                        proof: proof.proof.clone(),
-                                        proof_block_number: proof.block_number,
-                                        block_number,
-                                        block_hash: merkle_root_entry.block_hash,
-                                        merkle_root
-                                    }) else {
-                                        log::error!("Merkle root relayer {}: RPC response send failed", self.options.relayer_id);
-                                        continue;
-                                    };
-                                }
-                            });
+                        let root_key = (block_number, merkle_root);
+                        let local_proof_only = is_local_proof_only(&self.roots, root_key);
 
+                        let merkle_root_entry = self
+                            .roots
+                            .get_mut(&root_key)
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "Proven merkle root {merkle_root} for block #{block_number} not found in storage"
+                                )
+                            })?;
+                        merkle_root_entry.single_proof_in_flight = false;
+                        merkle_root_entry.proof = Some(proof.clone());
+                        if !local_proof_only {
+                            merkle_root_entry.status = MerkleRootStatus::SubmitProof;
+                        }
+                        for rpc in merkle_root_entry.http_requests.drain(..) {
+                            if rpc
+                                .send(MerkleRootsResponse::MerkleRootProof {
+                                    proof: proof.proof.clone(),
+                                    proof_block_number: proof.block_number,
+                                    block_number,
+                                    block_hash: merkle_root_entry.block_hash,
+                                    merkle_root,
+                                })
+                                .is_err()
+                            {
+                                log::error!(
+                                    "Merkle root relayer {}: RPC response send failed",
+                                    self.options.relayer_id
+                                );
+                            }
+                        }
+                        self.storage.save(&self.roots).await?;
 
-                        if !submitter.submit_merkle_root(block_number, merkle_root, proof) {
+                        if !local_proof_only
+                            && !submitter.submit_merkle_root(block_number, merkle_root, proof)
+                        {
                             log::warn!(
                                 "Merkle root relayer {}: proof submitter connection closed, exiting",
                                 self.options.relayer_id
@@ -1065,55 +1159,24 @@ impl MerkleRootRelayer {
                             return Ok(false);
                         }
                     }
-
                     prover::Response::Batched {
                         block_number,
                         merkle_root,
                         proof,
-                        batch_roots
+                        batch_roots,
                     } => {
                         log::info!("Merkle root relayer {}: finality proof for block #{block_number} with merkle root {merkle_root} received (will apply to {} blocks)", self.options.relayer_id, batch_roots.len());
 
-                        for (block_number, merkle_root) in batch_roots {
-                            log::debug!("Merkle root relayer {}: merkle-root {merkle_root} finalized as part of batch for block #{block_number}", self.options.relayer_id);
-                            self.roots.entry((block_number, merkle_root))
-                                .and_modify(|merkle_root_entry| {
-                                    merkle_root_entry.status = MerkleRootStatus::Finalized;
-                                    merkle_root_entry.proof = Some(proof.clone());
-                                    for rpc in merkle_root_entry.http_requests.drain(..) {
-                                        let Ok(_) = rpc.send(MerkleRootsResponse::MerkleRootProof {
-                                            proof: proof.proof.clone(),
-                                            proof_block_number: proof.block_number,
-                                            block_number,
-                                            block_hash: merkle_root_entry.block_hash,
-                                            merkle_root,
-                                        }) else {
-                                            log::error!("Merkle root relayer {}: RPC response send failed", self.options.relayer_id);
-                                            continue;
-                                        };
-                                        log::info!("Merkle root relayer {}: send HTTP response for merkle root {merkle_root} at block #{block_number}", self.options.relayer_id);
-                                    }
-                            });
-
+                        if let Some(merkle_root_entry) =
+                            self.roots.get_mut(&(block_number, merkle_root))
+                        {
+                            merkle_root_entry.stage_batched_submission(proof.clone(), batch_roots);
+                        } else {
+                            return Err(anyhow::anyhow!(
+                                "Selected batched merkle root {merkle_root} for block #{block_number} not found in storage"
+                            ));
                         }
-
-                        self.roots.entry((block_number, merkle_root))
-                            .and_modify(|merkle_root_entry| {
-                                merkle_root_entry.status = MerkleRootStatus::SubmitProof;
-                                merkle_root_entry.proof = Some(proof.clone());
-                                for rpc in merkle_root_entry.http_requests.drain(..) {
-                                    let Ok(_) = rpc.send(MerkleRootsResponse::MerkleRootProof {
-                                        proof: proof.proof.clone(),
-                                        proof_block_number: proof.block_number,
-                                        block_number,
-                                        block_hash: merkle_root_entry.block_hash,
-                                        merkle_root,
-                                    }) else {
-                                        log::error!("Merkle root relayer {}: RPC response send failed", self.options.relayer_id);
-                                        continue;
-                                    };
-                                }
-                            });
+                        self.storage.save(&self.roots).await?;
 
                         if !submitter.submit_merkle_root(block_number, merkle_root, proof) {
                             log::warn!(
@@ -1141,22 +1204,82 @@ impl MerkleRootRelayer {
                     authority_set_sync::Response::AuthoritySetSynced(id, block) => {
                         self.storage.authority_set_processed(block).await;
 
-                        let Some(mut to_submit) = self.waiting_for_authority_set_sync.remove(&id) else {
-                            log::warn!("Merkle root relayer {}: no blocks to sync for authority set #{id}", self.options.relayer_id);
-                            return Ok(true)
-                        };
+                        let queued_blocks = self
+                            .waiting_for_authority_set_sync
+                            .remove(&id)
+                            .map_or(0, |blocks| blocks.len());
+                        let inner_proof = self
+                            .storage
+                            .proofs
+                            .get_proof_for_authority_set_id(id)
+                            .await?;
+                        let pending = self
+                            .roots
+                            .iter()
+                            .filter_map(|(&(block_number, merkle_root), root)| {
+                                if matches!(
+                                    root.status,
+                                    MerkleRootStatus::WaitForAuthoritySetSync(waiting_id, _)
+                                        if waiting_id == id
+                                ) {
+                                    Some((
+                                        block_number,
+                                        root.block_hash,
+                                        merkle_root,
+                                        root.queue_id,
+                                        root.block_inclusion_proof.clone(),
+                                        root.batch,
+                                    ))
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>();
 
-                        log::info!("Merkle root relayer {}: authority set #{id} is synced, submitting {} blocks", self.options.relayer_id, to_submit.len());
-                        while let Some(block) = to_submit.pop() {
-                            self.try_proof_merkle_root(prover, authority_set_sync, block, Batch::Yes, Priority::No, ForceGeneration::Yes).await?;
+                        log::info!(
+                            "Merkle root relayer {}: authority set #{id} is synced, releasing {} roots from {} queued blocks",
+                            self.options.relayer_id,
+                            pending.len(),
+                            queued_blocks
+                        );
+                        for (
+                            block_number,
+                            block_hash,
+                            merkle_root,
+                            queue_id,
+                            block_inclusion_proof,
+                            batch,
+                        ) in pending
+                        {
+                            let root = self
+                                .roots
+                                .get_mut(&(block_number, merkle_root))
+                                .expect("pending root was collected from storage");
+                            root.status = MerkleRootStatus::GenerateProof;
+                            root.single_proof_in_flight = !batch;
+                            if !prover.prove(
+                                block_number,
+                                block_hash,
+                                merkle_root,
+                                inner_proof.clone(),
+                                queue_id,
+                                batch,
+                                block_inclusion_proof,
+                            ) {
+                                return Err(anyhow::anyhow!(
+                                    "Merkle root relayer {}: prover connection closed while releasing authority set #{id}",
+                                    self.options.relayer_id
+                                ));
+                            }
                         }
+                        self.storage.save(&self.roots).await?;
 
                         if let CriticalThreshold::AuthoritySetChange = self.options.critical_threshold {
                             let block_hash = client.search_for_authority_set_block(id).await?;
                             let block = client.get_block_at(block_hash).await?;
                             let block = GearBlock::from_subxt_block(&client, block).await?;
                             log::info!("Merkle root relayer {}: critical threshold is set to AuthoritySetChange, forcing proof at block #{}", self.options.relayer_id, block.number());
-                            self.try_proof_merkle_root(prover, authority_set_sync, block, Batch::No, Priority::No, ForceGeneration::Yes).await?;
+                            self.try_proof_merkle_root(prover, authority_set_sync, block, ProofTarget::SignedAnchor, Batch::No, Priority::No, ForceGeneration::Yes).await?;
 
                         }
                     }
@@ -1172,13 +1295,31 @@ impl MerkleRootRelayer {
                     return Ok(false);
                 };
 
-                self.finalize_merkle_root(response).await?;
+                let continuation_blocks = self.finalize_merkle_root(response).await?;
+                for block_number in continuation_blocks {
+                    let block_hash = client.block_number_to_hash(block_number).await?;
+                    let block = client.get_block_at(block_hash).await?;
+                    let block = GearBlock::from_subxt_block(&client, block).await?;
+                    self.try_proof_merkle_root(
+                        prover,
+                        authority_set_sync,
+                        block,
+                        ProofTarget::SignedAnchor,
+                        Batch::No,
+                        Priority::No,
+                        ForceGeneration::Yes,
+                    )
+                    .await?;
+                }
             }
         }
         Ok(true)
     }
 
-    async fn finalize_merkle_root(&mut self, response: submitter::Response) -> anyhow::Result<()> {
+    async fn finalize_merkle_root(
+        &mut self,
+        response: submitter::Response,
+    ) -> anyhow::Result<Vec<u32>> {
         if let Some(era) = response.era {
             log::info!(
                 "Merkle root relayer {}: era #{} merkle root {} for block #{} is finalized with status: {:?}",
@@ -1189,16 +1330,71 @@ impl MerkleRootRelayer {
                 response.status,
             );
         }
-        if let Some(merkle_root) = self
+        let root_key = (response.merkle_root_block, response.merkle_root);
+        let covered_roots = self
             .roots
-            .get_mut(&(response.merkle_root_block, response.merkle_root))
-        {
+            .get(&root_key)
+            .map(|root| root.covered_roots.clone())
+            .unwrap_or_default();
+        let is_submitted = matches!(&response.status, submitter::ResponseStatus::Submitted);
+        let mut submission_failure = None;
+
+        let confirmation_timestamp_ms = if is_submitted {
+            match self
+                .roots
+                .get(&root_key)
+                .filter(|root| {
+                    self.last_confirmed_block
+                        .is_none_or(|last| root.block_number >= last)
+                })
+                .map(|root| root.block_hash)
+            {
+                Some(block_hash) => {
+                    match self.api_provider.client().fetch_timestamp(block_hash).await {
+                        Ok(timestamp) => Some(timestamp),
+                        Err(err) => {
+                            log::warn!(
+                                "Merkle root relayer {}: failed to refresh confirmed block timestamp: {err}",
+                                self.options.relayer_id
+                            );
+                            None
+                        }
+                    }
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+
+        if let Some(merkle_root) = self.roots.get_mut(&root_key) {
             match response.status {
                 submitter::ResponseStatus::Submitted => {
-                    self.last_submitted_block = match self.last_submitted_block {
-                        Some(n) if merkle_root.block_number > n => Some(merkle_root.block_number),
-                        _ => Some(merkle_root.block_number),
-                    };
+                    let proof = merkle_root
+                        .proof
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("Finalized root has no proof"))?;
+                    if proof.block_number != merkle_root.block_number
+                        || H256::from(proof.merkle_root) != response.merkle_root
+                    {
+                        return Err(anyhow::anyhow!(
+                            "Finalized proof metadata does not match merkle root {} at block #{}",
+                            response.merkle_root,
+                            response.merkle_root_block
+                        ));
+                    }
+
+                    if self
+                        .last_confirmed_block
+                        .is_none_or(|last| merkle_root.block_number >= last)
+                    {
+                        self.last_confirmed_block = Some(
+                            self.last_confirmed_block
+                                .unwrap_or(0)
+                                .max(merkle_root.block_number),
+                        );
+                        self.last_confirmed_timestamp_ms = confirmation_timestamp_ms;
+                    }
                     merkle_root.status = MerkleRootStatus::Finalized;
                     log::info!(
                         "Merkle root relayer {}: merkle root {} for block #{} is finalized",
@@ -1206,29 +1402,28 @@ impl MerkleRootRelayer {
                         response.merkle_root,
                         response.merkle_root_block
                     );
-                    let proof = merkle_root
-                        .proof
-                        .as_ref()
-                        .expect("proof should be available if root is finalized");
                     for req in merkle_root.http_requests.drain(..) {
-                        let Ok(_) = req.send(MerkleRootsResponse::MerkleRootProof {
-                            proof: proof.proof.clone(),
-                            proof_block_number: proof.block_number,
-                            block_number: merkle_root.block_number,
-                            block_hash: merkle_root.block_hash,
-                            merkle_root: response.merkle_root,
-                        }) else {
-                            log::error!(
-                                "Merkle root relayer {}: HTTP response send failed",
+                        if req
+                            .send(MerkleRootsResponse::MerkleRootProof {
+                                proof: proof.proof.clone(),
+                                proof_block_number: proof.block_number,
+                                block_number: merkle_root.block_number,
+                                block_hash: merkle_root.block_hash,
+                                merkle_root: response.merkle_root,
+                            })
+                            .is_err()
+                        {
+                            log::debug!(
+                                "Merkle root relayer {}: HTTP client disconnected before response",
                                 self.options.relayer_id
                             );
-                            return Err(anyhow::anyhow!("HTTP response send failed"));
-                        };
+                        }
                     }
                 }
 
                 submitter::ResponseStatus::Failed(err) => {
                     merkle_root.status = MerkleRootStatus::Failed(err.to_string());
+                    submission_failure = Some(err.clone());
                     log::error!(
                         "Merkle root relayer {}: failed to finalize merkle root {} for block #{}: {}",
                         self.options.relayer_id,
@@ -1237,28 +1432,46 @@ impl MerkleRootRelayer {
                         err
                     );
                     for req in merkle_root.http_requests.drain(..) {
-                        let Ok(_) = req.send(MerkleRootsResponse::Failed {
-                            message: err.clone(),
-                        }) else {
-                            log::error!(
-                                "Merkle root relayer {}: HTTP response send failed",
+                        if req
+                            .send(MerkleRootsResponse::Failed {
+                                message: err.clone(),
+                            })
+                            .is_err()
+                        {
+                            log::debug!(
+                                "Merkle root relayer {}: HTTP client disconnected before response",
                                 self.options.relayer_id
                             );
-                            return Err(anyhow::anyhow!("HTTP response send failed"));
-                        };
+                        }
                     }
                 }
             }
         } else {
-            log::warn!(
-                "Merkle root relayer {}: merkle root {} for block #{} not found in storage",
-                self.options.relayer_id,
+            return Err(anyhow::anyhow!(
+                "Merkle root {} for block #{} not found in storage while finalizing",
                 response.merkle_root,
                 response.merkle_root_block
-            );
+            ));
         }
 
-        Ok(())
+        let continuation_blocks = if is_submitted {
+            let (covered_source_blocks, continuation_blocks) =
+                finalize_confirmed_roots(&mut self.roots, root_key, &covered_roots);
+            for block_number in covered_source_blocks {
+                self.storage.merkle_root_processed(block_number).await;
+            }
+            continuation_blocks
+        } else {
+            Vec::new()
+        };
+        self.storage.save(&self.roots).await?;
+        if let Some(err) = submission_failure {
+            return Err(anyhow::anyhow!(
+                "Merkle root submission failed for block #{}: {err}",
+                response.merkle_root_block
+            ));
+        }
+        Ok(continuation_blocks)
     }
 
     /// Attempt to create proof for merkle root of `block`. If authority set that signed `block`
@@ -1269,6 +1482,7 @@ impl MerkleRootRelayer {
         prover: &mut FinalityProverIo,
         authority_set_sync: &mut AuthoritySetSyncIo,
         block: GearBlock,
+        proof_target: ProofTarget,
         batch: Batch,
         priority: Priority,
         force_generation: ForceGeneration,
@@ -1276,9 +1490,10 @@ impl MerkleRootRelayer {
         let api = self.api_provider.client();
 
         let (queue_id, merkle_root) = if force_generation == ForceGeneration::Yes {
-            api.fetch_queue_merkle_root(block.hash()).await?
+            api.fetch_authenticated_queue_merkle_root(block.hash())
+                .await?
         } else {
-            match storage::queue_merkle_root_changed(&block) {
+            let event_state = match storage::queue_merkle_root_changed(&block) {
                 Some(merkle_root) => merkle_root,
                 None => {
                     log::trace!(
@@ -1287,14 +1502,24 @@ impl MerkleRootRelayer {
                     );
                     return Ok(None);
                 }
+            };
+            let authenticated_state = api
+                .fetch_authenticated_queue_merkle_root(block.hash())
+                .await?;
+            if event_state != authenticated_state {
+                return Err(anyhow::anyhow!(
+                    "Queue event at block #{} does not match authenticated Vara state",
+                    block.number()
+                ));
             }
+            event_state
         };
 
         // finality proof might be available already which happens in the case of
         // merkle roots being inserted there before authority set is synced. Otherwise
         // immediately fetch finality proof.
 
-        let block_inclusion_proof = match self
+        let mut block_inclusion_proof = match self
             .roots
             .get(&(block.number(), merkle_root))
             .map(|root| root.block_inclusion_proof.clone())
@@ -1307,55 +1532,272 @@ impl MerkleRootRelayer {
         };
 
         let nonces = storage::message_queued_events_of(&block).collect::<Vec<_>>();
+        let source_block_number = block.number();
+        let source_block_hash = block.hash();
+        let source_queue_id = queue_id;
+        let source_merkle_root = merkle_root;
+        let source_authority_set_id = api
+            .fetch_authenticated_signed_by_authority_set_id(source_block_hash)
+            .await?;
 
-        if self
-            .storage
-            .is_merkle_root_submitted(block.number(), merkle_root)
-            .await
-            && force_generation == ForceGeneration::No
-        {
-            log::debug!(
-                "Merkle root relayer {}: skipping merkle root {} for block #{} as there were no new messages",
-                self.options.relayer_id,
-                merkle_root,
-                block.number()
-            );
-            self.storage.merkle_root_processed(block.number()).await;
-            if let Err(err) = self.storage.save(&self.roots).await {
-                log::error!(
-                    "Merkle root relayer {}: failed to save block storage state: {err:?}",
-                    self.options.relayer_id
+        let (
+            block_number,
+            block_hash,
+            queue_id,
+            merkle_root,
+            proof_authority_set_id,
+            source_covered,
+        ) = match proof_target {
+            ProofTarget::Exact => (
+                source_block_number,
+                source_block_hash,
+                source_queue_id,
+                source_merkle_root,
+                block_inclusion_proof.required_authority_set_id,
+                true,
+            ),
+            ProofTarget::SignedAnchor => {
+                let signed_target_block_number = block_inclusion_proof.block_number;
+                let contract_limit = contract_anchor_limit(
+                    self.last_confirmed_block,
+                    self.max_block_distance,
+                    signed_target_block_number,
                 );
+                if contract_limit < signed_target_block_number {
+                    let anchor = self.signed_block_at_or_before(contract_limit).await?;
+                    block_inclusion_proof = anchor.inclusion_proof(&api).await?;
+                    let target_block_number = block_inclusion_proof.block_number;
+                    let target_block_hash = block_inclusion_proof.block_hash;
+                    let target_authority_set_id = block_inclusion_proof.required_authority_set_id;
+                    let (target_queue_id, target_merkle_root) = api
+                        .fetch_authenticated_queue_merkle_root(target_block_hash)
+                        .await?;
+                    if self
+                        .last_confirmed_block
+                        .is_some_and(|confirmed| target_block_number <= confirmed)
+                    {
+                        return Err(anyhow::anyhow!(
+                            "Contract-gap anchor #{target_block_number} does not advance confirmed block"
+                        ));
+                    }
+                    log::warn!(
+                        "Merkle root relayer {}: signed target #{} exceeds contract limit #{}; scheduling intermediate anchor #{}",
+                        self.options.relayer_id,
+                        signed_target_block_number,
+                        contract_limit,
+                        target_block_number,
+                    );
+                    (
+                        target_block_number,
+                        target_block_hash,
+                        target_queue_id,
+                        target_merkle_root,
+                        target_authority_set_id,
+                        false,
+                    )
+                } else {
+                    let target_block_number = block_inclusion_proof.block_number;
+                    let target_block_hash = block_inclusion_proof.block_hash;
+                    let target_authority_set_id = block_inclusion_proof.required_authority_set_id;
+                    let (target_queue_id, target_merkle_root) = api
+                        .fetch_authenticated_queue_merkle_root(target_block_hash)
+                        .await?;
+
+                    if anchor_covers_source(
+                        source_block_number,
+                        target_block_number,
+                        source_authority_set_id,
+                        target_authority_set_id,
+                        source_queue_id,
+                        target_queue_id,
+                    ) {
+                        log::debug!(
+                            "Merkle root relayer {}: rebasing source block #{} queue #{} onto signed anchor block #{} queue #{}",
+                            self.options.relayer_id,
+                            source_block_number,
+                            source_queue_id,
+                            target_block_number,
+                            target_queue_id,
+                        );
+                        (
+                            target_block_number,
+                            target_block_hash,
+                            target_queue_id,
+                            target_merkle_root,
+                            target_authority_set_id,
+                            true,
+                        )
+                    } else {
+                        log::warn!(
+                            "Merkle root relayer {}: signed anchor mismatch for source block #{} (authority set #{}, queue #{}): anchor block #{} has authority set #{}, queue #{}; retaining exact source target",
+                            self.options.relayer_id,
+                            source_block_number,
+                            source_authority_set_id,
+                            source_queue_id,
+                            target_block_number,
+                            target_authority_set_id,
+                            target_queue_id,
+                        );
+                        (
+                            source_block_number,
+                            source_block_hash,
+                            source_queue_id,
+                            source_merkle_root,
+                            block_inclusion_proof.required_authority_set_id,
+                            true,
+                        )
+                    }
+                }
             }
-            return Ok(None);
+        };
+        let proof_target_block_hash = block_inclusion_proof.block_hash;
+        let (chain_queue_id, chain_merkle_root) = api
+            .fetch_authenticated_queue_merkle_root(block_hash)
+            .await?;
+        if chain_queue_id != queue_id || chain_merkle_root != merkle_root {
+            return Err(anyhow::anyhow!(
+                "Selected proof target #{block_number} does not match Vara queue state"
+            ));
         }
 
-        let block_hash_for_authority = block.hash();
-        let signed_by_authority_set_id = rpc::retry_gear(
-            &mut self.api_provider,
-            "merkle root signed authority set id",
-            move |api| async move {
-                api.signed_by_authority_set_id(block_hash_for_authority)
-                    .await
-            },
-        )
-        .await?;
+        let selected_key = (block_number, merkle_root);
+        let selected_state = self.roots.get(&selected_key).and_then(|root| {
+            if matches!(root.status, MerkleRootStatus::Finalized)
+                && self
+                    .last_confirmed_block
+                    .is_some_and(|confirmed| block_number <= confirmed)
+                && root.proof.as_ref().is_some_and(|proof| {
+                    proof.block_number == block_number
+                        && H256::from(proof.merkle_root) == merkle_root
+                })
+            {
+                Some(true)
+            } else if matches!(
+                root.status,
+                MerkleRootStatus::WaitForAuthoritySetSync(_, _)
+                    | MerkleRootStatus::GenerateProof
+                    | MerkleRootStatus::SubmitProof
+                    | MerkleRootStatus::Finalized
+            ) {
+                Some(false)
+            } else {
+                None
+            }
+        });
 
-        let block_number = block.number();
+        if let Some(is_finalized) = selected_state {
+            if is_finalized {
+                if source_covered {
+                    self.storage
+                        .merkle_root_processed(source_block_number)
+                        .await;
+                    self.storage.save(&self.roots).await?;
+                }
+                return Ok(Some((queue_id, merkle_root)));
+            }
+
+            let mut added_nonces = 0;
+            let root = self
+                .roots
+                .get_mut(&selected_key)
+                .expect("selected work was read from storage");
+            if source_covered {
+                if !root.covered_source_blocks.contains(&source_block_number) {
+                    root.covered_source_blocks.push(source_block_number);
+                }
+                for nonce in &nonces {
+                    if !root.message_nonces.contains(nonce) {
+                        root.message_nonces.push(*nonce);
+                        added_nonces += 1;
+                    }
+                }
+            } else if !root
+                .continuation_source_blocks
+                .contains(&source_block_number)
+            {
+                root.continuation_source_blocks.push(source_block_number);
+            }
+            let should_schedule_single =
+                matches!(batch, Batch::No) && root.promote_to_single_proof();
+
+            if let Some(index) = self.merkle_root_batch.iter().position(|pending| {
+                pending.block_number == block_number && pending.merkle_root == merkle_root
+            }) {
+                self.merkle_root_batch[index].nonces_count += added_nonces;
+                if matches!(priority, Priority::Yes) {
+                    self.merkle_root_batch[index].priority = true;
+                }
+                if matches!(batch, Batch::No) {
+                    let pending = self.merkle_root_batch.remove(index);
+                    if self.merkle_root_batch.is_empty() {
+                        self.first_pending_timestamp.take();
+                    }
+                    let inclusion_proof = self
+                        .roots
+                        .get(&selected_key)
+                        .expect("selected work was read from storage")
+                        .block_inclusion_proof
+                        .clone();
+                    if !prover.prove(
+                        pending.block_number,
+                        pending.block_hash,
+                        pending.merkle_root,
+                        pending.inner_proof,
+                        pending.queue_id,
+                        false,
+                        inclusion_proof,
+                    ) {
+                        return Err(anyhow::anyhow!("Prover connection closed"));
+                    }
+                }
+            } else if should_schedule_single {
+                let inner_proof = self
+                    .storage
+                    .proofs
+                    .get_proof_for_authority_set_id(proof_authority_set_id)
+                    .await?;
+                let inclusion_proof = self
+                    .roots
+                    .get(&selected_key)
+                    .expect("selected work was read from storage")
+                    .block_inclusion_proof
+                    .clone();
+                if !prover.prove(
+                    block_number,
+                    block_hash,
+                    merkle_root,
+                    inner_proof,
+                    queue_id,
+                    false,
+                    inclusion_proof,
+                ) {
+                    return Err(anyhow::anyhow!("Prover connection closed"));
+                }
+            }
+            self.storage.save(&self.roots).await?;
+            return Ok(Some((queue_id, merkle_root)));
+        }
+
+        let covered_source_blocks = source_covered
+            .then_some(source_block_number)
+            .into_iter()
+            .collect::<Vec<_>>();
+        let continuation_source_blocks = (!source_covered)
+            .then_some(source_block_number)
+            .into_iter()
+            .collect::<Vec<_>>();
+        let nonces = if source_covered { nonces } else { Vec::new() };
+
+        self.roots.remove(&selected_key);
 
         match self
             .storage
             .proofs
-            .get_proof_for_authority_set_id(signed_by_authority_set_id)
+            .get_proof_for_authority_set_id(proof_authority_set_id)
             .await
         {
             Ok(inner_proof) => {
-                let block_hash = block.hash();
                 let nonces_count = nonces.len();
-                self.last_submitted_block = match self.last_submitted_block {
-                    Some(n) if block.number() > n => Some(block.number()),
-                    _ => Some(block.number()),
-                };
                 self.roots
                     .entry((block_number, merkle_root))
                     .or_insert(MerkleRoot {
@@ -1367,6 +1809,11 @@ impl MerkleRootRelayer {
                         message_nonces: nonces,
                         http_requests: Vec::new(),
                         proof: None,
+                        covered_roots: Vec::new(),
+                        covered_source_blocks: covered_source_blocks.clone(),
+                        continuation_source_blocks: continuation_source_blocks.clone(),
+                        batch: matches!(batch, Batch::Yes),
+                        single_proof_in_flight: matches!(batch, Batch::No),
                         block_inclusion_proof: block_inclusion_proof.clone(),
                     });
                 if matches!(batch, Batch::Yes) {
@@ -1388,9 +1835,10 @@ impl MerkleRootRelayer {
                         queue_id,
                         priority: matches!(priority, Priority::Yes),
                     });
+                    self.storage.save(&self.roots).await?;
                     return Ok(Some((queue_id, merkle_root)));
                 }
-                log::info!("Merkle root relayer {}: proof for authority set #{signed_by_authority_set_id} is found, generating proof for merkle-root {merkle_root} at block #{block_number} with queue #{queue_id}", self.options.relayer_id);
+                log::info!("Merkle root relayer {}: proof for authority set #{proof_authority_set_id} is found, generating proof for merkle-root {merkle_root} at block #{block_number} with queue #{queue_id}", self.options.relayer_id);
                 if !prover.prove(
                     block_number,
                     block_hash,
@@ -1414,22 +1862,27 @@ impl MerkleRootRelayer {
                     "Merkle root relayer {}: delaying proof generation for merkle root {} at block #{} until authority set #{} is synced",
                     self.options.relayer_id,
                     merkle_root,
-                    block.number(),
-                    signed_by_authority_set_id,
+                    block_number,
+                    proof_authority_set_id,
                 );
                 self.roots
                     .entry((block_number, merkle_root))
                     .or_insert(MerkleRoot {
                         queue_id,
-                        block_number: block.number(),
-                        block_hash: block.hash(),
+                        block_number,
+                        block_hash,
                         status: MerkleRootStatus::WaitForAuthoritySetSync(
-                            signed_by_authority_set_id,
-                            block.number(),
+                            proof_authority_set_id,
+                            block_number,
                         ),
                         message_nonces: nonces,
                         http_requests: Vec::new(),
                         proof: None,
+                        covered_roots: Vec::new(),
+                        covered_source_blocks,
+                        continuation_source_blocks,
+                        batch: matches!(batch, Batch::Yes),
+                        single_proof_in_flight: false,
                         block_inclusion_proof,
                     });
 
@@ -1443,62 +1896,42 @@ impl MerkleRootRelayer {
                 // `Response::AuthoritySetSynced` so waiting blocks / parked HTTP requests
                 // are released once the set is available.
                 let force_sync = match self.storage.proofs.get_latest_authority_set_id().await {
-                    Some(latest) => signed_by_authority_set_id > latest,
+                    Some(latest) => proof_authority_set_id > latest,
                     None => true,
                 };
 
+                let sync_block = if block.hash() == proof_target_block_hash {
+                    block
+                } else {
+                    let target = api.get_block_at(proof_target_block_hash).await?;
+                    GearBlock::from_subxt_block(&api, target).await?
+                };
                 let waiting = self
                     .waiting_for_authority_set_sync
-                    .entry(signed_by_authority_set_id)
+                    .entry(proof_authority_set_id)
                     .or_default();
-                if waiting.is_empty() && force_sync && !authority_set_sync.send(block.clone()) {
+                if waiting.is_empty() && force_sync && !authority_set_sync.send(sync_block.clone())
+                {
                     return Err(anyhow::anyhow!(
                         "Merkle root relayer {}: authority set sync connection closed",
                         self.options.relayer_id
                     ));
                 }
-                waiting.push(block);
+                waiting.push(sync_block);
             }
 
             Err(err) => {
-                self.roots.insert(
-                    (block_number, merkle_root),
-                    MerkleRoot {
-                        queue_id,
-
-                        block_number: block.number(),
-                        block_hash: block.hash(),
-                        status: MerkleRootStatus::Failed(err.to_string()),
-                        message_nonces: nonces,
-                        http_requests: Vec::new(),
-                        proof: None,
-                        block_inclusion_proof,
-                    },
-                );
-
                 log::error!(
-                    "Merkle root relayer {}: failed to get proof for authority set id {signed_by_authority_set_id}: {err}",
+                    "Merkle root relayer {}: failed to get proof for authority set id {proof_authority_set_id}: {err}",
                     self.options.relayer_id
                 );
-                self.storage.merkle_root_processed(block_number).await;
-                if let Err(save_err) = self.storage.save(&self.roots).await {
-                    log::error!(
-                        "Merkle root relayer {}: failed to save block storage state: {save_err:?}",
-                        self.options.relayer_id
-                    );
-                }
+                self.storage.save(&self.roots).await?;
                 return Err(err.into());
             }
         }
 
-        // Mark root processed only after durable root state exists or the work is queued.
-        self.storage.merkle_root_processed(block_number).await;
-        if let Err(err) = self.storage.save(&self.roots).await {
-            log::error!(
-                "Merkle root relayer {}: failed to save block storage state: {err:?}",
-                self.options.relayer_id
-            );
-        }
+        // Source blocks stay replayable until a selected anchor confirms on Ethereum.
+        self.storage.save(&self.roots).await?;
 
         Ok(Some((queue_id, merkle_root)))
     }
@@ -1514,6 +1947,16 @@ pub struct MerkleRoot {
     pub http_requests: Vec<tokio::sync::oneshot::Sender<MerkleRootsResponse>>,
     #[serde(default)]
     pub proof: Option<FinalProof>,
+    #[serde(default)]
+    pub covered_roots: Vec<(u32, H256)>,
+    #[serde(default)]
+    pub covered_source_blocks: Vec<u32>,
+    #[serde(default = "default_batch")]
+    pub batch: bool,
+    #[serde(skip)]
+    pub single_proof_in_flight: bool,
+    #[serde(default)]
+    pub continuation_source_blocks: Vec<u32>,
     pub status: MerkleRootStatus,
     pub block_inclusion_proof: RawBlockInclusionProof,
 }
@@ -1527,10 +1970,77 @@ impl Clone for MerkleRoot {
             message_nonces: self.message_nonces.clone(),
             http_requests: Vec::new(),
             proof: self.proof.clone(),
+            covered_roots: self.covered_roots.clone(),
+            batch: self.batch,
+            single_proof_in_flight: self.single_proof_in_flight,
+            covered_source_blocks: self.covered_source_blocks.clone(),
+            continuation_source_blocks: self.continuation_source_blocks.clone(),
             status: self.status.clone(),
             block_inclusion_proof: self.block_inclusion_proof.clone(),
         }
     }
+}
+
+fn default_batch() -> bool {
+    true
+}
+
+impl MerkleRoot {
+    fn stage_batched_submission(&mut self, proof: FinalProof, covered_roots: Vec<(u32, H256)>) {
+        self.covered_roots = covered_roots;
+        self.status = MerkleRootStatus::SubmitProof;
+        self.proof = Some(proof);
+    }
+
+    fn promote_to_single_proof(&mut self) -> bool {
+        self.batch = false;
+        if matches!(
+            self.status,
+            MerkleRootStatus::GenerateProof | MerkleRootStatus::Finalized
+        ) && !self.single_proof_in_flight
+        {
+            self.single_proof_in_flight = true;
+            true
+        } else {
+            false
+        }
+    }
+}
+fn is_local_proof_only(roots: &HashMap<(u32, H256), MerkleRoot>, root_key: (u32, H256)) -> bool {
+    roots
+        .get(&root_key)
+        .is_some_and(|root| matches!(root.status, MerkleRootStatus::Finalized))
+        || roots.iter().any(|(anchor_key, anchor)| {
+            *anchor_key != root_key
+                && matches!(
+                    anchor.status,
+                    MerkleRootStatus::SubmitProof | MerkleRootStatus::Finalized
+                )
+                && anchor.covered_roots.contains(&root_key)
+        })
+}
+
+fn finalize_confirmed_roots(
+    roots: &mut HashMap<(u32, H256), MerkleRoot>,
+    confirmed_root: (u32, H256),
+    covered_roots: &[(u32, H256)],
+) -> (Vec<u32>, Vec<u32>) {
+    let mut covered_source_blocks = Vec::new();
+    let mut continuation_blocks = Vec::new();
+
+    for key in std::iter::once(&confirmed_root).chain(covered_roots) {
+        if let Some(root) = roots.get_mut(key) {
+            root.status = MerkleRootStatus::Finalized;
+            covered_source_blocks.extend_from_slice(&root.covered_source_blocks);
+            continuation_blocks.extend_from_slice(&root.continuation_source_blocks);
+        }
+    }
+
+    covered_source_blocks.sort_unstable();
+    covered_source_blocks.dedup();
+    continuation_blocks.sort_unstable();
+    continuation_blocks.dedup();
+    (covered_source_blocks, continuation_blocks)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1618,6 +2128,12 @@ pub struct PendingMerkleRoot {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
+enum ProofTarget {
+    Exact,
+    SignedAnchor,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
 enum Priority {
     Yes,
     No,
@@ -1635,23 +2151,50 @@ enum Batch {
     No,
 }
 
+fn contract_anchor_limit(
+    last_confirmed_block: Option<u32>,
+    max_block_distance: Option<u32>,
+    candidate: u32,
+) -> u32 {
+    match (last_confirmed_block, max_block_distance) {
+        (Some(last), Some(distance)) => candidate.min(last.saturating_add(distance)),
+        _ => candidate,
+    }
+}
+
+fn anchor_covers_source(
+    source_block: u32,
+    target_block: u32,
+    source_authority_set_id: u64,
+    target_authority_set_id: u64,
+    source_queue_id: u64,
+    target_queue_id: u64,
+) -> bool {
+    target_block >= source_block
+        && target_authority_set_id == source_authority_set_id
+        && target_queue_id == source_queue_id
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CriticalThreshold {
-    Timeout(u32),
+    Timeout(Duration),
     AuthoritySetChange,
 }
 
 fn critical_timeout_reached(
     critical_threshold: CriticalThreshold,
-    last_submitted_block: Option<u32>,
-    block_number: u32,
-) -> Option<(u32, u32)> {
+    last_confirmed_block: Option<u32>,
+    last_confirmed_timestamp_ms: Option<u64>,
+    block_timestamp_ms: u64,
+) -> Option<(u32, Duration)> {
     let CriticalThreshold::Timeout(threshold) = critical_threshold else {
         return None;
     };
-    let last_submitted_block = last_submitted_block?;
-    if block_number >= last_submitted_block && block_number - last_submitted_block >= threshold {
-        Some((last_submitted_block, threshold))
+    let last_confirmed_block = last_confirmed_block?;
+    let last_confirmed_timestamp_ms = last_confirmed_timestamp_ms?;
+    let elapsed_ms = block_timestamp_ms.saturating_sub(last_confirmed_timestamp_ms);
+    if u128::from(elapsed_ms) >= threshold.as_millis() {
+        Some((last_confirmed_block, threshold))
     } else {
         None
     }
@@ -1666,28 +2209,49 @@ pub enum StartupSyncStrategy {
 
 #[cfg(test)]
 mod tests {
-    use super::{critical_timeout_reached, CriticalThreshold};
+    use super::{
+        anchor_covers_source, contract_anchor_limit, critical_timeout_reached,
+        finalize_confirmed_roots, is_local_proof_only, CriticalThreshold, FinalProof, MerkleRoot,
+        MerkleRootStatus, RawBlockInclusionProof, H256,
+    };
+    use std::{collections::HashMap, time::Duration};
 
     #[test]
     fn critical_timeout_is_reached_at_threshold() {
+        let threshold = Duration::from_millis(5);
         assert_eq!(
-            critical_timeout_reached(CriticalThreshold::Timeout(5), Some(10), 15),
-            Some((10, 5))
+            critical_timeout_reached(
+                CriticalThreshold::Timeout(threshold),
+                Some(10),
+                Some(100),
+                105,
+            ),
+            Some((10, threshold))
         );
     }
 
     #[test]
     fn critical_timeout_is_not_reached_before_threshold() {
         assert_eq!(
-            critical_timeout_reached(CriticalThreshold::Timeout(5), Some(10), 14),
+            critical_timeout_reached(
+                CriticalThreshold::Timeout(Duration::from_millis(5)),
+                Some(10),
+                Some(100),
+                104,
+            ),
             None
         );
     }
 
     #[test]
-    fn critical_timeout_requires_last_submitted_block() {
+    fn critical_timeout_requires_last_confirmed_timestamp() {
         assert_eq!(
-            critical_timeout_reached(CriticalThreshold::Timeout(5), None, 15),
+            critical_timeout_reached(
+                CriticalThreshold::Timeout(Duration::from_millis(5)),
+                Some(10),
+                None,
+                105,
+            ),
             None
         );
     }
@@ -1695,8 +2259,128 @@ mod tests {
     #[test]
     fn authority_set_change_is_not_a_timeout_threshold() {
         assert_eq!(
-            critical_timeout_reached(CriticalThreshold::AuthoritySetChange, Some(10), 15),
+            critical_timeout_reached(
+                CriticalThreshold::AuthoritySetChange,
+                Some(10),
+                Some(100),
+                105,
+            ),
             None
         );
+    }
+
+    #[test]
+    fn contract_anchor_limit_keeps_candidate_inside_window() {
+        assert_eq!(contract_anchor_limit(Some(100), Some(25), 120), 120);
+    }
+
+    #[test]
+    fn contract_anchor_limit_caps_candidate_and_saturates_distance() {
+        assert_eq!(contract_anchor_limit(Some(100), Some(25), 150), 125);
+        assert_eq!(
+            contract_anchor_limit(Some(u32::MAX - 1), Some(u32::MAX), u32::MAX),
+            u32::MAX
+        );
+    }
+
+    #[test]
+    fn anchor_covers_source_requires_matching_authority_set_and_queue() {
+        assert!(anchor_covers_source(100, 120, 7, 7, 9, 9));
+        assert!(!anchor_covers_source(100, 120, 7, 8, 9, 9));
+        assert!(!anchor_covers_source(100, 120, 7, 7, 9, 10));
+    }
+
+    #[test]
+    fn anchor_covers_source_rejects_older_target_with_matching_metadata() {
+        assert!(!anchor_covers_source(100, 99, 7, 7, 9, 9));
+    }
+
+    #[test]
+    fn confirmed_anchor_finalizes_covered_roots_and_releases_sources() {
+        fn root(block_number: u32, block_hash: H256) -> MerkleRoot {
+            MerkleRoot {
+                block_number,
+                block_hash,
+                queue_id: 1,
+                message_nonces: Vec::new(),
+                http_requests: Vec::new(),
+                proof: None,
+                covered_roots: Vec::new(),
+                covered_source_blocks: Vec::new(),
+                continuation_source_blocks: Vec::new(),
+                batch: true,
+                single_proof_in_flight: false,
+                status: MerkleRootStatus::GenerateProof,
+                block_inclusion_proof: RawBlockInclusionProof {
+                    justification_round: 0,
+                    required_authority_set_id: 1,
+                    validator_set: Vec::new(),
+                    block_hash,
+                    block_number,
+                    pre_commits: Vec::new(),
+                },
+            }
+        }
+
+        let covered_key = (100, H256::repeat_byte(1));
+        let anchor_key = (120, H256::repeat_byte(2));
+        let mut covered_root = root(covered_key.0, H256::repeat_byte(3));
+        covered_root.covered_source_blocks = vec![90];
+        let mut anchor_root = root(anchor_key.0, H256::repeat_byte(4));
+        anchor_root.continuation_source_blocks = vec![130];
+        let mut roots = HashMap::from([(covered_key, covered_root), (anchor_key, anchor_root)]);
+        let exact_root = roots.get_mut(&covered_key).unwrap();
+        assert!(exact_root.promote_to_single_proof());
+        assert!(!exact_root.promote_to_single_proof());
+        assert!(!exact_root.batch);
+
+        let proof = FinalProof {
+            proof: vec![1],
+            block_number: anchor_key.0,
+            merkle_root: *anchor_key.1.as_fixed_bytes(),
+        };
+
+        roots
+            .get_mut(&anchor_key)
+            .unwrap()
+            .stage_batched_submission(proof, vec![covered_key]);
+        assert!(matches!(
+            roots[&covered_key].status,
+            MerkleRootStatus::GenerateProof
+        ));
+        assert!(is_local_proof_only(&roots, covered_key));
+
+        let (covered_sources, continuation_blocks) =
+            finalize_confirmed_roots(&mut roots, anchor_key, &[covered_key]);
+        assert!(matches!(
+            roots[&covered_key].status,
+            MerkleRootStatus::Finalized
+        ));
+        assert!(matches!(
+            roots[&anchor_key].status,
+            MerkleRootStatus::Finalized
+        ));
+        assert!(is_local_proof_only(&roots, covered_key));
+        let exact_root = roots.get_mut(&covered_key).unwrap();
+        exact_root.single_proof_in_flight = false;
+        assert!(exact_root.promote_to_single_proof());
+        assert!(matches!(exact_root.status, MerkleRootStatus::Finalized));
+        assert_eq!(covered_sources, vec![90]);
+        assert_eq!(continuation_blocks, vec![130]);
+    }
+
+    #[test]
+    fn timeout_and_contract_limit_require_confirmed_cursor() {
+        assert_eq!(
+            critical_timeout_reached(
+                CriticalThreshold::Timeout(Duration::from_millis(5)),
+                None,
+                Some(100),
+                105,
+            ),
+            None
+        );
+        assert_eq!(contract_anchor_limit(None, Some(25), 150), 150);
+        assert_eq!(contract_anchor_limit(Some(100), None, 150), 150);
     }
 }

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -648,40 +648,68 @@ impl MerkleRootRelayer {
     ) -> anyhow::Result<()> {
         let relayer_id = self.options.relayer_id.clone();
         let client = self.api_provider.client();
-        let last_block_hash = client.latest_finalized_block().await?;
-        let last_block = client.block_hash_to_number(last_block_hash).await?;
+        let latest_block_hash = client.latest_finalized_block().await?;
+        let latest_block = client.block_hash_to_number(latest_block_hash).await?;
+        let latest_timestamp_ms = client.fetch_timestamp(latest_block_hash).await?;
+        let latest_queue_state = client
+            .fetch_authenticated_queue_merkle_root(latest_block_hash)
+            .await?;
+        let confirmed_block = self
+            .last_confirmed_block
+            .context("Ethereum MessageQueue max block number is not initialized")?;
+        let confirmed_block_hash = client.block_number_to_hash(confirmed_block).await?;
+        let confirmed_queue_state = client
+            .fetch_authenticated_queue_merkle_root(confirmed_block_hash)
+            .await?;
 
-        log::info!(
-            "Merkle root relayer {relayer_id} supervisor: checking Vara queue state near latest finalized block #{last_block}"
-        );
+        if !queue_state_changed(confirmed_queue_state, latest_queue_state) {
+            log::trace!(
+                "Merkle root relayer {relayer_id} supervisor: Vara queue state has not changed since Ethereum MessageQueue block #{confirmed_block}, skipping proof generation"
+            );
+            return Ok(());
+        }
 
-        let block = self.signed_block_after(last_block).await?;
+        let Some(target_limit) = recovery_target_limit(
+            self.last_confirmed_block,
+            self.max_block_distance,
+            latest_block,
+        ) else {
+            log::debug!(
+                "Merkle root relayer {relayer_id} supervisor: changed Vara queue state is still inside the MessageQueue window after block #{confirmed_block}, leaving proof generation to the event path"
+            );
+            return Ok(());
+        };
+
+        let block = self.signed_block_at_or_before(target_limit).await?;
         let block_number = block.number();
+        if block_number <= confirmed_block {
+            log::warn!(
+                "Merkle root relayer {relayer_id} supervisor: no signed Vara block advances MessageQueue block #{confirmed_block} inside the bound ending at #{target_limit}"
+            );
+            return Ok(());
+        }
         let block_hash = block.hash();
         let block_timestamp_ms = client.fetch_timestamp(block_hash).await?;
-        let (_queue_id, merkle_root) = client
+        let (_, merkle_root) = client
             .fetch_authenticated_queue_merkle_root(block_hash)
             .await?;
         if self.last_confirmed_timestamp_ms.is_none() {
-            if let Some(last_confirmed_block) = self.last_confirmed_block {
-                let hash = client.block_number_to_hash(last_confirmed_block).await?;
-                self.last_confirmed_timestamp_ms = Some(client.fetch_timestamp(hash).await?);
-            }
+            self.last_confirmed_timestamp_ms =
+                Some(client.fetch_timestamp(confirmed_block_hash).await?);
         }
 
         let threshold = critical_timeout_reached(
             self.options.critical_threshold,
             self.last_confirmed_block,
             self.last_confirmed_timestamp_ms,
-            block_timestamp_ms,
+            latest_timestamp_ms,
         );
-
-        if merkle_root == H256::zero() && threshold.is_none() {
-            log::trace!(
-                "Merkle root relayer {relayer_id} supervisor: latest Vara queue root is zero at block #{block_number}, skipping"
+        let Some((last_confirmed_block, threshold)) = threshold else {
+            log::debug!(
+                "Merkle root relayer {relayer_id} supervisor: critical threshold is not reached at latest finalized Vara block #{latest_block}, skipping forced proof generation"
             );
             return Ok(());
-        }
+        };
 
         let eth_root = match self
             .read_finalized_merkle_root(eth_api, block_number)
@@ -696,39 +724,19 @@ impl MerkleRootRelayer {
         };
         if eth_root == Some(merkle_root) {
             log::info!(
-                "Merkle root relayer {relayer_id} supervisor: finalized Ethereum state already has merkle root {merkle_root} for block #{block_number}"
+                "Merkle root relayer {relayer_id} supervisor: finalized Ethereum state already has merkle root {merkle_root} for bounded Vara block #{block_number}"
             );
-            if self
-                .last_confirmed_block
-                .is_none_or(|confirmed| block_number >= confirmed)
-            {
-                self.last_confirmed_block = Some(block_number);
-                self.last_confirmed_timestamp_ms = Some(block_timestamp_ms);
-            }
+            self.last_confirmed_block = Some(block_number);
+            self.last_confirmed_timestamp_ms = Some(block_timestamp_ms);
             return Ok(());
         }
 
-        let Some((last_confirmed_block, threshold)) = threshold else {
-            log::debug!(
-                "Merkle root relayer {relayer_id} supervisor: critical threshold is not reached for block #{block_number}, skipping forced proof generation"
-            );
-            return Ok(());
-        };
         log::warn!(
-            "Merkle root relayer {relayer_id} supervisor: last confirmed block {last_confirmed_block} is older than supervised block number {block_number} by at least {threshold:?}, forcing proof generation"
+            "Merkle root relayer {relayer_id} supervisor: MessageQueue block #{last_confirmed_block} is stale by at least {threshold:?}; scheduling recovery at signed Vara block #{block_number} within upper bound #{target_limit}, not at latest block #{latest_block}"
         );
-
-        if merkle_root == H256::zero() {
+        if let Some(eth_root) = eth_root {
             log::warn!(
-                "Merkle root relayer {relayer_id} supervisor: Vara queue root is zero at block #{block_number}; scheduling proof anyway because critical threshold is reached"
-            );
-        } else if let Some(eth_root) = eth_root {
-            log::warn!(
-                "Merkle root relayer {relayer_id} supervisor: Ethereum has merkle root {eth_root} for block #{block_number}, but Vara queue root is {merkle_root}; scheduling proof anyway"
-            );
-        } else {
-            log::info!(
-                "Merkle root relayer {relayer_id} supervisor: Ethereum has no merkle root for Vara queue root {merkle_root} at block #{block_number}; scheduling proof"
+                "Merkle root relayer {relayer_id} supervisor: Ethereum has merkle root {eth_root} for bounded Vara block #{block_number}, but Vara queue root is {merkle_root}"
             );
         }
 
@@ -745,7 +753,7 @@ impl MerkleRootRelayer {
             .await?
         {
             log::info!(
-                "Merkle root relayer {relayer_id} supervisor: proof request selected queue #{selected_queue_id}, merkle root {selected_merkle_root} from supervised block #{block_number}"
+                "Merkle root relayer {relayer_id} supervisor: bounded proof request selected queue #{selected_queue_id}, merkle root {selected_merkle_root} at Vara block #{block_number}"
             );
         }
         Ok(())
@@ -2240,6 +2248,17 @@ fn contract_anchor_limit(
     }
 }
 
+fn recovery_target_limit(
+    last_confirmed_block: Option<u32>,
+    max_block_distance: Option<u32>,
+    latest_block: u32,
+) -> Option<u32> {
+    let last_confirmed_block = last_confirmed_block?;
+    let max_block_distance = max_block_distance?;
+    let target = last_confirmed_block.saturating_add(max_block_distance);
+    (target > last_confirmed_block && latest_block >= target).then_some(target)
+}
+
 fn anchor_covers_source(
     source_block: u32,
     target_block: u32,
@@ -2257,6 +2276,10 @@ fn anchor_covers_source(
 pub enum CriticalThreshold {
     Timeout(Duration),
     AuthoritySetChange,
+}
+
+fn queue_state_changed(confirmed: (u64, H256), latest: (u64, H256)) -> bool {
+    confirmed != latest
 }
 
 fn critical_timeout_reached(
@@ -2289,9 +2312,9 @@ pub enum StartupSyncStrategy {
 mod tests {
     use super::{
         anchor_covers_source, contract_anchor_limit, critical_timeout_reached,
-        finalize_confirmed_roots, is_local_proof_only, recover_finalized_continuations,
-        reusable_finalized_root, CriticalThreshold, FinalProof, MerkleRoot, MerkleRootStatus,
-        RawBlockInclusionProof, H256,
+        finalize_confirmed_roots, is_local_proof_only, queue_state_changed,
+        recover_finalized_continuations, recovery_target_limit, reusable_finalized_root,
+        CriticalThreshold, FinalProof, MerkleRoot, MerkleRootStatus, RawBlockInclusionProof, H256,
     };
     use std::{collections::HashMap, time::Duration};
 
@@ -2371,6 +2394,21 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn recovery_requires_queue_state_change_since_contract_max_block() {
+        let confirmed = (7, H256::repeat_byte(1));
+        assert!(!queue_state_changed(confirmed, confirmed));
+        assert!(queue_state_changed(confirmed, (7, H256::repeat_byte(2))));
+        assert!(queue_state_changed(confirmed, (8, H256::repeat_byte(1))));
+    }
+
+    #[test]
+    fn recovery_target_waits_for_and_stops_at_contract_bound() {
+        assert_eq!(recovery_target_limit(Some(100), Some(25), 124), None);
+        assert_eq!(recovery_target_limit(Some(100), Some(25), 125), Some(125));
+        assert_eq!(recovery_target_limit(Some(100), Some(25), 200), Some(125));
     }
 
     #[test]

--- a/relayer/src/merkle_roots/mod.rs
+++ b/relayer/src/merkle_roots/mod.rs
@@ -242,6 +242,35 @@ impl_metered_service!(
     }
 );
 
+struct DeferredStartupProof {
+    block_number: u32,
+    block_hash: H256,
+    merkle_root: H256,
+    authority_set_id: u64,
+    queue_id: u64,
+    batch: bool,
+    block_inclusion_proof: RawBlockInclusionProof,
+}
+
+fn defer_startup_proof(
+    roots: &mut HashMap<(u32, H256), MerkleRoot>,
+    deferred: &mut Vec<DeferredStartupProof>,
+    key: (u32, H256),
+    authority_set_id: u64,
+) {
+    let root = roots.get_mut(&key).expect("persisted root was reinstated");
+    root.single_proof_in_flight = false;
+    deferred.push(DeferredStartupProof {
+        block_number: root.block_number,
+        block_hash: root.block_hash,
+        merkle_root: key.1,
+        authority_set_id,
+        queue_id: root.queue_id,
+        batch: root.batch,
+        block_inclusion_proof: root.block_inclusion_proof.clone(),
+    });
+}
+
 pub struct MerkleRootRelayer {
     api_provider: ApiProviderConnection,
 
@@ -393,6 +422,7 @@ impl MerkleRootRelayer {
         }
 
         let gear_api = self.api_provider.client();
+        let mut deferred_startup_proofs = Vec::new();
 
         for ((block_number, hash), merkle_root) in roots.drain() {
             let block_hash = merkle_root.block_hash;
@@ -436,25 +466,14 @@ impl MerkleRootRelayer {
                         .get_proof_for_authority_set_id(*id)
                         .await
                     {
-                        Ok(authority_set_proof) => {
+                        Ok(_) => {
                             reinstate(MerkleRootStatus::GenerateProof);
-
-                            if !prover.prove(
-                                block_number,
-                                block_hash,
-                                hash,
-                                authority_set_proof,
-                                merkle_root.queue_id,
-                                merkle_root.batch,
-                                merkle_root.block_inclusion_proof.clone(),
-                            ) {
-                                log::error!(
-                                    "Merkle root relayer {relayer_id}: prover connection closed, exiting..."
-                                );
-                                return Err(anyhow::anyhow!(
-                                    "Merkle root relayer {relayer_id}: prover connection closed during startup recovery"
-                                ));
-                            }
+                            defer_startup_proof(
+                                &mut self.roots,
+                                &mut deferred_startup_proofs,
+                                (block_number, hash),
+                                *id,
+                            );
                         }
                         Err(_) => {
                             log::warn!("Merkle root relayer {relayer_id}: authority set proof for #{id} not found, waiting for authority set sync");
@@ -493,39 +512,16 @@ impl MerkleRootRelayer {
 
                 MerkleRootStatus::GenerateProof => {
                     reinstate(MerkleRootStatus::GenerateProof);
-
-                    log::info!(
-                        "Merkle root relayer {relayer_id}: merkle root {hash} for block #{block_number} is waiting for proof generation"
+                    defer_startup_proof(
+                        &mut self.roots,
+                        &mut deferred_startup_proofs,
+                        (block_number, hash),
+                        merkle_root.block_inclusion_proof.required_authority_set_id,
                     );
 
-                    // if merkle root was saved in `generate proof` phase, it means
-                    // that proof for authority set id is already generated and thus should be available in storage.
-                    // If it is not found that is a hard error and storage should be fixed.
-                    let signed_by_authority_set_id =
-                        merkle_root.block_inclusion_proof.required_authority_set_id;
-                    let inner_proof = self
-                        .storage
-                        .proofs
-                        .get_proof_for_authority_set_id(signed_by_authority_set_id)
-                        .await
-                        .with_context(|| format!("Proof for authority set #{signed_by_authority_set_id} not found, please clean-up your storage and restart relayer"))?;
-
-                    if !prover.prove(
-                        block_number,
-                        block_hash,
-                        hash,
-                        inner_proof,
-                        merkle_root.queue_id,
-                        merkle_root.batch,
-                        merkle_root.block_inclusion_proof.clone(),
-                    ) {
-                        log::error!(
-                            "Merkle root relayer {relayer_id}: prover connection closed, exiting..."
-                        );
-                        return Err(anyhow::anyhow!(
-                            "Merkle root relayer {relayer_id}: prover connection closed during startup recovery"
-                        ));
-                    }
+                    log::info!(
+                        "Merkle root relayer {relayer_id}: deferring persisted proof for merkle root {hash} at block #{block_number} until after startup supervision"
+                    );
                 }
 
                 MerkleRootStatus::SubmitProof if merkle_root.proof.is_some() => {
@@ -568,6 +564,42 @@ impl MerkleRootRelayer {
         self.supervisor_interval.tick().await;
         self.supervise_contract_state(&mut prover, &mut authority_set_sync, &mut eth_api)
             .await?;
+
+        for deferred in deferred_startup_proofs {
+            let key = (deferred.block_number, deferred.merkle_root);
+            if self
+                .roots
+                .get(&key)
+                .is_some_and(|root| root.single_proof_in_flight)
+            {
+                continue;
+            }
+            let inner_proof = self
+                .storage
+                .proofs
+                .get_proof_for_authority_set_id(deferred.authority_set_id)
+                .await
+                .with_context(|| format!("Proof for authority set #{} not found, please clean-up your storage and restart relayer", deferred.authority_set_id))?;
+            if !deferred.batch {
+                self.roots
+                    .get_mut(&key)
+                    .expect("persisted root was reinstated")
+                    .single_proof_in_flight = true;
+            }
+            if !prover.prove(
+                deferred.block_number,
+                deferred.block_hash,
+                deferred.merkle_root,
+                inner_proof,
+                deferred.queue_id,
+                deferred.batch,
+                deferred.block_inclusion_proof,
+            ) {
+                return Err(anyhow::anyhow!(
+                    "Merkle root relayer {relayer_id}: prover connection closed while resuming persisted proof"
+                ));
+            }
+        }
 
         if let Err(err) = self
             .run_inner(
@@ -662,6 +694,23 @@ impl MerkleRootRelayer {
             .fetch_authenticated_queue_merkle_root(confirmed_block_hash)
             .await?;
 
+        if self.last_confirmed_timestamp_ms.is_none() {
+            self.last_confirmed_timestamp_ms =
+                Some(client.fetch_timestamp(confirmed_block_hash).await?);
+        }
+        let threshold = critical_timeout_reached(
+            self.options.critical_threshold,
+            self.last_confirmed_block,
+            self.last_confirmed_timestamp_ms,
+            latest_timestamp_ms,
+        );
+        let Some((last_confirmed_block, threshold)) = threshold else {
+            log::debug!(
+                "Merkle root relayer {relayer_id} supervisor: critical threshold is not reached at latest finalized Vara block #{latest_block}, skipping forced proof generation"
+            );
+            return Ok(());
+        };
+
         if !queue_state_changed(confirmed_queue_state, latest_queue_state) {
             log::trace!(
                 "Merkle root relayer {relayer_id} supervisor: Vara queue state has not changed since Ethereum MessageQueue block #{confirmed_block}, skipping proof generation"
@@ -675,7 +724,7 @@ impl MerkleRootRelayer {
             latest_block,
         ) else {
             log::debug!(
-                "Merkle root relayer {relayer_id} supervisor: changed Vara queue state is still inside the MessageQueue window after block #{confirmed_block}, leaving proof generation to the event path"
+                "Merkle root relayer {relayer_id} supervisor: no finalized Vara block advances MessageQueue block #{confirmed_block}"
             );
             return Ok(());
         };
@@ -693,23 +742,6 @@ impl MerkleRootRelayer {
         let (_, merkle_root) = client
             .fetch_authenticated_queue_merkle_root(block_hash)
             .await?;
-        if self.last_confirmed_timestamp_ms.is_none() {
-            self.last_confirmed_timestamp_ms =
-                Some(client.fetch_timestamp(confirmed_block_hash).await?);
-        }
-
-        let threshold = critical_timeout_reached(
-            self.options.critical_threshold,
-            self.last_confirmed_block,
-            self.last_confirmed_timestamp_ms,
-            latest_timestamp_ms,
-        );
-        let Some((last_confirmed_block, threshold)) = threshold else {
-            log::debug!(
-                "Merkle root relayer {relayer_id} supervisor: critical threshold is not reached at latest finalized Vara block #{latest_block}, skipping forced proof generation"
-            );
-            return Ok(());
-        };
 
         let eth_root = match self
             .read_finalized_merkle_root(eth_api, block_number)
@@ -732,7 +764,7 @@ impl MerkleRootRelayer {
         }
 
         log::warn!(
-            "Merkle root relayer {relayer_id} supervisor: MessageQueue block #{last_confirmed_block} is stale by at least {threshold:?}; scheduling recovery at signed Vara block #{block_number} within upper bound #{target_limit}, not at latest block #{latest_block}"
+            "Merkle root relayer {relayer_id} supervisor: MessageQueue block #{last_confirmed_block} is stale by at least {threshold:?}; scheduling recovery at signed Vara block #{block_number} within upper bound #{target_limit} (latest finalized #{latest_block})"
         );
         if let Some(eth_root) = eth_root {
             log::warn!(
@@ -1194,6 +1226,7 @@ impl MerkleRootRelayer {
                             }
                         }
                         if !local_proof_only {
+                            self.storage.save(&self.roots).await?;
                             self.queue_submission(root_key);
                         }
                     }
@@ -1214,6 +1247,7 @@ impl MerkleRootRelayer {
                                 "Selected batched merkle root {merkle_root} for block #{block_number} not found in storage"
                             ));
                         }
+                        self.storage.save(&self.roots).await?;
                         self.queue_submission((block_number, merkle_root));
                     }
                 }
@@ -2254,9 +2288,9 @@ fn recovery_target_limit(
     latest_block: u32,
 ) -> Option<u32> {
     let last_confirmed_block = last_confirmed_block?;
-    let max_block_distance = max_block_distance?;
-    let target = last_confirmed_block.saturating_add(max_block_distance);
-    (target > last_confirmed_block && latest_block >= target).then_some(target)
+    let target =
+        contract_anchor_limit(Some(last_confirmed_block), max_block_distance, latest_block);
+    (target > last_confirmed_block).then_some(target)
 }
 
 fn anchor_covers_source(
@@ -2311,7 +2345,7 @@ pub enum StartupSyncStrategy {
 #[cfg(test)]
 mod tests {
     use super::{
-        anchor_covers_source, contract_anchor_limit, critical_timeout_reached,
+        anchor_covers_source, contract_anchor_limit, critical_timeout_reached, defer_startup_proof,
         finalize_confirmed_roots, is_local_proof_only, queue_state_changed,
         recover_finalized_continuations, recovery_target_limit, reusable_finalized_root,
         CriticalThreshold, FinalProof, MerkleRoot, MerkleRootStatus, RawBlockInclusionProof, H256,
@@ -2405,10 +2439,60 @@ mod tests {
     }
 
     #[test]
-    fn recovery_target_waits_for_and_stops_at_contract_bound() {
-        assert_eq!(recovery_target_limit(Some(100), Some(25), 124), None);
+    fn recovery_target_uses_latest_inside_contract_window_and_caps_beyond_it() {
+        assert_eq!(recovery_target_limit(Some(100), Some(25), 100), None);
+        assert_eq!(recovery_target_limit(Some(100), Some(25), 124), Some(124));
         assert_eq!(recovery_target_limit(Some(100), Some(25), 125), Some(125));
         assert_eq!(recovery_target_limit(Some(100), Some(25), 200), Some(125));
+    }
+
+    #[test]
+    fn timeout_inside_window_schedules_fresh_proof_before_resumed_1034_header_proof() {
+        const CONFIRMED: u32 = 35_490_266;
+        const OLD_BLOCK: u32 = 35_491_497;
+        const OLD_SIGNED_BLOCK: u32 = 35_492_530;
+        const LATEST: u32 = 35_509_509;
+        const MAX_DISTANCE: u32 = 57_600;
+
+        let threshold = Duration::from_secs(14 * 60 * 60);
+        assert_eq!(
+            critical_timeout_reached(
+                CriticalThreshold::Timeout(threshold),
+                Some(CONFIRMED),
+                Some(0),
+                15 * 60 * 60 * 1_000,
+            ),
+            Some((CONFIRMED, threshold))
+        );
+        assert!(queue_state_changed(
+            (1, H256::repeat_byte(1)),
+            (1, H256::repeat_byte(2)),
+        ));
+        let recovery_target =
+            recovery_target_limit(Some(CONFIRMED), Some(MAX_DISTANCE), LATEST).unwrap();
+        assert_eq!(recovery_target, LATEST);
+
+        let old_key = (OLD_BLOCK, H256::repeat_byte(3));
+        let mut old_root = root(OLD_BLOCK, H256::repeat_byte(4));
+        old_root.block_inclusion_proof.block_number = OLD_SIGNED_BLOCK;
+        let mut roots = HashMap::from([(old_key, old_root)]);
+        let mut deferred = Vec::new();
+        defer_startup_proof(&mut roots, &mut deferred, old_key, 1);
+
+        assert!(matches!(
+            roots[&old_key].status,
+            MerkleRootStatus::GenerateProof
+        ));
+        assert!(!roots[&old_key].single_proof_in_flight);
+        assert_eq!(deferred.len(), 1);
+
+        let old_span = super::prover::proof_span_order_key(
+            deferred[0].block_number,
+            deferred[0].block_inclusion_proof.block_number,
+        );
+        let recovery_span = super::prover::proof_span_order_key(recovery_target, recovery_target);
+        assert_eq!(old_span.0, 1_033);
+        assert!(recovery_span < old_span);
     }
 
     #[test]

--- a/relayer/src/merkle_roots/prover.rs
+++ b/relayer/src/merkle_roots/prover.rs
@@ -386,8 +386,13 @@ impl FinalityProver {
                 .pending_requests
                 .set((non_batch_requests.len() + request_groups.len()) as i64);
 
-            // sort by block number ascending to process older requests first
-            non_batch_requests.sort_by_key(|r| r.block_number);
+            // A short recovery proof must not wait behind a resumed long-span proof.
+            non_batch_requests.sort_by_key(|request| {
+                proof_span_order_key(
+                    request.block_number,
+                    request.block_inclusion_proof.block_number,
+                )
+            });
 
             // First process all non-batched requests, then batched requests.
             // Non batched requests are processed first as they're the most important ones, and
@@ -799,12 +804,17 @@ async fn take_next_shared_proof_work(
         return Ok(None);
     };
 
-    if let Some((index, _)) = pending
-        .iter()
-        .enumerate()
-        .filter(|(_, request)| request.relayer_id == relayer_id && !request.request.batch)
-        .min_by_key(|(_, request)| (request.request.block_number, request.sequence))
-    {
+    if let Some(index) = select_short_proof_with_fifo_aging(
+        pending,
+        |request| request.relayer_id == relayer_id && !request.request.batch,
+        |request| request.sequence,
+        |request| {
+            proof_span_order_key(
+                request.request.block_number,
+                request.request.block_inclusion_proof.block_number,
+            )
+        },
+    ) {
         return Ok(Some(SelectedSharedProofWork::Single(pending.remove(index))));
     }
 
@@ -1184,27 +1194,65 @@ impl BatchProofRequest {
     }
 }
 
+const MAX_SHORT_PROOFS_BEFORE_FIFO: u64 = 8;
+
+fn select_short_proof_with_fifo_aging<T>(
+    requests: &[T],
+    eligible: impl Fn(&T) -> bool,
+    sequence: impl Fn(&T) -> u64,
+    span: impl Fn(&T) -> (u32, u32),
+) -> Option<usize> {
+    let mut oldest = None;
+    let mut newest_sequence = 0;
+    for (index, request) in requests
+        .iter()
+        .enumerate()
+        .filter(|(_, request)| eligible(request))
+    {
+        let request_sequence = sequence(request);
+        if oldest.is_none_or(|(_, oldest_sequence)| request_sequence < oldest_sequence) {
+            oldest = Some((index, request_sequence));
+        }
+        newest_sequence = newest_sequence.max(request_sequence);
+    }
+
+    let (oldest_index, oldest_sequence) = oldest?;
+    if newest_sequence.saturating_sub(oldest_sequence) >= MAX_SHORT_PROOFS_BEFORE_FIFO {
+        return Some(oldest_index);
+    }
+
+    requests
+        .iter()
+        .enumerate()
+        .filter(|(_, request)| eligible(request))
+        .min_by_key(|(_, request)| (span(request), sequence(request)))
+        .map(|(index, _)| index)
+}
+
+pub(super) fn proof_span_order_key(block_number: u32, signed_block_number: u32) -> (u32, u32) {
+    (
+        signed_block_number.saturating_sub(block_number),
+        block_number,
+    )
+}
+
 fn proof_request_order_key(
     authority_set_id: u64,
     queue_id: u64,
     block_number: u32,
     signed_block_number: u32,
 ) -> (u32, u64, u64, u32) {
-    (
-        signed_block_number.saturating_sub(block_number),
-        authority_set_id,
-        queue_id,
-        block_number,
-    )
+    let (proof_span, block_number) = proof_span_order_key(block_number, signed_block_number);
+    (proof_span, authority_set_id, queue_id, block_number)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         clear_current_shared_request, plan_shared_relayer_requests, proof_request_order_key,
-        receive_batch, record_current_shared_request, record_pending_request_counts,
-        select_next_relayer_id, send_shared_response, Metrics, Response, SharedProofRequestInfo,
-        SharedProofWork,
+        proof_span_order_key, receive_batch, record_current_shared_request,
+        record_pending_request_counts, select_next_relayer_id, select_short_proof_with_fifo_aging,
+        send_shared_response, Metrics, Response, SharedProofRequestInfo, SharedProofWork,
     };
     use crate::prover_interface::FinalProof;
     use primitive_types::H256;
@@ -1219,6 +1267,39 @@ mod tests {
         let current_root = proof_request_order_key(3625, 597, 35_361_830, 35_361_830);
 
         assert!(current_root < long_recovery);
+    }
+
+    #[test]
+    fn recovery_scheduler_prefers_fresh_short_span_over_resumed_1034_header_proof() {
+        let resumed = proof_span_order_key(35_491_497, 35_492_530);
+        let fresh = proof_span_order_key(35_509_509, 35_509_509);
+
+        assert_eq!(resumed.0, 1_033);
+        assert!(fresh < resumed);
+    }
+
+    #[test]
+    fn shared_scheduler_ages_long_proof_into_fifo() {
+        let requests = [
+            (0_u64, 35_491_497_u32, 35_492_530_u32),
+            (7, 35_509_509, 35_509_509),
+        ];
+        let selected = select_short_proof_with_fifo_aging(
+            &requests,
+            |_| true,
+            |request| request.0,
+            |request| proof_span_order_key(request.1, request.2),
+        );
+        assert_eq!(selected, Some(1));
+
+        let aged_requests = [requests[0], (8, 35_509_510, 35_509_510)];
+        let selected = select_short_proof_with_fifo_aging(
+            &aged_requests,
+            |_| true,
+            |request| request.0,
+            |request| proof_span_order_key(request.1, request.2),
+        );
+        assert_eq!(selected, Some(0));
     }
     #[tokio::test]
     async fn batch_collection_uses_one_deadline() {

--- a/relayer/src/merkle_roots/storage.rs
+++ b/relayer/src/merkle_roots/storage.rs
@@ -251,23 +251,16 @@ impl MerkleRootStorage {
 
     pub async fn prune_blocks(&self) {
         let mut blocks = self.blocks.write().await;
-        let mut remove_until = None;
-        for (index, (number, block)) in blocks.iter().enumerate() {
-            if index + 100 > blocks.len() {
-                remove_until = Some(*number);
-                break;
-            }
-
-            if !block.is_processed() {
-                remove_until = Some(*number);
-                break;
-            }
-        }
-
-        if let Some(remove_until) = remove_until {
-            *blocks = blocks.split_off(&remove_until);
-        }
+        prune_processed_blocks(&mut blocks);
     }
+}
+
+fn prune_processed_blocks(blocks: &mut BTreeMap<u32, Block>) {
+    let Some(keep_from) = blocks.keys().rev().nth(99).copied() else {
+        return;
+    };
+
+    blocks.retain(|number, block| *number >= keep_from || !block.is_processed());
 }
 
 struct SerializedStorage<'a> {
@@ -347,5 +340,45 @@ impl<'de> Deserialize<'de> for DeserializedStorage {
             submitted_merkle_roots: helper.submitted_merkle_roots,
             roots,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{prune_processed_blocks, Block};
+    use gear_rpc_client::dto::RawBlockInclusionProof;
+    use primitive_types::H256;
+    use std::collections::BTreeMap;
+
+    fn processed_block(block_number: u32) -> Block {
+        Block {
+            block_hash: H256::zero(),
+            merkle_root_changed: None,
+            authority_set_changed: false,
+            inclusion_proof: RawBlockInclusionProof {
+                justification_round: 0,
+                required_authority_set_id: 0,
+                validator_set: Vec::new(),
+                block_hash: H256::zero(),
+                block_number,
+                pre_commits: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn unresolved_event_does_not_retain_processed_backlog() {
+        let mut blocks = (0..200)
+            .map(|number| (number, processed_block(number)))
+            .collect::<BTreeMap<_, _>>();
+        blocks.get_mut(&0).unwrap().merkle_root_changed = Some((1, H256::repeat_byte(1)));
+
+        prune_processed_blocks(&mut blocks);
+
+        assert_eq!(blocks.len(), 101);
+        assert!(blocks.contains_key(&0));
+        assert!(!blocks.contains_key(&99));
+        assert!(blocks.contains_key(&100));
+        assert!(blocks.contains_key(&199));
     }
 }

--- a/relayer/src/merkle_roots/storage.rs
+++ b/relayer/src/merkle_roots/storage.rs
@@ -110,6 +110,9 @@ impl UnprocessedBlocksStorage for MerkleRootStorage {
     ) -> anyhow::Result<()> {
         let merkle_root_changed = queue_merkle_root_changed(block);
         let authority_set_changed = authority_set_changed(block);
+        if merkle_root_changed.is_none() && !authority_set_changed {
+            return Ok(());
+        }
 
         let proof = api
             .produce_finality_proof(&block.grandpa_justification)

--- a/relayer/src/merkle_roots/submitter.rs
+++ b/relayer/src/merkle_roots/submitter.rs
@@ -1,7 +1,7 @@
 use alloy::{
     network::Ethereum, providers::PendingTransactionBuilder, rpc::types::TransactionReceipt,
 };
-use anyhow::Context;
+use anyhow::Result;
 use ethereum_client::EthApi;
 use futures::{stream::FuturesUnordered, StreamExt};
 use primitive_types::H256;
@@ -10,7 +10,9 @@ use prometheus::{
     Gauge, IntCounter, IntGauge,
 };
 use std::{collections::VecDeque, sync::Arc, time::Duration};
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{
+    channel, unbounded_channel, Receiver, Sender, UnboundedReceiver, UnboundedSender,
+};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
 use crate::{
@@ -22,6 +24,10 @@ use crate::{
 use super::storage::MerkleRootStorage;
 const FINALIZATION_POLL_INTERVAL: Duration = Duration::from_secs(12);
 const FINALIZATION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const MAX_PENDING_RECONCILIATIONS: usize = 8;
+const MAX_PENDING_TRANSACTIONS: usize = 8;
+const MAX_PENDING_SUBMISSION_WORK: usize = 16;
+const ABSENCE_OBSERVATIONS_REQUIRED: usize = 2;
 
 async fn finalized_submission_exists(
     eth_api: &mut EthApi,
@@ -49,15 +55,93 @@ async fn finalized_submission_exists(
     .map(|root| root == Some(expected_root))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SubmissionState {
+    Finalized,
+    Pending,
+    Absent,
+}
+
+fn submission_state(finalized_exists: bool, chainhead_exists: bool) -> SubmissionState {
+    if finalized_exists {
+        SubmissionState::Finalized
+    } else if chainhead_exists {
+        SubmissionState::Pending
+    } else {
+        SubmissionState::Absent
+    }
+}
+
+async fn chainhead_submission_exists(
+    eth_api: &mut EthApi,
+    gear_block: u32,
+    expected_root: [u8; 32],
+) -> Result<bool, ethereum_client::Error> {
+    if expected_root == [0; 32] {
+        return rpc::retry_eth_bounded(
+            eth_api,
+            "read chainhead MessageQueue max block number",
+            MAX_RETRIES,
+            |api| async move { api.max_block_number().await },
+        )
+        .await
+        .map(|block| block >= gear_block);
+    }
+
+    rpc::retry_eth_bounded(
+        eth_api,
+        "read chainhead MessageQueue merkle root",
+        MAX_RETRIES,
+        |api| async move { api.read_chainhead_merkle_root(gear_block).await },
+    )
+    .await
+    .map(|root| root == Some(expected_root))
+}
+
+async fn current_submission_state(
+    eth_api: &mut EthApi,
+    gear_block: u32,
+    expected_root: [u8; 32],
+) -> Result<SubmissionState, ethereum_client::Error> {
+    let finalized_exists = finalized_submission_exists(eth_api, gear_block, expected_root).await?;
+    if finalized_exists {
+        return Ok(submission_state(true, false));
+    }
+    let chainhead_exists = chainhead_submission_exists(eth_api, gear_block, expected_root).await?;
+    Ok(submission_state(false, chainhead_exists))
+}
+
+async fn state_after_finalization_timeout(
+    eth_api: &mut EthApi,
+    gear_block: u32,
+    expected_root: [u8; 32],
+) -> Result<SubmissionState> {
+    current_submission_state(eth_api, gear_block, expected_root)
+        .await
+        .map_err(Into::into)
+}
+
 async fn wait_for_persisted_submission(
     eth_api: &mut EthApi,
     gear_block: u32,
     expected_root: [u8; 32],
-) -> anyhow::Result<bool> {
+) -> Result<SubmissionState> {
     match tokio::time::timeout(FINALIZATION_TIMEOUT, async {
+        let mut absent_observations = 0;
         loop {
-            if finalized_submission_exists(eth_api, gear_block, expected_root).await? {
-                return Ok::<bool, ethereum_client::Error>(true);
+            match current_submission_state(eth_api, gear_block, expected_root).await? {
+                SubmissionState::Finalized => {
+                    return Ok::<SubmissionState, ethereum_client::Error>(
+                        SubmissionState::Finalized,
+                    );
+                }
+                SubmissionState::Pending => absent_observations = 0,
+                SubmissionState::Absent => {
+                    absent_observations += 1;
+                    if absent_observations >= ABSENCE_OBSERVATIONS_REQUIRED {
+                        return Ok(SubmissionState::Absent);
+                    }
+                }
             }
             tokio::time::sleep(FINALIZATION_POLL_INTERVAL).await;
         }
@@ -65,7 +149,7 @@ async fn wait_for_persisted_submission(
     .await
     {
         Ok(result) => result.map_err(Into::into),
-        Err(_) => Ok(false),
+        Err(_) => state_after_finalization_timeout(eth_api, gear_block, expected_root).await,
     }
 }
 
@@ -73,41 +157,32 @@ async fn wait_for_finalized_merkle_root(
     eth_api: &mut EthApi,
     gear_block: u32,
     expected_root: [u8; 32],
-) -> anyhow::Result<bool> {
-    tokio::time::timeout(FINALIZATION_TIMEOUT, async {
+) -> Result<SubmissionState> {
+    match tokio::time::timeout(FINALIZATION_TIMEOUT, async {
+        let mut absent_observations = 0;
         loop {
-            if finalized_submission_exists(eth_api, gear_block, expected_root).await? {
-                return Ok::<bool, ethereum_client::Error>(true);
-            }
-
-            let exists_at_chainhead = if expected_root == [0; 32] {
-                rpc::retry_eth_bounded(
-                    eth_api,
-                    "read chainhead MessageQueue max block number",
-                    MAX_RETRIES,
-                    |api| async move { api.max_block_number().await },
-                )
-                .await?
-                    >= gear_block
-            } else {
-                rpc::retry_eth_bounded(
-                    eth_api,
-                    "read chainhead MessageQueue merkle root",
-                    MAX_RETRIES,
-                    |api| async move { api.read_chainhead_merkle_root(gear_block).await },
-                )
-                .await?
-                    == Some(expected_root)
-            };
-            if !exists_at_chainhead {
-                return Ok(false);
+            match current_submission_state(eth_api, gear_block, expected_root).await? {
+                SubmissionState::Finalized => {
+                    return Ok::<SubmissionState, ethereum_client::Error>(
+                        SubmissionState::Finalized,
+                    );
+                }
+                SubmissionState::Pending => absent_observations = 0,
+                SubmissionState::Absent => {
+                    absent_observations += 1;
+                    if absent_observations >= ABSENCE_OBSERVATIONS_REQUIRED {
+                        return Ok(SubmissionState::Absent);
+                    }
+                }
             }
             tokio::time::sleep(FINALIZATION_POLL_INTERVAL).await;
         }
     })
     .await
-    .context("Timed out waiting for finalized MessageQueue merkle root")?
-    .map_err(Into::into)
+    {
+        Ok(result) => result.map_err(Into::into),
+        Err(_) => state_after_finalization_timeout(eth_api, gear_block, expected_root).await,
+    }
 }
 
 pub struct Request {
@@ -132,19 +207,27 @@ pub enum ResponseStatus {
 }
 
 pub struct SubmitterIo {
-    requests: UnboundedSender<Request>,
+    requests: Sender<Request>,
     responses: UnboundedReceiver<Response>,
 }
 
 impl SubmitterIo {
-    pub fn new(requests: UnboundedSender<Request>, responses: UnboundedReceiver<Response>) -> Self {
+    pub fn new(requests: Sender<Request>, responses: UnboundedReceiver<Response>) -> Self {
         Self {
             requests,
             responses,
         }
     }
+    pub(super) fn request_sender(&self) -> Sender<Request> {
+        self.requests.clone()
+    }
 
-    pub fn submit_era_root(&self, era: u64, merkle_root_block: u32, proof: FinalProof) -> bool {
+    pub async fn submit_era_root(
+        &self,
+        era: u64,
+        merkle_root_block: u32,
+        proof: FinalProof,
+    ) -> bool {
         self.requests
             .send(Request {
                 era: Some(era),
@@ -152,10 +235,11 @@ impl SubmitterIo {
                 merkle_root: H256::from(proof.merkle_root),
                 proof,
             })
+            .await
             .is_ok()
     }
 
-    pub fn submit_merkle_root(
+    pub async fn submit_merkle_root(
         &self,
         merkle_root_block: u32,
         merkle_root: H256,
@@ -168,6 +252,7 @@ impl SubmitterIo {
                 merkle_root,
                 proof,
             })
+            .await
             .is_ok()
     }
 
@@ -178,20 +263,20 @@ impl SubmitterIo {
 
 struct ReconciledSubmission {
     request: Request,
-    finalized: bool,
+    state: Result<SubmissionState>,
 }
 
-async fn reconcile_submission(
-    mut eth_api: EthApi,
-    request: Request,
-) -> anyhow::Result<ReconciledSubmission> {
-    let finalized = wait_for_persisted_submission(
+async fn reconcile_submission(mut eth_api: EthApi, request: Request) -> ReconciledSubmission {
+    let state = wait_for_persisted_submission(
         &mut eth_api,
         request.proof.block_number,
         request.proof.merkle_root,
     )
-    .await?;
-    Ok(ReconciledSubmission { request, finalized })
+    .await;
+    if state.is_err() {
+        tokio::time::sleep(FINALIZATION_POLL_INTERVAL).await;
+    }
+    ReconciledSubmission { request, state }
 }
 
 struct SubmittedMerkleRoot {
@@ -200,7 +285,7 @@ struct SubmittedMerkleRoot {
     merkle_root: H256,
     proof: FinalProof,
     receipt: TransactionReceipt,
-    root_is_finalized: bool,
+    finalization: Result<SubmissionState>,
 }
 
 struct SubmissionError {
@@ -232,18 +317,11 @@ impl SubmittedMerkleRoot {
                 error: error.into(),
                 proof: proof.clone(),
             })?;
-        let root_is_finalized = if receipt.status() {
+        let finalization = if receipt.status() {
             wait_for_finalized_merkle_root(&mut eth_api, proof.block_number, proof.merkle_root)
                 .await
-                .map_err(|error| SubmissionError {
-                    era,
-                    merkle_root_block,
-                    merkle_root,
-                    error,
-                    proof: proof.clone(),
-                })?
         } else {
-            false
+            Ok(SubmissionState::Absent)
         };
 
         Ok(Self {
@@ -252,8 +330,17 @@ impl SubmittedMerkleRoot {
             era,
             proof,
             receipt,
-            root_is_finalized,
+            finalization,
         })
+    }
+
+    fn reconciliation_request(&self) -> Request {
+        Request {
+            era: self.era,
+            merkle_root_block: self.merkle_root_block,
+            merkle_root: self.merkle_root,
+            proof: self.proof.clone(),
+        }
     }
 }
 
@@ -337,13 +424,20 @@ impl MerkleRootSubmitter {
 
     async fn process(
         &mut self,
-        proofs: &mut UnboundedReceiver<Request>,
+        proofs: &mut Receiver<Request>,
         responses: &UnboundedSender<Response>,
     ) -> anyhow::Result<()> {
         let mut pending_transactions = FuturesUnordered::new();
         let mut pending_reconciliations = FuturesUnordered::new();
+        let mut reconciliation_requests = VecDeque::new();
         let mut retry_requests = VecDeque::new();
         loop {
+            while pending_reconciliations.len() < MAX_PENDING_RECONCILIATIONS {
+                let Some(request) = reconciliation_requests.pop_front() else {
+                    break;
+                };
+                pending_reconciliations.push(reconcile_submission(self.eth_api.clone(), request));
+            }
             let relayer_id = self.relayer_id.clone();
             match self.eth_api.get_approx_balance().await {
                 Ok(balance) => self.metrics.fee_payer_balance.set(balance),
@@ -351,9 +445,13 @@ impl MerkleRootSubmitter {
                     "Merkle root relayer {relayer_id}: failed to update Ethereum fee payer balance metric: {err}"
                 ),
             }
-            self.metrics
-                .pending_submissions
-                .set(pending_transactions.len() as i64);
+            let tracked_work = pending_transactions.len()
+                + pending_reconciliations.len()
+                + reconciliation_requests.len()
+                + retry_requests.len();
+            let can_process_request = pending_transactions.len() < MAX_PENDING_TRANSACTIONS
+                && (!retry_requests.is_empty() || tracked_work < MAX_PENDING_SUBMISSION_WORK);
+            self.metrics.pending_submissions.set(tracked_work as i64);
 
             tokio::select! {
                 request = async {
@@ -361,7 +459,7 @@ impl MerkleRootSubmitter {
                         Some(request) => Some(request),
                         None => proofs.recv().await,
                     }
-                } => {
+                }, if can_process_request => {
                     let Some(request) = request else {
                         log::info!(
                             "Merkle root relayer {relayer_id}: no more proofs to process, exiting"
@@ -377,10 +475,7 @@ impl MerkleRootSubmitter {
                         )
                         .await
                     {
-                        pending_reconciliations.push(reconcile_submission(
-                            self.eth_api.clone(),
-                            request,
-                        ));
+                        reconciliation_requests.push_back(request);
                         continue;
                     }
 
@@ -423,39 +518,49 @@ impl MerkleRootSubmitter {
                         // - Relayer crashed and already submitted the merkle root but not yet confirmed it
                         // - Somebody else submitted the merkle root
                         Err(ethereum_client::Error::ErrorDuringContractExecution(err)) => {
-                            let root_exists = finalized_submission_exists(
+                            match current_submission_state(
                                 &mut self.eth_api,
                                 request.proof.block_number,
                                 request.proof.merkle_root,
                             )
-                            .await?;
-                            if root_exists {
-                                log::warn!("Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted, contract execution failed: {err:?}", H256::from(request.proof.merkle_root), request.merkle_root_block);
-                                if responses.send(Response {
-                                    era: request.era,
-                                    merkle_root_block: request.merkle_root_block,
-                                    merkle_root: request.merkle_root,
-                                    status: ResponseStatus::Submitted,
-                                    proof: request.proof.clone(),
-                                }).is_err() {
-                                    return Ok(());
-                                };
-                                continue;
-                            } else {
-                                log::error!("Merkle root relayer {relayer_id}: failed to submit merkle root {}: Error during contract execution: {err:?}", H256::from(request.proof.merkle_root));
-                                self.metrics.failed_submissions.inc();
-                                self.storage.submission_failed(request.proof.block_number, H256::from(request.proof.merkle_root)).await;
-                                if responses.send(Response {
-                                    era: request.era,
-                                    merkle_root_block: request.merkle_root_block,
-                                    merkle_root: request.merkle_root,
-                                    status: ResponseStatus::Failed("Error during contract execution".to_string()),
-                                    proof: request.proof.clone(),
-                                }).is_err() {
-                                    return Ok(());
-                                };
-                                continue;
+                            .await?
+                            {
+                                SubmissionState::Finalized => {
+                                    log::warn!("Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted, contract execution failed: {err:?}", H256::from(request.proof.merkle_root), request.merkle_root_block);
+                                    if responses.send(Response {
+                                        era: request.era,
+                                        merkle_root_block: request.merkle_root_block,
+                                        merkle_root: request.merkle_root,
+                                        status: ResponseStatus::Submitted,
+                                        proof: request.proof.clone(),
+                                    }).is_err() {
+                                        return Ok(());
+                                    };
+                                }
+                                SubmissionState::Pending => {
+                                    log::warn!("Merkle root relayer {relayer_id}: merkle root {} for block #{} is canonical but not finalized after contract execution failed: {err:?}", H256::from(request.proof.merkle_root), request.merkle_root_block);
+                                    self.storage.submitted_merkle_root(
+                                        request.merkle_root_block,
+                                        H256::from(request.proof.merkle_root),
+                                    ).await;
+                                    reconciliation_requests.push_back(request);
+                                }
+                                SubmissionState::Absent => {
+                                    log::error!("Merkle root relayer {relayer_id}: failed to submit merkle root {}: Error during contract execution: {err:?}", H256::from(request.proof.merkle_root));
+                                    self.metrics.failed_submissions.inc();
+                                    self.storage.submission_failed(request.proof.block_number, H256::from(request.proof.merkle_root)).await;
+                                    if responses.send(Response {
+                                        era: request.era,
+                                        merkle_root_block: request.merkle_root_block,
+                                        merkle_root: request.merkle_root,
+                                        status: ResponseStatus::Failed("Error during contract execution".to_string()),
+                                        proof: request.proof.clone(),
+                                    }).is_err() {
+                                        return Ok(());
+                                    };
+                                }
                             }
+                            continue;
                         }
                         Err(err) => {
 
@@ -476,40 +581,53 @@ impl MerkleRootSubmitter {
                     }
                 },
 
-                Some(result) = pending_reconciliations.next() => {
-                    let reconciled = result?;
+                Some(reconciled) = pending_reconciliations.next() => {
                     let request = reconciled.request;
-                    if reconciled.finalized {
-                        log::info!(
-                            "Merkle root relayer {relayer_id}: merkle root {} for block #{} is already finalized",
-                            H256::from(request.proof.merkle_root),
-                            request.merkle_root_block
-                        );
-                        if responses
-                            .send(Response {
-                                era: request.era,
-                                merkle_root_block: request.merkle_root_block,
-                                merkle_root: request.merkle_root,
-                                status: ResponseStatus::Submitted,
-                                proof: request.proof,
-                            })
-                            .is_err()
-                        {
-                            return Ok(());
-                        }
-                    } else {
-                        log::warn!(
-                            "Merkle root relayer {relayer_id}: persisted submission marker for merkle root {} at block #{} is not on the canonical chain; resubmitting",
-                            H256::from(request.proof.merkle_root),
-                            request.merkle_root_block
-                        );
-                        self.storage
-                            .submission_failed(
-                                request.merkle_root_block,
+                    match reconciled.state {
+                        Ok(SubmissionState::Finalized) => {
+                            log::info!(
+                                "Merkle root relayer {relayer_id}: merkle root {} for block #{} is already finalized",
                                 H256::from(request.proof.merkle_root),
-                            )
-                            .await;
-                        retry_requests.push_back(request);
+                                request.merkle_root_block
+                            );
+                            if responses
+                                .send(Response {
+                                    era: request.era,
+                                    merkle_root_block: request.merkle_root_block,
+                                    merkle_root: request.merkle_root,
+                                    status: ResponseStatus::Submitted,
+                                    proof: request.proof,
+                                })
+                                .is_err()
+                            {
+                                return Ok(());
+                            }
+                        }
+                        Ok(SubmissionState::Absent) => {
+                            log::warn!(
+                                "Merkle root relayer {relayer_id}: persisted submission marker for merkle root {} at block #{} is absent from chain head; resubmitting",
+                                H256::from(request.proof.merkle_root),
+                                request.merkle_root_block
+                            );
+                            self.storage
+                                .submission_failed(
+                                    request.merkle_root_block,
+                                    H256::from(request.proof.merkle_root),
+                                )
+                                .await;
+                            retry_requests.push_back(request);
+                        }
+                        Ok(SubmissionState::Pending) => {
+                            reconciliation_requests.push_back(request);
+                        }
+                        Err(err) => {
+                            log::warn!(
+                                "Merkle root relayer {relayer_id}: failed to reconcile merkle root {} at block #{}: {err}; retaining submission marker",
+                                H256::from(request.proof.merkle_root),
+                                request.merkle_root_block
+                            );
+                            reconciliation_requests.push_back(request);
+                        }
                     }
                 },
 
@@ -529,137 +647,158 @@ impl MerkleRootSubmitter {
                             self.metrics.last_gas_used.set(gas_used);
 
                             if !submitted.receipt.status() {
-                                let root_exists = finalized_submission_exists(
+                                match current_submission_state(
                                     &mut self.eth_api,
                                     submitted.proof.block_number,
                                     submitted.proof.merkle_root,
                                 )
-                                .await?;
+                                .await?
+                                {
+                                    SubmissionState::Finalized => {
+                                        if responses
+                                            .send(Response {
+                                                era: submitted.era,
+                                                merkle_root_block: submitted.merkle_root_block,
+                                                merkle_root: submitted.merkle_root,
+                                                status: ResponseStatus::Submitted,
+                                                proof: submitted.proof.clone(),
+                                            })
+                                            .is_err()
+                                        {
+                                            return Ok(());
+                                        };
+                                        log::info!(
+                                            "Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted",
+                                            submitted.merkle_root,
+                                            submitted.merkle_root_block
+                                        );
+                                    }
+                                    SubmissionState::Pending => {
+                                        log::warn!(
+                                            "Merkle root relayer {relayer_id}: merkle root {} for block #{} is canonical despite reverted transaction; retaining submission marker",
+                                            submitted.merkle_root,
+                                            submitted.merkle_root_block
+                                        );
+                                        reconciliation_requests
+                                            .push_back(submitted.reconciliation_request());
+                                    }
+                                    SubmissionState::Absent => {
+                                        self.storage
+                                            .submission_failed(
+                                                submitted.merkle_root_block,
+                                                H256::from(submitted.proof.merkle_root),
+                                            )
+                                            .await;
+                                        if responses
+                                            .send(Response {
+                                                era: submitted.era,
+                                                merkle_root_block: submitted.merkle_root_block,
+                                                merkle_root: submitted.merkle_root,
+                                                status: ResponseStatus::Failed(format!(
+                                                    "Transaction {} failed",
+                                                    submitted.receipt.transaction_hash
+                                                )),
+                                                proof: submitted.proof.clone(),
+                                            })
+                                            .is_err()
+                                        {
+                                            return Ok(());
+                                        };
+                                    }
+                                }
+                                continue;
+                            }
 
-                                if root_exists {
-                                    if responses
-                                        .send(Response {
-                                            era: submitted.era,
-                                            merkle_root_block: submitted.merkle_root_block,
-                                            merkle_root: submitted.merkle_root,
-                                            status: ResponseStatus::Submitted,
-                                            proof: submitted.proof.clone(),
-                                        })
-                                        .is_err()
-                                    {
+                            match &submitted.finalization {
+                                Ok(SubmissionState::Finalized) => {
+                                    if responses.send(Response {
+                                        era: submitted.era,
+                                        merkle_root_block: submitted.merkle_root_block,
+                                        merkle_root: submitted.merkle_root,
+                                        status: ResponseStatus::Submitted,
+                                        proof: submitted.proof.clone(),
+                                    }).is_err() {
                                         return Ok(());
                                     };
+                                    self.metrics.last_submitted_block.set(submitted.merkle_root_block as i64);
                                     log::info!(
-                                        "Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted",
+                                        "Merkle root relayer {relayer_id}: merkle root {} for block #{} submission confirmed after {} confirmations",
+                                        submitted.merkle_root,
+                                        submitted.merkle_root_block,
+                                        self.confirmations
+                                    );
+                                }
+                                Ok(SubmissionState::Pending) => {
+                                    log::warn!(
+                                        "Merkle root relayer {relayer_id}: merkle root {} for block #{} is canonical but not finalized; retaining submission marker",
                                         submitted.merkle_root,
                                         submitted.merkle_root_block
                                     );
-                                    continue;
+                                    reconciliation_requests
+                                        .push_back(submitted.reconciliation_request());
                                 }
-
-                                self.storage
-                                    .submission_failed(
-                                        submitted.merkle_root_block,
-                                        H256::from(submitted.proof.merkle_root),
-                                    )
-                                    .await;
-                                if responses
-                                    .send(Response {
-                                        era: submitted.era,
-                                        merkle_root_block: submitted.merkle_root_block,
-                                        merkle_root: submitted.merkle_root,
-                                        status: ResponseStatus::Failed(format!(
-                                            "Transaction {} failed",
-                                            submitted.receipt.transaction_hash
-                                        )),
-                                        proof: submitted.proof.clone(),
-                                    })
-                                    .is_err()
-                                {
-                                    return Ok(());
-                                };
-                                continue;
-                            }
-
-                            if !submitted.root_is_finalized {
-                                self.storage
-                                    .submission_failed(
-                                        submitted.merkle_root_block,
-                                        H256::from(submitted.proof.merkle_root),
-                                    )
-                                    .await;
-                                if responses
-                                    .send(Response {
-                                        era: submitted.era,
-                                        merkle_root_block: submitted.merkle_root_block,
-                                        merkle_root: submitted.merkle_root,
-                                        status: ResponseStatus::Failed(
-                                            "Confirmed transaction did not store the expected merkle root"
-                                                .to_string(),
-                                        ),
-                                        proof: submitted.proof.clone(),
-                                    })
-                                    .is_err()
-                                {
-                                    return Ok(());
+                                Err(err) => {
+                                    log::warn!(
+                                        "Merkle root relayer {relayer_id}: failed to inspect finality for merkle root {} at block #{}: {err}; retaining submission marker",
+                                        submitted.merkle_root,
+                                        submitted.merkle_root_block
+                                    );
+                                    reconciliation_requests
+                                        .push_back(submitted.reconciliation_request());
                                 }
-                                continue;
+                                Ok(SubmissionState::Absent) => {
+                                    log::warn!(
+                                        "Merkle root relayer {relayer_id}: confirmed transaction {} is absent from chain head; clearing its marker and resubmitting merkle root {} at block #{}",
+                                        submitted.receipt.transaction_hash,
+                                        submitted.merkle_root,
+                                        submitted.merkle_root_block,
+                                    );
+                                    self.storage
+                                        .submission_failed(
+                                            submitted.merkle_root_block,
+                                            H256::from(submitted.proof.merkle_root),
+                                        )
+                                        .await;
+                                    retry_requests.push_back(submitted.reconciliation_request());
+                                }
                             }
-
-                            if responses.send(Response {
-                                era: submitted.era,
-                                merkle_root_block: submitted.merkle_root_block,
-                                merkle_root: submitted.merkle_root,
-                                status: ResponseStatus::Submitted,
-                                proof: submitted.proof.clone(),
-                            }).is_err() {
-                                return Ok(());
-                            };
-                            self.metrics.last_submitted_block.set(submitted.merkle_root_block as i64);
-                            log::info!(
-                                "Merkle root relayer {relayer_id}: merkle root {} for block #{} submission confirmed after {} confirmations",
-                                submitted.merkle_root,
-                                submitted.merkle_root_block,
-                                self.confirmations
-                            );
-                            self.metrics.pending_submissions.dec();
                         }
 
                         Err(err) => {
-                            let root_exists = finalized_submission_exists(
+                            match finalized_submission_exists(
                                 &mut self.eth_api,
                                 err.proof.block_number,
                                 err.proof.merkle_root,
                             )
-                            .await?;
-
-                            if root_exists {
-                                if responses.send(Response {
-                                    era: err.era,
-                                    merkle_root_block: err.merkle_root_block,
-                                    merkle_root: err.merkle_root,
-                                    status: ResponseStatus::Submitted,
-                                    proof: err.proof,
-                                }).is_err() {
-                                    return Ok(());
-                                };
-                                log::info!("Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted", err.merkle_root, err.merkle_root_block);
-                                continue;
+                            .await
+                            {
+                                Ok(true) => {
+                                    if responses.send(Response {
+                                        era: err.era,
+                                        merkle_root_block: err.merkle_root_block,
+                                        merkle_root: err.merkle_root,
+                                        status: ResponseStatus::Submitted,
+                                        proof: err.proof,
+                                    }).is_err() {
+                                        return Ok(());
+                                    };
+                                    log::info!("Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted", err.merkle_root, err.merkle_root_block);
+                                }
+                                state => {
+                                    log::warn!(
+                                        "Merkle root relayer {relayer_id}: receipt lookup for merkle root {} at block #{} failed: {}; retaining submission marker ({state:?})",
+                                        err.merkle_root,
+                                        err.merkle_root_block,
+                                        err.error
+                                    );
+                                    reconciliation_requests.push_back(Request {
+                                        era: err.era,
+                                        merkle_root_block: err.merkle_root_block,
+                                        merkle_root: err.merkle_root,
+                                        proof: err.proof,
+                                    });
+                                }
                             }
-
-                            log::error!("Merkle root relayer {relayer_id}: failed to submit merkle root {}: {}", err.merkle_root, err.error);
-                            self.metrics.pending_submissions.dec();
-                            self.metrics.failed_submissions.inc();
-                            self.storage.submission_failed(err.merkle_root_block, H256::from(err.proof.merkle_root)).await;
-                            if responses.send(Response {
-                                era: err.era,
-                                merkle_root_block: err.merkle_root_block,
-                                merkle_root: err.merkle_root,
-                                status: ResponseStatus::Failed(err.error.to_string()),
-                                proof: err.proof,
-                            }).is_err() {
-                                return Ok(());
-                            };
                         }
                     }
                 }
@@ -668,7 +807,7 @@ impl MerkleRootSubmitter {
     }
 
     pub fn run(self) -> SubmitterIo {
-        let (tx, rx) = unbounded_channel();
+        let (tx, rx) = channel(MAX_PENDING_SUBMISSION_WORK);
         let (response_tx, response_rx) = unbounded_channel();
 
         tokio::task::spawn(task(self, rx, response_tx));
@@ -679,7 +818,7 @@ impl MerkleRootSubmitter {
 
 async fn task(
     mut this: MerkleRootSubmitter,
-    mut proofs: UnboundedReceiver<Request>,
+    mut proofs: Receiver<Request>,
     responses: UnboundedSender<Response>,
 ) {
     if let Err(err) = this.process(&mut proofs, &responses).await {
@@ -690,5 +829,68 @@ async fn task(
             "Merkle root relayer {} submitter failed, exiting: {err}",
             this.relayer_id
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        submission_state, FinalProof, Request, Response, ResponseStatus, SubmissionState,
+        SubmitterIo, H256,
+    };
+    use tokio::sync::mpsc::{channel, unbounded_channel};
+
+    fn proof() -> FinalProof {
+        FinalProof {
+            proof: Vec::new(),
+            block_number: 1,
+            merkle_root: [1; 32],
+        }
+    }
+
+    fn request() -> Request {
+        Request {
+            era: None,
+            merkle_root_block: 1,
+            merkle_root: H256::repeat_byte(1),
+            proof: proof(),
+        }
+    }
+
+    #[test]
+    fn chainhead_submission_stays_pending_until_finalized() {
+        assert_eq!(submission_state(false, true), SubmissionState::Pending);
+        assert_eq!(submission_state(true, true), SubmissionState::Finalized);
+    }
+
+    #[test]
+    fn submission_is_absent_only_from_both_views() {
+        assert_eq!(submission_state(false, false), SubmissionState::Absent);
+    }
+
+    #[tokio::test]
+    async fn full_request_queue_does_not_block_response_reception() {
+        let (requests, _requests_rx) = channel(1);
+        let (responses, response_rx) = unbounded_channel();
+        let mut io = SubmitterIo::new(requests, response_rx);
+        io.request_sender().try_send(request()).unwrap();
+
+        let sender = io.request_sender();
+        let blocked_send = sender.send(request());
+        tokio::pin!(blocked_send);
+        responses
+            .send(Response {
+                era: None,
+                merkle_root_block: 1,
+                merkle_root: H256::repeat_byte(1),
+                proof: proof(),
+                status: ResponseStatus::Submitted,
+            })
+            .unwrap();
+
+        tokio::select! {
+            _ = &mut blocked_send => panic!("full request queue unexpectedly accepted work"),
+            response = io.recv() => assert_eq!(response.unwrap().merkle_root_block, 1),
+        }
     }
 }

--- a/relayer/src/merkle_roots/submitter.rs
+++ b/relayer/src/merkle_roots/submitter.rs
@@ -1,8 +1,7 @@
 use alloy::{
-    network::Ethereum,
-    providers::{PendingTransactionBuilder, PendingTransactionError},
-    rpc::types::TransactionReceipt,
+    network::Ethereum, providers::PendingTransactionBuilder, rpc::types::TransactionReceipt,
 };
+use anyhow::Context;
 use ethereum_client::EthApi;
 use futures::{stream::FuturesUnordered, StreamExt};
 use primitive_types::H256;
@@ -10,7 +9,7 @@ use prometheus::{
     core::{AtomicU64, GenericCounter, GenericGauge},
     Gauge, IntCounter, IntGauge,
 };
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc, time::Duration};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use utils_prometheus::{impl_metered_service, MeteredService};
 
@@ -21,6 +20,95 @@ use crate::{
 };
 
 use super::storage::MerkleRootStorage;
+const FINALIZATION_POLL_INTERVAL: Duration = Duration::from_secs(12);
+const FINALIZATION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+async fn finalized_submission_exists(
+    eth_api: &mut EthApi,
+    gear_block: u32,
+    expected_root: [u8; 32],
+) -> Result<bool, ethereum_client::Error> {
+    if expected_root == [0; 32] {
+        return rpc::retry_eth_bounded(
+            eth_api,
+            "read finalized MessageQueue max block number",
+            MAX_RETRIES,
+            |api| async move { api.finalized_max_block_number().await },
+        )
+        .await
+        .map(|block| block >= gear_block);
+    }
+
+    rpc::retry_eth_bounded(
+        eth_api,
+        "read finalized MessageQueue merkle root",
+        MAX_RETRIES,
+        |api| async move { api.read_finalized_merkle_root(gear_block).await },
+    )
+    .await
+    .map(|root| root == Some(expected_root))
+}
+
+async fn wait_for_persisted_submission(
+    eth_api: &mut EthApi,
+    gear_block: u32,
+    expected_root: [u8; 32],
+) -> anyhow::Result<bool> {
+    match tokio::time::timeout(FINALIZATION_TIMEOUT, async {
+        loop {
+            if finalized_submission_exists(eth_api, gear_block, expected_root).await? {
+                return Ok::<bool, ethereum_client::Error>(true);
+            }
+            tokio::time::sleep(FINALIZATION_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result.map_err(Into::into),
+        Err(_) => Ok(false),
+    }
+}
+
+async fn wait_for_finalized_merkle_root(
+    eth_api: &mut EthApi,
+    gear_block: u32,
+    expected_root: [u8; 32],
+) -> anyhow::Result<bool> {
+    tokio::time::timeout(FINALIZATION_TIMEOUT, async {
+        loop {
+            if finalized_submission_exists(eth_api, gear_block, expected_root).await? {
+                return Ok::<bool, ethereum_client::Error>(true);
+            }
+
+            let exists_at_chainhead = if expected_root == [0; 32] {
+                rpc::retry_eth_bounded(
+                    eth_api,
+                    "read chainhead MessageQueue max block number",
+                    MAX_RETRIES,
+                    |api| async move { api.max_block_number().await },
+                )
+                .await?
+                    >= gear_block
+            } else {
+                rpc::retry_eth_bounded(
+                    eth_api,
+                    "read chainhead MessageQueue merkle root",
+                    MAX_RETRIES,
+                    |api| async move { api.read_chainhead_merkle_root(gear_block).await },
+                )
+                .await?
+                    == Some(expected_root)
+            };
+            if !exists_at_chainhead {
+                return Ok(false);
+            }
+            tokio::time::sleep(FINALIZATION_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .context("Timed out waiting for finalized MessageQueue merkle root")?
+    .map_err(Into::into)
+}
 
 pub struct Request {
     pub era: Option<u64>,
@@ -88,12 +176,31 @@ impl SubmitterIo {
     }
 }
 
+struct ReconciledSubmission {
+    request: Request,
+    finalized: bool,
+}
+
+async fn reconcile_submission(
+    mut eth_api: EthApi,
+    request: Request,
+) -> anyhow::Result<ReconciledSubmission> {
+    let finalized = wait_for_persisted_submission(
+        &mut eth_api,
+        request.proof.block_number,
+        request.proof.merkle_root,
+    )
+    .await?;
+    Ok(ReconciledSubmission { request, finalized })
+}
+
 struct SubmittedMerkleRoot {
     era: Option<u64>,
     merkle_root_block: u32,
     merkle_root: H256,
     proof: FinalProof,
     receipt: TransactionReceipt,
+    root_is_finalized: bool,
 }
 
 struct SubmissionError {
@@ -101,34 +208,51 @@ struct SubmissionError {
     merkle_root_block: u32,
     merkle_root: H256,
     proof: FinalProof,
-    error: PendingTransactionError,
+    error: anyhow::Error,
 }
 
 impl SubmittedMerkleRoot {
     async fn new(
         pending_tx: PendingTransactionBuilder<Ethereum>,
+        mut eth_api: EthApi,
         era: Option<u64>,
         merkle_root_block: u32,
         merkle_root: H256,
         proof: FinalProof,
         confirmations: u64,
     ) -> Result<Self, SubmissionError> {
-        Ok(Self {
-            merkle_root_block,
-            merkle_root,
-            era,
-            proof: proof.clone(),
-            receipt: pending_tx
-                .with_required_confirmations(confirmations)
-                .get_receipt()
+        let receipt = pending_tx
+            .with_required_confirmations(confirmations)
+            .get_receipt()
+            .await
+            .map_err(|error| SubmissionError {
+                era,
+                merkle_root_block,
+                merkle_root,
+                error: error.into(),
+                proof: proof.clone(),
+            })?;
+        let root_is_finalized = if receipt.status() {
+            wait_for_finalized_merkle_root(&mut eth_api, proof.block_number, proof.merkle_root)
                 .await
                 .map_err(|error| SubmissionError {
                     era,
                     merkle_root_block,
                     merkle_root,
                     error,
-                    proof,
-                })?,
+                    proof: proof.clone(),
+                })?
+        } else {
+            false
+        };
+
+        Ok(Self {
+            merkle_root_block,
+            merkle_root,
+            era,
+            proof,
+            receipt,
+            root_is_finalized,
         })
     }
 }
@@ -211,25 +335,14 @@ impl MerkleRootSubmitter {
         }
     }
 
-    async fn read_finalized_merkle_root(
-        &mut self,
-        gear_block: u32,
-    ) -> Result<Option<[u8; 32]>, ethereum_client::Error> {
-        rpc::retry_eth_bounded(
-            &mut self.eth_api,
-            "read finalized MessageQueue merkle root",
-            MAX_RETRIES,
-            |api| async move { api.read_finalized_merkle_root(gear_block).await },
-        )
-        .await
-    }
-
     async fn process(
         &mut self,
         proofs: &mut UnboundedReceiver<Request>,
         responses: &UnboundedSender<Response>,
     ) -> anyhow::Result<()> {
         let mut pending_transactions = FuturesUnordered::new();
+        let mut pending_reconciliations = FuturesUnordered::new();
+        let mut retry_requests = VecDeque::new();
         loop {
             let relayer_id = self.relayer_id.clone();
             match self.eth_api.get_approx_balance().await {
@@ -243,7 +356,12 @@ impl MerkleRootSubmitter {
                 .set(pending_transactions.len() as i64);
 
             tokio::select! {
-                request = proofs.recv() => {
+                request = async {
+                    match retry_requests.pop_front() {
+                        Some(request) => Some(request),
+                        None => proofs.recv().await,
+                    }
+                } => {
                     let Some(request) = request else {
                         log::info!(
                             "Merkle root relayer {relayer_id}: no more proofs to process, exiting"
@@ -251,18 +369,18 @@ impl MerkleRootSubmitter {
                         return Ok(());
                     };
 
-                    if self.storage.is_merkle_root_submitted(request.merkle_root_block, H256::from(request.proof.merkle_root)).await {
-                        log::info!(
-                            "Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted", H256::from(request.proof.merkle_root), request.merkle_root_block);
-                        if responses.send(Response {
-                            era: request.era,
-                            merkle_root_block: request.merkle_root_block,
-                            merkle_root: request.merkle_root,
-                            status: ResponseStatus::Submitted,
-                            proof: request.proof,
-                        }).is_err() {
-                            return Ok(());
-                        };
+                    if self
+                        .storage
+                        .is_merkle_root_submitted(
+                            request.merkle_root_block,
+                            H256::from(request.proof.merkle_root),
+                        )
+                        .await
+                    {
+                        pending_reconciliations.push(reconcile_submission(
+                            self.eth_api.clone(),
+                            request,
+                        ));
                         continue;
                     }
 
@@ -286,6 +404,7 @@ impl MerkleRootSubmitter {
                             self.metrics.total_submissions.inc();
                             pending_transactions.push(SubmittedMerkleRoot::new(
                                 pending_tx,
+                                self.eth_api.clone(),
                                 request.era,
                                 request.merkle_root_block,
                                 request.merkle_root,
@@ -304,10 +423,12 @@ impl MerkleRootSubmitter {
                         // - Relayer crashed and already submitted the merkle root but not yet confirmed it
                         // - Somebody else submitted the merkle root
                         Err(ethereum_client::Error::ErrorDuringContractExecution(err)) => {
-                            let root_exists = self.read_finalized_merkle_root(request.proof.block_number)
-                                .await?
-                                .is_some();
-
+                            let root_exists = finalized_submission_exists(
+                                &mut self.eth_api,
+                                request.proof.block_number,
+                                request.proof.merkle_root,
+                            )
+                            .await?;
                             if root_exists {
                                 log::warn!("Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted, contract execution failed: {err:?}", H256::from(request.proof.merkle_root), request.merkle_root_block);
                                 if responses.send(Response {
@@ -355,6 +476,43 @@ impl MerkleRootSubmitter {
                     }
                 },
 
+                Some(result) = pending_reconciliations.next() => {
+                    let reconciled = result?;
+                    let request = reconciled.request;
+                    if reconciled.finalized {
+                        log::info!(
+                            "Merkle root relayer {relayer_id}: merkle root {} for block #{} is already finalized",
+                            H256::from(request.proof.merkle_root),
+                            request.merkle_root_block
+                        );
+                        if responses
+                            .send(Response {
+                                era: request.era,
+                                merkle_root_block: request.merkle_root_block,
+                                merkle_root: request.merkle_root,
+                                status: ResponseStatus::Submitted,
+                                proof: request.proof,
+                            })
+                            .is_err()
+                        {
+                            return Ok(());
+                        }
+                    } else {
+                        log::warn!(
+                            "Merkle root relayer {relayer_id}: persisted submission marker for merkle root {} at block #{} is not on the canonical chain; resubmitting",
+                            H256::from(request.proof.merkle_root),
+                            request.merkle_root_block
+                        );
+                        self.storage
+                            .submission_failed(
+                                request.merkle_root_block,
+                                H256::from(request.proof.merkle_root),
+                            )
+                            .await;
+                        retry_requests.push_back(request);
+                    }
+                },
+
                 Some(result) = pending_transactions.next() => {
                     match result {
                         Ok(submitted) => {
@@ -371,33 +529,81 @@ impl MerkleRootSubmitter {
                             self.metrics.last_gas_used.set(gas_used);
 
                             if !submitted.receipt.status() {
-                                let root_exists = self.read_finalized_merkle_root(submitted.proof.block_number)
-                                    .await?
-                                    .is_some();
+                                let root_exists = finalized_submission_exists(
+                                    &mut self.eth_api,
+                                    submitted.proof.block_number,
+                                    submitted.proof.merkle_root,
+                                )
+                                .await?;
 
                                 if root_exists {
-                                    if responses.send(Response {
-                                        era: submitted.era,
-                                        merkle_root_block: submitted.merkle_root_block,
-                                        merkle_root: submitted.merkle_root,
-                                        status: ResponseStatus::Submitted,
-                                        proof: submitted.proof.clone(),
-                                    }).is_err() {
+                                    if responses
+                                        .send(Response {
+                                            era: submitted.era,
+                                            merkle_root_block: submitted.merkle_root_block,
+                                            merkle_root: submitted.merkle_root,
+                                            status: ResponseStatus::Submitted,
+                                            proof: submitted.proof.clone(),
+                                        })
+                                        .is_err()
+                                    {
                                         return Ok(());
                                     };
-                                    log::info!("Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted", submitted.merkle_root, submitted.merkle_root_block);
+                                    log::info!(
+                                        "Merkle root relayer {relayer_id}: merkle root {} for block #{} is already submitted",
+                                        submitted.merkle_root,
+                                        submitted.merkle_root_block
+                                    );
                                     continue;
                                 }
 
-                                if responses.send(Response {
-                                    era: submitted.era,
-                                    merkle_root_block: submitted.merkle_root_block,
-                                    merkle_root: submitted.merkle_root,
-                                    status: ResponseStatus::Failed(format!("Transaction {} failed", submitted.receipt.transaction_hash)),
-                                    proof: submitted.proof.clone(),
-                                }).is_err() {
+                                self.storage
+                                    .submission_failed(
+                                        submitted.merkle_root_block,
+                                        H256::from(submitted.proof.merkle_root),
+                                    )
+                                    .await;
+                                if responses
+                                    .send(Response {
+                                        era: submitted.era,
+                                        merkle_root_block: submitted.merkle_root_block,
+                                        merkle_root: submitted.merkle_root,
+                                        status: ResponseStatus::Failed(format!(
+                                            "Transaction {} failed",
+                                            submitted.receipt.transaction_hash
+                                        )),
+                                        proof: submitted.proof.clone(),
+                                    })
+                                    .is_err()
+                                {
                                     return Ok(());
                                 };
+                                continue;
+                            }
+
+                            if !submitted.root_is_finalized {
+                                self.storage
+                                    .submission_failed(
+                                        submitted.merkle_root_block,
+                                        H256::from(submitted.proof.merkle_root),
+                                    )
+                                    .await;
+                                if responses
+                                    .send(Response {
+                                        era: submitted.era,
+                                        merkle_root_block: submitted.merkle_root_block,
+                                        merkle_root: submitted.merkle_root,
+                                        status: ResponseStatus::Failed(
+                                            "Confirmed transaction did not store the expected merkle root"
+                                                .to_string(),
+                                        ),
+                                        proof: submitted.proof.clone(),
+                                    })
+                                    .is_err()
+                                {
+                                    return Ok(());
+                                }
+                                continue;
                             }
 
                             if responses.send(Response {
@@ -420,9 +626,12 @@ impl MerkleRootSubmitter {
                         }
 
                         Err(err) => {
-                            let root_exists = self.read_finalized_merkle_root(err.proof.block_number)
-                                .await?
-                                .is_some();
+                            let root_exists = finalized_submission_exists(
+                                &mut self.eth_api,
+                                err.proof.block_number,
+                                err.proof.merkle_root,
+                            )
+                            .await?;
 
                             if root_exists {
                                 if responses.send(Response {

--- a/relayer/src/message_relayer/common/gear/block_listener.rs
+++ b/relayer/src/message_relayer/common/gear/block_listener.rs
@@ -155,17 +155,31 @@ impl BlockListener {
             let block_hash = justification.commit.target_hash;
             let block_number = justification.commit.target_number;
 
-            // Check if there are missing blocks and fetch them
+            // GRANDPA justifications commonly skip block numbers. Replay the gap
+            // inline so slow archive RPCs cannot create overlapping replay tasks.
             if let Some(last_finalized) = *last_finalized_block_number {
-                if last_finalized + 1 != block_number {
+                if block_number <= last_finalized {
+                    log::trace!(
+                        "Gear block listener for relayer {}: skipping already replayed finalized block #{block_number}",
+                        self.relayer_id
+                    );
+                    continue;
+                }
+
+                if last_finalized.saturating_add(1) < block_number {
                     log::info!("Gear block listener for relayer {}: detected gap: last finalized block was #{last_finalized}, current block is #{block_number}", self.relayer_id);
 
-                    self.spawn_replay_range(
-                        tx.clone(),
-                        last_finalized + 1,
-                        block_number.saturating_sub(1),
-                        "live gap replay",
-                    );
+                    if !self
+                        .replay_gap(
+                            tx,
+                            last_finalized.saturating_add(1),
+                            block_number.saturating_sub(1),
+                            last_finalized_block_number,
+                        )
+                        .await?
+                    {
+                        return Ok(false);
+                    }
                 }
             }
 
@@ -235,6 +249,35 @@ impl BlockListener {
                 reason,
             );
         }
+    }
+
+    async fn replay_gap(
+        &mut self,
+        tx: &broadcast::Sender<GearBlock>,
+        from_block: u32,
+        to_block: u32,
+        last_finalized_block_number: &mut Option<u32>,
+    ) -> anyhow::Result<bool> {
+        log::info!(
+            "Gear block listener for relayer {} live gap replay: replaying blocks #{from_block}..=#{to_block}",
+            self.relayer_id
+        );
+        for block_number in from_block..=to_block {
+            log::trace!(
+                "Gear block listener for relayer {} live gap replay: replaying finalized block #{block_number}",
+                self.relayer_id
+            );
+            if !self.fetch_store_send(tx, block_number, None).await? {
+                return Ok(false);
+            }
+            *last_finalized_block_number = Some(block_number);
+            self.metrics.latest_block.set(block_number as i64);
+        }
+        log::info!(
+            "Gear block listener for relayer {} live gap replay: replay finished",
+            self.relayer_id
+        );
+        Ok(true)
     }
 
     fn spawn_replay_range(

--- a/relayer/src/message_relayer/common/gear/block_listener.rs
+++ b/relayer/src/message_relayer/common/gear/block_listener.rs
@@ -77,16 +77,27 @@ impl BlockListener {
             let mut last_finalized_block_number = None;
             if let Some(from_block) = first_block.or(last_block) {
                 log::info!(
-                    "Gear block listener for relayer {relayer_id}: unprocessed blocks found, replaying from #{} in background",
+                    "Gear block listener for relayer {relayer_id}: unprocessed blocks found, replaying from #{}",
                     from_block.1
                 );
-                self.spawn_replay_to_latest(
-                    tx2.clone(),
-                    from_block.1,
-                    &mut last_finalized_block_number,
-                    "startup catch-up",
-                )
-                .await;
+                match self
+                    .replay_to_latest(
+                        &tx2,
+                        from_block.1,
+                        &mut last_finalized_block_number,
+                        "startup catch-up",
+                    )
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => return,
+                    Err(err) => {
+                        log::error!(
+                            "Gear block listener for relayer {relayer_id}: startup replay failed: {err}"
+                        );
+                        return;
+                    }
+                }
             }
 
             loop {
@@ -124,13 +135,24 @@ impl BlockListener {
                 let from_block = last_finalized_block_number
                     .map(|block| block.saturating_add(1))
                     .unwrap_or_default();
-                self.spawn_replay_to_latest(
-                    tx2.clone(),
-                    from_block,
-                    &mut last_finalized_block_number,
-                    "reconnect replay",
-                )
-                .await;
+                match self
+                    .replay_to_latest(
+                        &tx2,
+                        from_block,
+                        &mut last_finalized_block_number,
+                        "reconnect replay",
+                    )
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => return,
+                    Err(err) => {
+                        log::error!(
+                            "Gear block listener for relayer {relayer_id}: reconnect replay failed: {err}"
+                        );
+                        return;
+                    }
+                }
             }
         });
 
@@ -175,6 +197,7 @@ impl BlockListener {
                             last_finalized.saturating_add(1),
                             block_number.saturating_sub(1),
                             last_finalized_block_number,
+                            "live gap replay",
                         )
                         .await?
                     {
@@ -199,56 +222,29 @@ impl BlockListener {
         Ok(true)
     }
 
-    async fn spawn_replay_to_latest(
+    async fn replay_to_latest(
         &mut self,
-        tx: broadcast::Sender<GearBlock>,
+        tx: &broadcast::Sender<GearBlock>,
         from_block: u32,
         last_finalized_block_number: &mut Option<u32>,
         reason: &'static str,
-    ) {
-        let latest = {
-            let client = self.api_provider.client();
-            match client.latest_finalized_block().await {
-                Ok(hash) => match client.block_hash_to_number(hash).await {
-                    Ok(number) => Some(number),
-                    Err(err) => {
-                        log::warn!(
-                            "Gear block listener for relayer {} failed to inspect latest finalized block number for {reason}: {err}. Background replay will retry latest lookup",
-                            self.relayer_id
-                        );
-                        None
-                    }
-                },
-                Err(err) => {
-                    log::warn!(
-                    "Gear block listener for relayer {} failed to inspect latest finalized block for {reason}: {err}. Background replay will retry latest lookup",
-                    self.relayer_id
-                );
-                    None
-                }
-            }
-        };
+    ) -> anyhow::Result<bool> {
+        let latest = rpc::retry_gear(
+            &mut self.api_provider,
+            "gear latest finalized block for replay",
+            |api| async move {
+                let hash = api.latest_finalized_block().await?;
+                api.block_hash_to_number(hash).await
+            },
+        )
+        .await?;
 
-        if let Some(latest) = latest {
-            if from_block > latest {
-                return;
-            }
-            *last_finalized_block_number = Some(
-                last_finalized_block_number
-                    .map(|current| current.max(latest))
-                    .unwrap_or(latest),
-            );
-            self.spawn_replay_range(tx, from_block, latest, reason);
-        } else {
-            spawn_replay_to_latest(
-                self.api_provider.clone(),
-                self.block_storage.clone(),
-                self.relayer_id.clone(),
-                tx,
-                from_block,
-                reason,
-            );
+        if from_block > latest {
+            return Ok(true);
         }
+
+        self.replay_gap(tx, from_block, latest, last_finalized_block_number, reason)
+            .await
     }
 
     async fn replay_gap(
@@ -257,14 +253,15 @@ impl BlockListener {
         from_block: u32,
         to_block: u32,
         last_finalized_block_number: &mut Option<u32>,
+        reason: &'static str,
     ) -> anyhow::Result<bool> {
         log::info!(
-            "Gear block listener for relayer {} live gap replay: replaying blocks #{from_block}..=#{to_block}",
+            "Gear block listener for relayer {} {reason}: replaying blocks #{from_block}..=#{to_block}",
             self.relayer_id
         );
         for block_number in from_block..=to_block {
             log::trace!(
-                "Gear block listener for relayer {} live gap replay: replaying finalized block #{block_number}",
+                "Gear block listener for relayer {} {reason}: replaying finalized block #{block_number}",
                 self.relayer_id
             );
             if !self.fetch_store_send(tx, block_number, None).await? {
@@ -274,32 +271,10 @@ impl BlockListener {
             self.metrics.latest_block.set(block_number as i64);
         }
         log::info!(
-            "Gear block listener for relayer {} live gap replay: replay finished",
+            "Gear block listener for relayer {} {reason}: replay finished",
             self.relayer_id
         );
         Ok(true)
-    }
-
-    fn spawn_replay_range(
-        &self,
-        tx: broadcast::Sender<GearBlock>,
-        from_block: u32,
-        to_block: u32,
-        reason: &'static str,
-    ) {
-        if from_block > to_block {
-            return;
-        }
-
-        spawn_replay_range(
-            self.api_provider.clone(),
-            self.block_storage.clone(),
-            self.relayer_id.clone(),
-            tx,
-            from_block,
-            to_block,
-            reason,
-        );
     }
 
     async fn fetch_store_send(
@@ -336,120 +311,4 @@ impl BlockListener {
         }
         Ok(true)
     }
-}
-
-fn spawn_replay_to_latest(
-    mut api_provider: ApiProviderConnection,
-    storage: Arc<dyn UnprocessedBlocksStorage>,
-    relayer_id: String,
-    tx: broadcast::Sender<GearBlock>,
-    from_block: u32,
-    reason: &'static str,
-) {
-    tokio::spawn(async move {
-        let latest = match rpc::retry_gear(
-            &mut api_provider,
-            "gear background latest finalized block",
-            |api| async move {
-                let hash = api.latest_finalized_block().await?;
-                api.block_hash_to_number(hash).await
-            },
-        )
-        .await
-        {
-            Ok(latest) => latest,
-            Err(err) => {
-                log::error!(
-                    "Gear block listener for relayer {relayer_id} {reason} failed to fetch latest block: {err}"
-                );
-                return;
-            }
-        };
-
-        replay_range(
-            api_provider,
-            storage,
-            relayer_id,
-            tx,
-            from_block,
-            latest,
-            reason,
-        )
-        .await;
-    });
-}
-
-fn spawn_replay_range(
-    api_provider: ApiProviderConnection,
-    storage: Arc<dyn UnprocessedBlocksStorage>,
-    relayer_id: String,
-    tx: broadcast::Sender<GearBlock>,
-    from_block: u32,
-    to_block: u32,
-    reason: &'static str,
-) {
-    tokio::spawn(async move {
-        replay_range(
-            api_provider,
-            storage,
-            relayer_id,
-            tx,
-            from_block,
-            to_block,
-            reason,
-        )
-        .await;
-    });
-}
-
-async fn replay_range(
-    mut api_provider: ApiProviderConnection,
-    storage: Arc<dyn UnprocessedBlocksStorage>,
-    relayer_id: String,
-    tx: broadcast::Sender<GearBlock>,
-    from_block: u32,
-    to_block: u32,
-    reason: &'static str,
-) {
-    log::info!(
-        "Gear block listener for relayer {relayer_id} {reason}: replaying blocks #{from_block}..=#{to_block}"
-    );
-    for block_number in from_block..=to_block {
-        log::trace!(
-            "Gear block listener for relayer {relayer_id} {reason}: replaying finalized block #{block_number}"
-        );
-        let storage = storage.clone();
-        let gear_block = match rpc::retry_gear(
-            &mut api_provider,
-            "gear background finalized block replay",
-            move |api| {
-                let storage = storage.clone();
-                async move {
-                    let block_hash = api.block_number_to_hash(block_number).await?;
-                    let block = api.api.blocks().at(block_hash).await?;
-                    let gear_block = GearBlock::from_subxt_block(&api, block).await?;
-                    storage.add_block(&api, &gear_block).await?;
-                    Ok::<_, anyhow::Error>(gear_block)
-                }
-            },
-        )
-        .await
-        {
-            Ok(block) => block,
-            Err(err) => {
-                log::error!(
-                    "Gear block listener for relayer {relayer_id} {reason}: failed to replay block #{block_number}: {err}"
-                );
-                return;
-            }
-        };
-
-        if tx.send(gear_block).is_err() {
-            log::info!(
-                "Gear block listener for relayer {relayer_id} {reason}: no active receivers, stopping replay"
-            );
-            return;
-        }
-    }
-    log::info!("Gear block listener for relayer {relayer_id} {reason}: replay finished");
 }


### PR DESCRIPTION
## Problem

The production mainnet Gear→Ethereum relayer could stop advancing Merkle roots after falling behind the finalized Gear stream. Gap recovery spawned overlapping archive-RPC replay tasks, while Merkle proof/submission state could lose the exact source-root relationship or misclassify an unfinalized Ethereum transaction during restart recovery. The observed outcome was a root-submission timeout and delayed transfer nonce 829.

## Solution

- authenticate queue roots and authority-set data against the exact Gear block header used by the proof
- preserve exact source-root coverage across batching, single-proof fallback, authority-set sync, persistence, and restart recovery
- reconcile persisted Ethereum submissions against finalized contract state before resubmitting
- fail closed on corrupt persisted Merkle state and disconnected proof/HTTP channels
- replay finalized Gear gaps inline and skip already-replayed justifications, preventing overlapping archive-RPC scans
- document the revised Merkle lifecycle and recovery invariants
- bump the workspace version to 1.2.1

## Test Coverage

```mermaid
flowchart LR
    A[Finalized Gear block] --> B[Authenticated queue root]
    B --> C[Proof generation]
    B --> G[Authority-set sync]
    C --> D[Durable pending submission]
    D --> E[Finalized Ethereum contract state]
    E --> F[Covered source roots finalized]
    A --> H[Inline bounded gap replay]
```

- `cargo test -p relayer --lib` — 91 passed
- `cargo test -p ethereum-client --lib` — 1 passed
- `cargo test -p gear-rpc-client --lib` — 3 passed
- `cargo clippy -p relayer --lib --tests -- -D warnings` — passed
- `cargo fmt --all --check` — passed
- independent correctness, adversarial, and security reviews found no remaining evidenced P0/P1 issue

## Operational note

`bridge-combined-merkle-root-relayers-1` remains stopped on `65.108.32.52`; this PR does not deploy or restart production. Roll out the built image, preserve `/root/bridge/merkle_blocks/blocks.json`, then verify root cursor, pending submissions, fee-payer balance, and transfer nonce 829 before declaring recovery.