### PR TITLE
fix(indexer): sync program IDs from runtime env

### DIFF
--- a/js/indexer/src/gear/programIds.ts
+++ b/js/indexer/src/gear/programIds.ts
@@ -34,13 +34,14 @@ export async function init(programs: Record<string, string>): Promise<Map<string
   }
 
   for (const [name, id] of Object.entries(programs)) {
-    const res = await client.query('SELECT * FROM gear_programs WHERE name = $1', [name]);
-    if (res.rows.length === 0) {
-      await client.query('INSERT INTO gear_programs (name, program_id) VALUES ($1, $2)', [name, id]);
-      console.log(`Inserted program ${name} with ID ${id}`);
-    } else {
-      console.log(`Program ${name} set to ${res.rows[0].program_id}`);
-    }
+    await client.query(
+      `INSERT INTO gear_programs (name, program_id)
+       VALUES ($1, $2)
+       ON CONFLICT (name)
+       DO UPDATE SET program_id = EXCLUDED.program_id`,
+      [name, id],
+    );
+    console.log(`Program ${name} set to ${id}`);
   }
 
   const ids = await client.query('SELECT name, program_id FROM gear_programs WHERE name = ANY($1::text[])', [


### PR DESCRIPTION
## Problem

The Gear indexer keeps existing `gear_programs` rows and ignores updated runtime environment values after program upgrades. A restart can therefore continue listening to exited/stale programs.

## Fix

Upsert configured program IDs during startup so the deployed runtime environment is authoritative.

## Verification

- `yarn build:indexer`
- `git diff --check`