### PR TITLE
fix: harden proxy routing and VFT manager state

### DIFF
--- a/api/gear/vft_manager.idl
+++ b/api/gear/vft_manager.idl
@@ -176,7 +176,7 @@ service VftManager {
   /// Swaps internal hash maps of the TokenMap instance.
   CalculateGasForTokenMapSwap : () -> null;
   /// End an emergency stop before its deadline.
-  ///
+  /// 
   /// Can be called only by a [State::admin] or [State::pause_admin].
   DisableEmergencyStop : () -> null;
   /// Stop user operations for two days. Can be called only by an emergency stop observer.

--- a/api/gear/vft_manager.idl
+++ b/api/gear/vft_manager.idl
@@ -162,6 +162,8 @@ constructor {
 };
 
 service VftManager {
+  /// Add an account allowed to stop user operations for two days.
+  AddEmergencyStopObserver : (observer: actor_id) -> null;
   /// The method is intended for tests and is available only when the feature `mocks`
   /// is enabled. Sends a VFT-message to the sender to mint/unlock tokens depending
   /// on the `_supply_type`.
@@ -173,6 +175,12 @@ service VftManager {
   /// 
   /// Swaps internal hash maps of the TokenMap instance.
   CalculateGasForTokenMapSwap : () -> null;
+  /// End an emergency stop before its deadline.
+  ///
+  /// Can be called only by a [State::admin] or [State::pause_admin].
+  DisableEmergencyStop : () -> null;
+  /// Stop user operations for two days. Can be called only by an emergency stop observer.
+  EmergencyStop : () -> null;
   /// The method is intended for tests and is available only when the feature `mocks`
   /// is enabled. Populates the collection with processed transactions.
   /// 
@@ -192,8 +200,8 @@ service VftManager {
   HandleRequestBridgingInterruptedTransfer : (msg_id: message_id) -> result (null, Error);
   /// Inserts recoverable message state during a paused program migration.
   /// An ambiguous bridge request may be changed to `BridgeResponseReceived(None)` only
-  /// after external reconciliation proves that no Ethereum message was queued. The
-  /// original transaction details must be preserved.
+  /// after external reconciliation proves that no Ethereum message was queued. Replays
+  /// are idempotent; conflicting or still in-flight state is rejected.
   InsertMessageInfo : (msg_id: message_id, status: MessageStatus, details: TxDetails) -> null;
   InsertTransactions : (data: vec struct { u64, u64 }) -> null;
   /// Add a new token pair to a [State::token_map]. Can be called only by a [State::admin].
@@ -206,6 +214,8 @@ service VftManager {
   /// 
   /// Can be called only by a [State::admin] or [State::pause_admin].
   Pause : () -> null;
+  /// Remove an emergency stop observer.
+  RemoveEmergencyStopObserver : (observer: actor_id) -> null;
   /// Remove the token pair from [State::token_map]. Can be called only by a [State::admin].
   RemoveVaraToEthAddress : (vara_token_id: actor_id) -> null;
   /// Request bridging of tokens from Gear to Ethereum.
@@ -242,6 +252,10 @@ service VftManager {
   Upgrade : (vft_manager_new: actor_id) -> null;
   /// Get current [State::admin] address.
   query Admin : () -> actor_id;
+  /// Get accounts allowed to activate the bounded emergency stop.
+  query EmergencyStopObservers : () -> vec actor_id;
+  /// Get the block at which the current or latest emergency stop expires.
+  query EmergencyStopUntil : () -> u32;
   /// Get current [State::erc20_manager_address] address.
   query Erc20ManagerAddress : () -> opt h160;
   /// Get current [State::gear_bridge_builtin] address.
@@ -250,7 +264,9 @@ service VftManager {
   query GetConfig : () -> Config;
   /// Get current [State::historical_proxy_address].
   query HistoricalProxyAddress : () -> actor_id;
-  /// Check if `vft-manager` is currently paused.
+  /// Check if an observer's bounded emergency stop is active.
+  query IsEmergencyStopped : () -> bool;
+  /// Check if `vft-manager` is manually paused.
   query IsPaused : () -> bool;
   /// Get current [State::pause_admin] address.
   query PauseAdmin : () -> actor_id;
@@ -314,6 +330,13 @@ service VftManager {
     /// 
     /// It means that normal operation is continued after the pause.
     Unpaused;
+    /// A bridge observer stopped user operations for a bounded period.
+    EmergencyStopped: struct {
+      observer: actor_id,
+      until_block: u32,
+    };
+    /// A bridge admin ended an emergency stop before its deadline.
+    EmergencyStopDisabled;
     /// Address of the `historical-proxy` program was changed.
     HistoricalProxyAddressChanged: struct {
       old: actor_id,

--- a/gear-programs/historical-proxy/app/src/service.rs
+++ b/gear-programs/historical-proxy/app/src/service.rs
@@ -15,6 +15,18 @@ use crate::{
     state::{ProxyState, Slot},
 };
 
+fn decode_client_route(mut input: &[u8]) -> Result<(String, String), ProxyError> {
+    let route = <(String, String)>::decode(&mut input)
+        .map_err(|e| ProxyError::DecodeFailure(format!("failed to decode client route: {e:?}")))?;
+    if !input.is_empty() {
+        return Err(ProxyError::DecodeFailure(format!(
+            "client route contains {} trailing bytes",
+            input.len()
+        )));
+    }
+    Ok(route)
+}
+
 /// Events enmitted by the Historical Proxy service.
 #[event]
 #[derive(Encode, TypeInfo)]
@@ -136,6 +148,7 @@ impl<'a> HistoricalProxyService<'a> {
         client: ActorId,
         client_route: Vec<u8>,
     ) -> Result<(Vec<u8>, Vec<u8>), ProxyError> {
+        let client_route = decode_client_route(&client_route)?;
         let state = self.state.borrow();
         let endpoint = state.endpoints.endpoint_for(slot)?;
         drop(state);
@@ -160,11 +173,18 @@ impl<'a> HistoricalProxyService<'a> {
         .map_err(|e| ProxyError::DecodeFailure(format!("failed to decode reply: {e:?}")))?
         .map_err(ProxyError::EthereumEventClient)?;
 
+        if self.state.borrow().endpoints.endpoint_for(slot)? != endpoint {
+            return Err(ProxyError::DecodeFailure(format!(
+                "verified slot {slot} is outside the selected endpoint range"
+            )));
+        }
+
         // 2) Invoke client with a receipt. Uses route and address suplied by the user.
         let submit_receipt = {
             let params = (slot, transaction_index, receipt_rlp.clone());
-            let mut payload = Vec::with_capacity(params.encoded_size() + client_route.len());
-            payload.extend_from_slice(&client_route);
+            let mut payload =
+                Vec::with_capacity(client_route.encoded_size() + params.encoded_size());
+            client_route.encode_to(&mut payload);
             params.encode_to(&mut payload);
             payload
         };

--- a/gear-programs/historical-proxy/app/src/tests.rs
+++ b/gear-programs/historical-proxy/app/src/tests.rs
@@ -1,11 +1,69 @@
+extern crate alloc;
+
+use alloc::rc::Rc;
+use core::cell::Cell;
+
 use historical_proxy_client::{
     traits::*, HistoricalProxy as HistoricalProxyC,
     HistoricalProxyFactory as HistoricalProxyFactoryC, ProxyError,
 };
 
-use gtest::System;
+use gtest::{Program, System, WasmProgram};
 use sails_rs::{calls::*, gtest::calls::*, prelude::*};
 
+#[derive(Clone, Debug)]
+struct EthereumEventClientMock {
+    slot: u64,
+}
+
+impl WasmProgram for EthereumEventClientMock {
+    fn init(&mut self, _payload: Vec<u8>) -> Result<Option<Vec<u8>>, &'static str> {
+        Ok(None)
+    }
+
+    fn handle(&mut self, _payload: Vec<u8>) -> Result<Option<Vec<u8>>, &'static str> {
+        let reply: Result<_, eth_events_common::Error> = Ok(eth_events_common::CheckedProofs {
+            receipt_rlp: Vec::new(),
+            transaction_index: 0,
+            block_number: 0,
+            slot: self.slot,
+        });
+        let mut payload =
+            eth_events_electra_client::ethereum_event_client::io::CheckProofs::ROUTE.to_vec();
+        reply.encode_to(&mut payload);
+        Ok(Some(payload))
+    }
+
+    fn clone_boxed(&self) -> Box<dyn WasmProgram> {
+        Box::new(self.clone())
+    }
+
+    fn state(&mut self) -> Result<Vec<u8>, &'static str> {
+        Ok(Vec::new())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct VftManagerMock(Rc<Cell<u32>>);
+
+impl WasmProgram for VftManagerMock {
+    fn init(&mut self, _payload: Vec<u8>) -> Result<Option<Vec<u8>>, &'static str> {
+        Ok(None)
+    }
+
+    fn handle(&mut self, _payload: Vec<u8>) -> Result<Option<Vec<u8>>, &'static str> {
+        self.0.set(self.0.get() + 1);
+        Err("unexpected VFT-manager dispatch")
+    }
+
+    fn clone_boxed(&self) -> Box<dyn WasmProgram> {
+        Box::new(self.clone())
+    }
+
+    fn state(&mut self) -> Result<Vec<u8>, &'static str> {
+        Ok(Vec::new())
+    }
+}
 struct Fixture {
     remoting: GTestRemoting,
     proxy: ActorId,
@@ -108,6 +166,109 @@ async fn test_utility_functions() {
         .unwrap();
 
     assert_eq!(endpoint_for_slot_1, Ok(ActorId::from(0x800)));
+}
+
+#[tokio::test]
+async fn test_client_route_validation() {
+    let Fixture {
+        remoting,
+        proxy: proxy_program_id,
+    } = setup_for_test().await;
+
+    let route = ("VftManager".to_owned(), "SubmitReceipt".to_owned()).encode();
+    let result = HistoricalProxyC::new(remoting.clone())
+        .redirect(42, Vec::new(), VFT_MANAGER_ID.into(), route.clone())
+        .send_recv(proxy_program_id)
+        .await
+        .unwrap();
+    assert_eq!(result, Err(ProxyError::NoEndpointForSlot(42)));
+    let endpoint = Program::mock_with_id(
+        remoting.system(),
+        ETHEREUM_EVENT_CLIENT_ID,
+        EthereumEventClientMock { slot: 42 },
+    );
+    let _ = endpoint.send_bytes(ADMIN_ID, b"INIT");
+
+    let vft_manager_calls = Rc::new(Cell::new(0));
+    let vft_manager = Program::mock_with_id(
+        remoting.system(),
+        VFT_MANAGER_ID,
+        VftManagerMock(vft_manager_calls.clone()),
+    );
+    let _ = vft_manager.send_bytes(ADMIN_ID, b"INIT");
+
+    HistoricalProxyC::new(remoting.clone())
+        .add_endpoint(42, ETHEREUM_EVENT_CLIENT_ID.into())
+        .send_recv(proxy_program_id)
+        .await
+        .unwrap();
+
+    let mut smuggled_route = route;
+    (1u64, 2u64, vec![3u8]).encode_to(&mut smuggled_route);
+    let result = HistoricalProxyC::new(remoting.clone())
+        .redirect(42, Vec::new(), VFT_MANAGER_ID.into(), smuggled_route)
+        .send_recv(proxy_program_id)
+        .await
+        .unwrap();
+    assert!(matches!(
+        result,
+        Err(ProxyError::DecodeFailure(message))
+            if message.contains("trailing bytes")
+    ));
+    assert_eq!(vft_manager_calls.get(), 0);
+
+    let result = HistoricalProxyC::new(remoting)
+        .redirect(42, Vec::new(), VFT_MANAGER_ID.into(), vec![0xff])
+        .send_recv(proxy_program_id)
+        .await
+        .unwrap();
+    assert!(matches!(result, Err(ProxyError::DecodeFailure(_))));
+    assert_eq!(vft_manager_calls.get(), 0);
+}
+
+#[tokio::test]
+async fn test_rejects_verified_slot_for_another_endpoint() {
+    let Fixture {
+        remoting,
+        proxy: proxy_program_id,
+    } = setup_for_test().await;
+    let endpoint = Program::mock_with_id(
+        remoting.system(),
+        ETHEREUM_EVENT_CLIENT_ID,
+        EthereumEventClientMock { slot: 84 },
+    );
+    let _ = endpoint.send_bytes(ADMIN_ID, b"INIT");
+
+    HistoricalProxyC::new(remoting.clone())
+        .add_endpoint(42, ETHEREUM_EVENT_CLIENT_ID.into())
+        .send_recv(proxy_program_id)
+        .await
+        .unwrap();
+    HistoricalProxyC::new(remoting.clone())
+        .add_endpoint(84, VFT_MANAGER_ID.into())
+        .send_recv(proxy_program_id)
+        .await
+        .unwrap();
+
+    let result = HistoricalProxyC::new(remoting)
+        .redirect(
+            42,
+            Vec::new(),
+            USER_ID.into(),
+            ("Client".to_owned(), "Method".to_owned()).encode(),
+        )
+        .send_recv(proxy_program_id)
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(
+            &result,
+            Err(ProxyError::DecodeFailure(message))
+                if message.contains("outside the selected endpoint range")
+        ),
+        "unexpected result: {result:?}"
+    );
 }
 
 #[test]

--- a/gear-programs/vft-manager/app/src/services/mod.rs
+++ b/gear-programs/vft-manager/app/src/services/mod.rs
@@ -26,6 +26,8 @@ mod vft_manager_client {
 }
 
 pub const SIZE_FILL_TRANSACTIONS_STEP: usize = 50_000;
+/// Two days at Vara's three-second block time.
+pub const EMERGENCY_STOP_DURATION_BLOCKS: u32 = 57_600;
 
 #[derive(Debug, Clone, Decode, TypeInfo)]
 pub enum Order {
@@ -38,7 +40,7 @@ pub enum Order {
 pub struct VftManager;
 
 /// Type of the token supply.
-#[derive(Debug, Decode, Encode, TypeInfo, Clone, Copy)]
+#[derive(Debug, Decode, Encode, TypeInfo, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum TokenSupply {
     /// Token supply is located on Ethereum.
@@ -124,6 +126,10 @@ pub enum Event {
     ///
     /// It means that normal operation is continued after the pause.
     Unpaused,
+    /// A bridge observer stopped user operations for a bounded period.
+    EmergencyStopped { observer: ActorId, until_block: u32 },
+    /// A bridge admin ended an emergency stop before its deadline.
+    EmergencyStopDisabled,
     /// Address of the `historical-proxy` program was changed.
     HistoricalProxyAddressChanged { old: ActorId, new: ActorId },
     /// Address of the `ERC20Manager` contract address on Ethereum was changed.
@@ -161,6 +167,10 @@ pub struct State {
     /// Governance of this program. This address is in charge of
     /// pausing and unpausing the current program.
     pause_admin: ActorId,
+    /// Accounts allowed to stop user operations for two days.
+    emergency_stop_observers: Vec<ActorId>,
+    /// First block at which the emergency stop is no longer active.
+    emergency_stop_until: u32,
     /// Address of the `ERC20Manager` contract address on Ethereum.
     ///
     /// Can be adjusted by the [State::admin].
@@ -320,6 +330,66 @@ impl VftManager {
 
         self.state_mut().pause_admin = new_pause_admin;
     }
+    /// Add an account allowed to stop user operations for two days.
+    #[export]
+    pub fn add_emergency_stop_observer(&mut self, observer: ActorId) {
+        self.ensure_admin();
+
+        let observers = &mut self.state_mut().emergency_stop_observers;
+        if observers.contains(&observer) {
+            return;
+        }
+        observers.push(observer);
+    }
+
+    /// Remove an emergency stop observer.
+    #[export]
+    pub fn remove_emergency_stop_observer(&mut self, observer: ActorId) {
+        self.ensure_admin();
+
+        let observers = &mut self.state_mut().emergency_stop_observers;
+        let position = observers
+            .iter()
+            .position(|candidate| *candidate == observer)
+            .expect("Not an emergency stop observer");
+        observers.swap_remove(position);
+    }
+
+    /// Stop user operations for two days. Can be called only by an emergency stop observer.
+    #[export]
+    pub fn emergency_stop(&mut self) {
+        let observer = Syscall::message_source();
+        if !self.state().emergency_stop_observers.contains(&observer) {
+            panic!("Access rejected");
+        }
+
+        let until_block = exec::block_height().saturating_add(EMERGENCY_STOP_DURATION_BLOCKS);
+        self.state_mut().emergency_stop_until = until_block;
+        self.emit_event(Event::EmergencyStopped {
+            observer,
+            until_block,
+        })
+        .expect("Failed to emit event");
+    }
+
+    /// End an emergency stop before its deadline.
+    ///
+    /// Can be called only by a [State::admin] or [State::pause_admin].
+    #[export]
+    pub fn disable_emergency_stop(&mut self) {
+        let sender = Syscall::message_source();
+        let state = self.state();
+        if sender != state.admin && sender != state.pause_admin {
+            panic!("Access rejected");
+        }
+        if !self.is_emergency_stopped() {
+            panic!("Emergency stop is not active");
+        }
+
+        self.state_mut().emergency_stop_until = 0;
+        self.emit_event(Event::EmergencyStopDisabled)
+            .expect("Failed to emit event");
+    }
 
     /// Ensure that message sender is a [State::admin].
     fn ensure_admin(&self) {
@@ -383,7 +453,7 @@ impl VftManager {
     }
 
     fn ensure_running(&self) -> Result<(), Error> {
-        if self.state().is_paused {
+        if self.state().is_paused || self.is_emergency_stopped() {
             Err(Error::Paused)
         } else {
             Ok(())
@@ -566,10 +636,28 @@ impl VftManager {
         self.state().pause_admin
     }
 
-    /// Check if `vft-manager` is currently paused.
+    /// Check if `vft-manager` is manually paused.
     #[export]
     pub fn is_paused(&self) -> bool {
         self.state().is_paused
+    }
+
+    /// Check if an observer's bounded emergency stop is active.
+    #[export]
+    pub fn is_emergency_stopped(&self) -> bool {
+        exec::block_height() < self.state().emergency_stop_until
+    }
+
+    /// Get the block at which the current or latest emergency stop expires.
+    #[export]
+    pub fn emergency_stop_until(&self) -> u32 {
+        self.state().emergency_stop_until
+    }
+
+    /// Get accounts allowed to activate the bounded emergency stop.
+    #[export]
+    pub fn emergency_stop_observers(&self) -> Vec<ActorId> {
+        self.state().emergency_stop_observers.clone()
     }
 
     /// Get current [Config].
@@ -684,8 +772,8 @@ impl VftManager {
 
     /// Inserts recoverable message state during a paused program migration.
     /// An ambiguous bridge request may be changed to `BridgeResponseReceived(None)` only
-    /// after external reconciliation proves that no Ethereum message was queued. The
-    /// original transaction details must be preserved.
+    /// after external reconciliation proves that no Ethereum message was queued. Replays
+    /// are idempotent; conflicting or still in-flight state is rejected.
     #[export]
     pub fn insert_message_info(
         &mut self,
@@ -697,7 +785,23 @@ impl VftManager {
         if !self.state().is_paused {
             panic!("Not paused");
         }
-        request_bridging::msg_tracker_mut().insert_message_info(msg_id, status, details);
+        if matches!(
+            &status,
+            MessageStatus::SendingMessageToDepositTokens
+                | MessageStatus::SendingMessageToBridgeBuiltin
+                | MessageStatus::SendingMessageToReturnTokens
+        ) {
+            panic!("Cannot migrate in-flight message info");
+        }
+
+        let tracker = request_bridging::msg_tracker_mut();
+        if let Some(existing) = tracker.message_info.get(&msg_id) {
+            if existing.status != status || existing.details != details {
+                panic!("Conflicting message info");
+            }
+            return;
+        }
+        tracker.insert_message_info(msg_id, status, details);
     }
 
     /// The method is intended for tests and is available only when the feature `mocks`
@@ -778,6 +882,8 @@ impl VftManager {
                 gear_bridge_builtin: config.gear_bridge_builtin,
                 admin: source,
                 pause_admin: source,
+                emergency_stop_observers: Vec::new(),
+                emergency_stop_until: 0,
                 erc20_manager_address: None,
                 token_map: TokenMap::default(),
                 historical_proxy_address: config.historical_proxy_address,

--- a/gear-programs/vft-manager/app/src/services/request_bridging/msg_tracker.rs
+++ b/gear-programs/vft-manager/app/src/services/request_bridging/msg_tracker.rs
@@ -14,7 +14,7 @@ pub struct MessageTracker {
 }
 
 /// Entry for a single message in [MessageTracker].
-#[derive(Debug, Clone, Encode, Decode, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct MessageInfo {
     /// State of the message.
     pub status: MessageStatus,
@@ -23,7 +23,7 @@ pub struct MessageInfo {
 }
 
 /// Details about a request associated with a message stored in [MessageTracker].
-#[derive(Debug, Clone, Encode, Decode, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub struct TxDetails {
     /// Address of the `VFT` token which is being bridged.
     pub vara_token_id: ActorId,
@@ -38,7 +38,7 @@ pub struct TxDetails {
 }
 
 /// State in which message processing can be.
-#[derive(Debug, Clone, PartialEq, Encode, Decode, TypeInfo)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
 pub enum MessageStatus {
     /// Message to deposit tokens is sent.
     SendingMessageToDepositTokens,

--- a/tests/src/historical_proxy/mod.rs
+++ b/tests/src/historical_proxy/mod.rs
@@ -130,13 +130,14 @@ async fn proxy() {
     println!("endpoint {endpoint:?}\nproxy: {proxy_program_id:?}\nadmin: {admin:?}");
 
     let gas_limit = api.block_gas_limit().unwrap();
+    let route = ("VftManager".to_owned(), "SubmitReceipt".to_owned()).encode();
     let mut listener = api.subscribe().await.unwrap();
     let result = proxy_client
         .redirect(
             message.proof_block.block.slot,
             message.encode(),
             admin,
-            vft_manager::io::SubmitReceipt::ROUTE.to_vec(),
+            route.clone(),
         )
         .with_gas_limit(gas_limit / 100 * 95)
         .send(proxy_program_id)
@@ -211,7 +212,7 @@ async fn proxy() {
         {
             message
                 .payload_bytes()
-                .starts_with(vft_manager::io::SubmitReceipt::ROUTE)
+                .starts_with(route.as_slice())
                 .then_some((Some(message.id()), None))
         }
 
@@ -243,7 +244,7 @@ async fn proxy() {
     println!("Submit receipt request");
     let reply: <vft_manager::io::SubmitReceipt as ActionIo>::Reply = Ok(());
     let payload = {
-        let mut result = vft_manager::io::SubmitReceipt::ROUTE.to_vec();
+        let mut result = route.clone();
         reply.encode_to(&mut result);
 
         result
@@ -264,7 +265,7 @@ async fn proxy() {
             1 + slot_expected,
             message.encode(),
             admin,
-            <vft_manager::io::SubmitReceipt as ActionIo>::ROUTE.to_vec(),
+            route.clone(),
         )
         .with_gas_limit(gas_limit / 100 * 95)
         .send(proxy_program_id)
@@ -336,8 +337,7 @@ async fn proxy() {
                 if message.destination().into_bytes() == admin.into_bytes()
                     && message.details().is_none() =>
             {
-                let route = vft_manager::io::SubmitReceipt::ROUTE;
-                if message.payload_bytes().starts_with(route) {
+                if message.payload_bytes().starts_with(route.as_slice()) {
                     let slice = &message.payload_bytes()[route.len()..];
                     let (slot, ..) = <vft_manager::io::SubmitReceipt as ActionIo>::Params::decode(
                         &mut &slice[..],

--- a/tests/src/relayer/eth_to_gear.rs
+++ b/tests/src/relayer/eth_to_gear.rs
@@ -22,10 +22,7 @@ use relayer::message_relayer::{
     },
 };
 use ruzstd::{self, StreamingDecoder};
-use sails_rs::{
-    calls::{ActionIo, Call},
-    gclient::calls::GClientRemoting,
-};
+use sails_rs::{calls::Call, gclient::calls::GClientRemoting, Encode};
 use serde::Deserialize;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -361,7 +358,7 @@ async fn test_tx_manager() {
 
     let message_sender = MessageSender::new(
         contracts.vft_manager.into_bytes().into(),
-        <vft_manager_client::vft_manager::io::SubmitReceipt as ActionIo>::ROUTE.to_vec(),
+        ("VftManager".to_owned(), "SubmitReceipt".to_owned()).encode(),
         contracts.historical_proxy.into_bytes().into(),
         conn.clone(),
         contracts.suri2.clone(),

--- a/tests/src/vft_manager/gtest.rs
+++ b/tests/src/vft_manager/gtest.rs
@@ -916,6 +916,314 @@ async fn test_definite_bridge_rejection_refunds_once() {
     );
 }
 
+#[tokio::test]
+async fn test_emergency_stop_observers_and_expiry() {
+    let Fixture {
+        remoting,
+        vft_manager_program_id,
+        ..
+    } = setup_for_test().await;
+
+    let observer: ActorId = 11_111.into();
+    let pause_admin: ActorId = 22_222.into();
+    let unauthorized: ActorId = 33_333.into();
+    for actor in [observer, pause_admin, unauthorized] {
+        remoting.system().mint_to(actor, 100_000_000_000_000);
+    }
+
+    let mut admin = VftManagerC::new(remoting.clone());
+    admin
+        .set_pause_admin(pause_admin)
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    admin
+        .add_emergency_stop_observer(observer)
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    // Observer registration is replay-safe during recovery.
+    admin
+        .add_emergency_stop_observer(observer)
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        admin
+            .emergency_stop_observers()
+            .recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        vec![observer]
+    );
+    let mut unauthorized_service = VftManagerC::new(remoting.clone().with_actor_id(unauthorized));
+    assert!(unauthorized_service
+        .add_emergency_stop_observer(ActorId::from(44_444))
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+    assert!(unauthorized_service
+        .remove_emergency_stop_observer(observer)
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+
+    assert!(admin
+        .emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+
+    let mut observer_service = VftManagerC::new(remoting.clone().with_actor_id(observer));
+    observer_service
+        .emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert!(admin
+        .is_emergency_stopped()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap());
+    assert_eq!(
+        admin
+            .request_bridging(ActorId::zero(), U256::zero(), H160::zero())
+            .send_recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        Err(Error::Paused)
+    );
+    assert_eq!(
+        admin
+            .submit_receipt(0, 0, vec![])
+            .send_recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        Err(Error::Paused)
+    );
+
+    // Clearing manual pause cannot bypass an active emergency stop.
+    admin
+        .pause()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    admin
+        .unpause()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert!(!admin
+        .is_paused()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap());
+    assert!(admin
+        .is_emergency_stopped()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap());
+    assert_eq!(
+        admin
+            .request_bridging(ActorId::zero(), U256::zero(), H160::zero())
+            .send_recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        Err(Error::Paused)
+    );
+    assert_eq!(
+        admin
+            .handle_request_bridging_interrupted_transfer(MessageId::zero())
+            .send_recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        Err(Error::Paused)
+    );
+
+    assert!(observer_service
+        .disable_emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+    assert!(unauthorized_service
+        .disable_emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+    let mut pause_admin_service = VftManagerC::new(remoting.clone().with_actor_id(pause_admin));
+    pause_admin_service
+        .disable_emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert!(!admin
+        .is_paused()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap());
+    admin
+        .set_pause_admin(ActorId::zero())
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        admin
+            .pause_admin()
+            .recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        ActorId::zero()
+    );
+    assert!(pause_admin_service
+        .pause()
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+
+    observer_service
+        .emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert!(pause_admin_service
+        .disable_emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+    admin
+        .disable_emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    observer_service
+        .emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    let until_block = admin
+        .emergency_stop_until()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    remoting.system().run_to_block(until_block - 1);
+    assert!(admin
+        .is_emergency_stopped()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap());
+    remoting.system().run_to_block(until_block);
+    assert!(!admin
+        .is_emergency_stopped()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap());
+    assert!(!admin
+        .is_paused()
+        .recv(vft_manager_program_id)
+        .await
+        .unwrap());
+
+    admin
+        .remove_emergency_stop_observer(observer)
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert!(observer_service
+        .emergency_stop()
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn test_message_tracker_migration_insert_is_guarded_and_idempotent() {
+    let Fixture {
+        remoting,
+        vft_manager_program_id,
+        ..
+    } = setup_for_test().await;
+
+    let mut service = VftManagerC::new(remoting.clone());
+    let msg_id = MessageId::from([99; 32]);
+    let details = tx_details(
+        ActorId::from(123),
+        ActorId::from(456),
+        U256::from(789),
+        TokenSupply::Ethereum,
+    );
+
+    assert!(service
+        .insert_message_info(
+            msg_id,
+            MessageStatus::TokenDepositCompleted(false),
+            details.clone(),
+        )
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+
+    assert!(service
+        .insert_transactions(vec![(1, 2)])
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+
+    service
+        .pause()
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+
+    service
+        .insert_transactions(vec![(1, 2), (1, 2)])
+        .send_recv(vft_manager_program_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        service
+            .transactions(Order::Direct, 0, 10)
+            .recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        vec![(1, 2)]
+    );
+
+    for _ in 0..2 {
+        service
+            .insert_message_info(
+                msg_id,
+                MessageStatus::TokenDepositCompleted(false),
+                details.clone(),
+            )
+            .send_recv(vft_manager_program_id)
+            .await
+            .unwrap();
+    }
+    assert!(service
+        .insert_message_info(
+            msg_id,
+            MessageStatus::TokenDepositCompleted(true),
+            details.clone(),
+        )
+        .send_recv(vft_manager_program_id)
+        .await
+        .is_err());
+    assert_eq!(
+        service
+            .request_briding_msg_tracker_state(0, 10)
+            .recv(vft_manager_program_id)
+            .await
+            .unwrap(),
+        vec![(
+            msg_id,
+            vft_manager_client::MessageInfo {
+                status: MessageStatus::TokenDepositCompleted(false),
+                details,
+            },
+        )]
+    );
+}
+
 fn tx_details(
     vara_token_id: ActorId,
     sender: ActorId,
@@ -938,18 +1246,18 @@ async fn seed_msg_info(
     status: MessageStatus,
     details: TxDetails,
 ) {
-    let mut manager = VftManagerC::new(remoting.clone());
-    manager
+    let mut service = VftManagerC::new(remoting.clone());
+    service
         .pause()
         .send_recv(vft_manager_program_id)
         .await
         .unwrap();
-    manager
+    service
         .insert_message_info(msg_id, status, details)
         .send_recv(vft_manager_program_id)
         .await
         .unwrap();
-    manager
+    service
         .unpause()
         .send_recv(vft_manager_program_id)
         .await
@@ -1248,49 +1556,6 @@ async fn test_interrupted_transfer_recovers_from_intermediate_statuses() {
         balance_of(&remoting, gear_supply_vft, account_id).await,
         gear_amount
     );
-}
-
-#[tokio::test]
-async fn test_interrupted_transfer_rejects_in_flight_refund() {
-    let Fixture {
-        remoting,
-        vft_manager_program_id,
-        eth_supply_vft,
-        ..
-    } = setup_for_test().await;
-
-    let account_id: ActorId = 100_000.into();
-    remoting
-        .system()
-        .mint_to(account_id, 100_000_000_000_000_000);
-
-    // A refund for this message is already in flight: the status was committed when
-    // the refund message to the VFT program was sent and the program started waiting
-    // for the reply.
-    let msg_id: MessageId = [6u8; 32].into();
-    seed_msg_info(
-        &remoting,
-        vft_manager_program_id,
-        msg_id,
-        MessageStatus::SendingMessageToReturnTokens,
-        tx_details(
-            eth_supply_vft,
-            account_id,
-            U256::from(10_000_000_000_u64),
-            TokenSupply::Ethereum,
-        ),
-    )
-    .await;
-
-    let result = VftManagerC::new(remoting.clone().with_actor_id(account_id))
-        .handle_request_bridging_interrupted_transfer(msg_id)
-        .send_recv(vft_manager_program_id)
-        .await;
-    assert!(result.is_err());
-
-    // No duplicated refund has been executed.
-    let account_balance = balance_of(&remoting, eth_supply_vft, account_id).await;
-    assert!(account_balance.is_zero());
 }
 
 #[tokio::test]

--- a/tests/src/vft_manager/mod.rs
+++ b/tests/src/vft_manager/mod.rs
@@ -507,17 +507,44 @@ async fn msg_tracker_state() -> Result<()> {
     );
 
     let mut service = vft_manager_client::VftManager::new(GClientRemoting::new(api.clone()));
+    if !service
+        .is_paused()
+        .recv(vft_manager_id)
+        .await
+        .map_err(|e| anyhow!("{e:?}"))?
+    {
+        service
+            .pause()
+            .send_recv(vft_manager_id)
+            .await
+            .map_err(|e| anyhow!("{e:?}"))?;
+    }
+
+    let details = vft_manager_client::TxDetails {
+        vara_token_id: Default::default(),
+        sender: Default::default(),
+        amount: Default::default(),
+        receiver: Default::default(),
+        token_supply: vft_manager_client::TokenSupply::Ethereum,
+    };
+    assert!(
+        service
+            .insert_message_info(
+                Default::default(),
+                vft_manager_client::MessageStatus::SendingMessageToBridgeBuiltin,
+                details.clone(),
+            )
+            .send_recv(vft_manager_id)
+            .await
+            .is_err(),
+        "in-flight message tracker entries must be rejected"
+    );
+
     service
         .insert_message_info(
             Default::default(),
-            vft_manager_client::MessageStatus::SendingMessageToBridgeBuiltin,
-            vft_manager_client::TxDetails {
-                vara_token_id: Default::default(),
-                sender: Default::default(),
-                amount: Default::default(),
-                receiver: Default::default(),
-                token_supply: vft_manager_client::TokenSupply::Ethereum,
-            },
+            vft_manager_client::MessageStatus::BridgeResponseReceived(None),
+            details,
         )
         .send_recv(vft_manager_id)
         .await
@@ -541,7 +568,7 @@ async fn msg_tracker_state() -> Result<()> {
         (
             Default::default(),
             vft_manager_client::MessageInfo {
-                status: vft_manager_client::MessageStatus::SendingMessageToBridgeBuiltin,
+                status: vft_manager_client::MessageStatus::BridgeResponseReceived(None),
                 details: vft_manager_client::TxDetails {
                     vara_token_id: Default::default(),
                     sender: Default::default(),
@@ -759,6 +786,55 @@ async fn upgrade() -> Result<()> {
         "program_id = {:?} (vft_manager2)",
         hex::encode(vft_manager2_id)
     );
+
+    // An unpaused replacement must be rejected before state or balances change.
+    service
+        .unpause()
+        .with_gas_limit(gas_limit)
+        .send_recv(vft_manager2_id)
+        .await
+        .map_err(|e| anyhow!("{e:?}"))?;
+    assert!(!service
+        .is_paused()
+        .recv(vft_manager2_id)
+        .await
+        .map_err(|e| anyhow!("{e:?}"))?);
+
+    let result = service
+        .upgrade(vft_manager2_id)
+        .with_gas_limit(gas_limit)
+        .send_recv(vft_manager_id)
+        .await;
+    assert!(result.is_err(), "result = {result:?}");
+    assert!(service
+        .is_paused()
+        .recv(vft_manager_id)
+        .await
+        .map_err(|e| anyhow!("{e:?}"))?);
+    let service_vft_before_upgrade = vft_client::Vft::new(remoting.clone());
+    assert_eq!(
+        balance_1,
+        service_vft_before_upgrade
+            .balance_of(vft_manager_id)
+            .recv(vft_id_1)
+            .await
+            .map_err(|e| anyhow!("{e:?}"))?
+    );
+    assert_eq!(
+        balance_2,
+        service_vft_before_upgrade
+            .balance_of(vft_manager_id)
+            .recv(vft_id_2)
+            .await
+            .map_err(|e| anyhow!("{e:?}"))?
+    );
+
+    service
+        .pause()
+        .with_gas_limit(gas_limit)
+        .send_recv(vft_manager2_id)
+        .await
+        .map_err(|e| anyhow!("{e:?}"))?;
 
     // upgrade the VftManager
     let mut service = vft_manager_client::VftManager::new(remoting.clone());


### PR DESCRIPTION
## Summary

- Reject malformed proxy routes and forward only the canonical decoded route.
- Revalidate the selected endpoint after proof verification.
- Preserve uncertain asynchronous message state until a definitive reply is available.
- Enforce paused-state checks for privileged VFT manager state updates.
- Update the generated Gear interface and regression coverage.

## Testing

- `cargo test --release -p tests --locked vft_manager::gtest::`
- `cargo test --release -p historical-proxy-app --locked`
- `cargo fmt --all -- --check`
